### PR TITLE
fix(build): Define package source mapping for indirect dependencies

### DIFF
--- a/CruiserJumpPractice/nuget.config
+++ b/CruiserJumpPractice/nuget.config
@@ -7,15 +7,22 @@
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget.org">
+      <package pattern="LethalCompany.*" />
+      <package pattern="Rune580.*" />
       <!-- Implicitly required by netstandard2.1 (targeting pack) -->
       <package pattern="NETStandard.Library.Ref" />
-      <package pattern="UnityEngine.*" />
+      <!-- Indirect dependencies -->
+      <package pattern="System.*" />
+      <package pattern="Microsoft.*" />
+      <package pattern="Newtonsoft.*" />
+      <package pattern="HarmonyX" />
+      <package pattern="MonoMod.*" />
+      <package pattern="Mono.*" />
     </packageSource>
 
     <packageSource key="bepinex">
       <package pattern="BepInEx.*" />
-      <package pattern="LethalCompany.*" />
-      <package pattern="Rune580.*" />
+      <package pattern="UnityEngine.*" />
     </packageSource>
   </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
This pull request updates `nuget.config` to improve package source mapping.

The main changes are:

- Fix incorrect package source mappings between `nuget.org` and `bepinex`
- Add explicit mappings for indirect dependencies
- Fix the previous broken configuration, which was not caught because the restore check did not force a clean resolution

## Related

- #6

## Check

```shell
dotnet nuget locals global-packages --clear
dotnet restore --locked-mode --no-cache --force-evaluate
```
