### PR TITLE
chore: Remove game version from reference alias

### DIFF
--- a/CruiserJumpPractice/CruiserJumpPractice.csproj
+++ b/CruiserJumpPractice/CruiserJumpPractice.csproj
@@ -18,13 +18,13 @@
     <!-- Runtime-provided dependencies -->
     <PackageReference Include="BepInEx.Core" Version="5.4.21" IncludeAssets="compile" />
     <PackageReference Include="LethalCompany.GameLibs.Steam" Version="73.0.0-ngd.0" IncludeAssets="compile">
-      <Aliases>LethalCompany73</Aliases>
+      <Aliases>LethalCompany</Aliases>
     </PackageReference>
     <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" IncludeAssets="compile">
-      <Aliases>UnityEngine73</Aliases>
+      <Aliases>UnityEngine</Aliases>
     </PackageReference>
     <PackageReference Include="Rune580.Mods.LethalCompany.InputUtils" Version="0.7.12" IncludeAssets="compile">
-      <Aliases>LethalCompanyInputUtils73</Aliases>
+      <Aliases>LethalCompanyInputUtils</Aliases>
     </PackageReference>
 
     <!-- Build/development-only dependencies -->

--- a/CruiserJumpPractice/Domain/CruiserSnapshot.cs
+++ b/CruiserJumpPractice/Domain/CruiserSnapshot.cs
@@ -1,8 +1,8 @@
 #nullable enable
 
-extern alias UnityEngine73;
+extern alias UnityEngine;
 
-using UnityEngine73::UnityEngine;
+using UnityEngine::UnityEngine;
 
 namespace CruiserJumpPractice.Domain;
 

--- a/CruiserJumpPractice/InputActions.cs
+++ b/CruiserJumpPractice/InputActions.cs
@@ -1,11 +1,11 @@
 #nullable enable
 
-extern alias LethalCompany73;
-extern alias LethalCompanyInputUtils73;
+extern alias LethalCompany;
+extern alias LethalCompanyInputUtils;
 
-using LethalCompany73::UnityEngine.InputSystem;
-using LethalCompanyInputUtils73::LethalCompanyInputUtils.Api;
-using LethalCompanyInputUtils73::LethalCompanyInputUtils.BindingPathEnums;
+using LethalCompany::UnityEngine.InputSystem;
+using LethalCompanyInputUtils::LethalCompanyInputUtils.Api;
+using LethalCompanyInputUtils::LethalCompanyInputUtils.BindingPathEnums;
 
 namespace CruiserJumpPractice;
 

--- a/CruiserJumpPractice/Interop/Adapters/V73/CruiserAdapterV73.cs
+++ b/CruiserJumpPractice/Interop/Adapters/V73/CruiserAdapterV73.cs
@@ -1,12 +1,12 @@
 #nullable enable
 
-extern alias LethalCompany73;
-extern alias UnityEngine73;
+extern alias LethalCompany;
+extern alias UnityEngine;
 
 using BepInEx.Logging;
-using LethalCompany73;
+using LethalCompany;
 using System.Reflection;
-using UnityEngine73::UnityEngine;
+using UnityEngine::UnityEngine;
 
 using CruiserJumpPractice.Domain;
 

--- a/CruiserJumpPractice/Interop/Adapters/V73/GameObjectAdapterV73.cs
+++ b/CruiserJumpPractice/Interop/Adapters/V73/GameObjectAdapterV73.cs
@@ -1,11 +1,11 @@
 #nullable enable
 
-extern alias LethalCompany73;
+extern alias LethalCompany;
 
 using BepInEx.Logging;
-using LethalCompany73;
-using LethalCompany73::GameNetcodeStuff;
-using LethalCompany73::Unity.Netcode;
+using LethalCompany;
+using LethalCompany::GameNetcodeStuff;
+using LethalCompany::Unity.Netcode;
 
 using CruiserJumpPractice.Domain;
 

--- a/CruiserJumpPractice/Interop/Behaviours/RpcSurrogateBehaviour.cs
+++ b/CruiserJumpPractice/Interop/Behaviours/RpcSurrogateBehaviour.cs
@@ -1,9 +1,9 @@
 #nullable enable
 
-extern alias LethalCompany73;
+extern alias LethalCompany;
 
 using BepInEx.Logging;
-using LethalCompany73::Unity.Netcode;
+using LethalCompany::Unity.Netcode;
 
 using CruiserJumpPractice.Domain;
 

--- a/CruiserJumpPractice/Interop/Patches/HUDManagerPatch.cs
+++ b/CruiserJumpPractice/Interop/Patches/HUDManagerPatch.cs
@@ -1,10 +1,10 @@
 #nullable enable
 
-extern alias LethalCompany73;
+extern alias LethalCompany;
 
 using BepInEx.Logging;
 using HarmonyLib;
-using LethalCompany73;
+using LethalCompany;
 
 namespace CruiserJumpPractice.Interop.Patches;
 


### PR DESCRIPTION
This pull request simplifies reference aliases by removing game version suffixes (e.g., `73`) from all `extern alias` and corresponding `PackageReference` definitions.

---

## Background

I originally attempted to support multiple game versions (e.g., v73 and v56) simultaneously and validate compatibility statically by introducing versioned aliases such as:

* `LethalCompany73`, `LethalCompany56`
* `UnityEngine73`, `UnityEngine56`

However, this approach ran into fundamental limitations in NuGet:

* Duplicate `PackageReference` entries for different versions trigger `NU1504` warnings during restore/build.
* Proper coexistence of multiple versions is not supported without abandoning NuGet and manually managing DLLs.

Relevant issues:

* [https://github.com/NuGet/Home/issues/4989](https://github.com/NuGet/Home/issues/4989)
* [https://github.com/NuGet/Home/issues/6693](https://github.com/NuGet/Home/issues/6693)
* [https://github.com/NuGet/Home/issues/12400](https://github.com/NuGet/Home/issues/12400)

As a result, the original goal of static multi-version validation is not feasible within the current NuGet ecosystem.

---

## Changes

* Removed version suffixes from all aliases:

  * `LethalCompany73` → `LethalCompany`
  * `UnityEngine73` → `UnityEngine`
  * `LethalCompanyInputUtils73` → `LethalCompanyInputUtils`
* Updated all `extern alias` and `using` directives accordingly
* Standardized the project to reference a single game version via NuGet

---

## Rationale

Keeping version-specific aliases created the impression that:

* Multiple game versions could be supported simultaneously via NuGet
* Static compatibility checks across versions were achievable

In practice, neither is true without significant complexity (manual DLL management), which is outside the intended scope of this project.

This change aims to:

* Reduce confusion about multi-version support
* Avoid misleading architecture assumptions
* Lower maintenance overhead
* Keep the project aligned with a “latest version only” support policy
    * Support for other versions is best-effort

---

## Notes

* This is a **non-functional change** (no behavior or compatibility impact)
* It is purely a cleanup/refactor to reflect current technical constraints and project direction
