### PR TITLE
refactor: alias Lethal Company v73 compile-time dependencies

### DIFF
--- a/CruiserJumpPractice/CruiserJumpPractice.csproj
+++ b/CruiserJumpPractice/CruiserJumpPractice.csproj
@@ -17,9 +17,15 @@
   <ItemGroup>
     <!-- Runtime-provided dependencies -->
     <PackageReference Include="BepInEx.Core" Version="5.4.21" IncludeAssets="compile" />
-    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="73.0.0-ngd.0" IncludeAssets="compile" />
-    <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" IncludeAssets="compile" />
-    <PackageReference Include="Rune580.Mods.LethalCompany.InputUtils" Version="0.7.12" IncludeAssets="compile" />
+    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="73.0.0-ngd.0" IncludeAssets="compile">
+      <Aliases>LethalCompany73</Aliases>
+    </PackageReference>
+    <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" IncludeAssets="compile">
+      <Aliases>UnityEngine73</Aliases>
+    </PackageReference>
+    <PackageReference Include="Rune580.Mods.LethalCompany.InputUtils" Version="0.7.12" IncludeAssets="compile">
+      <Aliases>LethalCompanyInputUtils73</Aliases>
+    </PackageReference>
 
     <!-- Build/development-only dependencies -->
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />

--- a/CruiserJumpPractice/Domain/CruiserSnapshot.cs
+++ b/CruiserJumpPractice/Domain/CruiserSnapshot.cs
@@ -1,6 +1,8 @@
 #nullable enable
 
-using UnityEngine;
+extern alias UnityEngine73;
+
+using UnityEngine73::UnityEngine;
 
 namespace CruiserJumpPractice.Domain;
 

--- a/CruiserJumpPractice/InputActions.cs
+++ b/CruiserJumpPractice/InputActions.cs
@@ -1,8 +1,11 @@
 #nullable enable
 
-using LethalCompanyInputUtils.Api;
-using LethalCompanyInputUtils.BindingPathEnums;
-using UnityEngine.InputSystem;
+extern alias LethalCompany73;
+extern alias LethalCompanyInputUtils73;
+
+using LethalCompany73::UnityEngine.InputSystem;
+using LethalCompanyInputUtils73::LethalCompanyInputUtils.Api;
+using LethalCompanyInputUtils73::LethalCompanyInputUtils.BindingPathEnums;
 
 namespace CruiserJumpPractice;
 

--- a/CruiserJumpPractice/Interop/Adapters/V73/CruiserAdapterV73.cs
+++ b/CruiserJumpPractice/Interop/Adapters/V73/CruiserAdapterV73.cs
@@ -1,9 +1,14 @@
 #nullable enable
 
+extern alias LethalCompany73;
+extern alias UnityEngine73;
+
 using BepInEx.Logging;
-using CruiserJumpPractice.Domain;
+using LethalCompany73;
 using System.Reflection;
-using UnityEngine;
+using UnityEngine73::UnityEngine;
+
+using CruiserJumpPractice.Domain;
 
 namespace CruiserJumpPractice.Interop.Adapters.V73;
 

--- a/CruiserJumpPractice/Interop/Adapters/V73/GameObjectAdapterV73.cs
+++ b/CruiserJumpPractice/Interop/Adapters/V73/GameObjectAdapterV73.cs
@@ -1,8 +1,11 @@
 #nullable enable
 
+extern alias LethalCompany73;
+
 using BepInEx.Logging;
-using GameNetcodeStuff;
-using Unity.Netcode;
+using LethalCompany73;
+using LethalCompany73::GameNetcodeStuff;
+using LethalCompany73::Unity.Netcode;
 
 using CruiserJumpPractice.Domain;
 

--- a/CruiserJumpPractice/Interop/Behaviours/RpcSurrogateBehaviour.cs
+++ b/CruiserJumpPractice/Interop/Behaviours/RpcSurrogateBehaviour.cs
@@ -1,8 +1,11 @@
 #nullable enable
 
-using CruiserJumpPractice.Domain;
+extern alias LethalCompany73;
+
 using BepInEx.Logging;
-using Unity.Netcode;
+using LethalCompany73::Unity.Netcode;
+
+using CruiserJumpPractice.Domain;
 
 namespace CruiserJumpPractice.Interop.Behaviours;
 

--- a/CruiserJumpPractice/Interop/Patches/HUDManagerPatch.cs
+++ b/CruiserJumpPractice/Interop/Patches/HUDManagerPatch.cs
@@ -1,7 +1,10 @@
 #nullable enable
 
+extern alias LethalCompany73;
+
 using BepInEx.Logging;
 using HarmonyLib;
+using LethalCompany73;
 
 namespace CruiserJumpPractice.Interop.Patches;
 


### PR DESCRIPTION
## Summary

This PR adds explicit extern aliases for Lethal Company v73-related compile-time dependencies.

The project now aliases:

- `LethalCompany.GameLibs.Steam` as `LethalCompany73`
- `UnityEngine.Modules` as `UnityEngine73`
- `Rune580.Mods.LethalCompany.InputUtils` as `LethalCompanyInputUtils73`

Source files that depend on these assemblies now import types through the corresponding extern aliases.

## Motivation

This makes version-specific dependencies explicit at the source level and reduces ambiguity when introducing adapters or compatibility layers for other Lethal Company versions in the future.

No functional behavior is changed.