### PR TITLE
build: Replace RestoreAdditionalProjectSources with nuget.config and source mapping

### DIFF
--- a/CruiserJumpPractice/CruiserJumpPractice.csproj
+++ b/CruiserJumpPractice/CruiserJumpPractice.csproj
@@ -12,20 +12,16 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <!-- C# language version. https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version -->
     <LangVersion>13.0</LangVersion>
-    <RestoreAdditionalProjectSources>
-      https://api.nuget.org/v3/index.json;
-      https://nuget.bepinex.dev/v3/index.json
-    </RestoreAdditionalProjectSources>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Runtime dependencies -->
-    <PackageReference Include="BepInEx.Core" Version="5.4.21" />
+    <!-- Runtime-provided dependencies -->
+    <PackageReference Include="BepInEx.Core" Version="5.4.21" IncludeAssets="compile" />
     <PackageReference Include="LethalCompany.GameLibs.Steam" Version="73.0.0-ngd.0" IncludeAssets="compile" />
     <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" IncludeAssets="compile" />
     <PackageReference Include="Rune580.Mods.LethalCompany.InputUtils" Version="0.7.12" IncludeAssets="compile" />
 
-    <!-- Development dependencies -->
+    <!-- Build/development-only dependencies -->
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" PrivateAssets="all" />
   </ItemGroup>

--- a/CruiserJumpPractice/nuget.config
+++ b/CruiserJumpPractice/nuget.config
@@ -7,6 +7,7 @@
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget.org">
+      <!-- Implicitly required by netstandard2.1 (targeting pack) -->
       <package pattern="NETStandard.Library.Ref" />
       <package pattern="UnityEngine.*" />
     </packageSource>

--- a/CruiserJumpPractice/nuget.config
+++ b/CruiserJumpPractice/nuget.config
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="bepinex" value="https://nuget.bepinex.dev/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="UnityEngine.*" />
+    </packageSource>
+
+    <packageSource key="bepinex">
+      <package pattern="BepInEx.*" />
+      <package pattern="LethalCompany.*" />
+      <package pattern="Rune580.*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/CruiserJumpPractice/nuget.config
+++ b/CruiserJumpPractice/nuget.config
@@ -7,6 +7,7 @@
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget.org">
+      <package pattern="NETStandard.Library.Ref" />
       <package pattern="UnityEngine.*" />
     </packageSource>
 


### PR DESCRIPTION
### Summary

Replace `RestoreAdditionalProjectSources` with an explicit `nuget.config`.

### Changes

- Remove `RestoreAdditionalProjectSources` from the project file
- Add `nuget.config` with explicit package sources
- Introduce `packageSourceMapping` to control which packages are restored from each source

### Motivation

`RestoreAdditionalProjectSources` is implicit and can lead to non-deterministic restores depending on the environment.

Using `nuget.config` with `<clear />` ensures:
- deterministic and reproducible dependency resolution
- explicit control over package sources
- reduced risk of unintended or unsafe package resolution

### Notes

This change does not affect runtime behavior. It only improves build reproducibility and dependency clarity.