### PR TITLE
build(deps): Update GameLib to Lethal Company v81.5

### DIFF
--- a/CruiserJumpPractice/CruiserJumpPractice.csproj
+++ b/CruiserJumpPractice/CruiserJumpPractice.csproj
@@ -17,13 +17,13 @@
   <ItemGroup>
     <!-- Runtime-provided dependencies -->
     <PackageReference Include="BepInEx.Core" Version="5.4.21" IncludeAssets="compile" />
-    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="73.0.0-ngd.0" IncludeAssets="compile">
+    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="81.0.5-ngd.0" IncludeAssets="compile">
       <Aliases>LethalCompany</Aliases>
     </PackageReference>
     <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" IncludeAssets="compile">
       <Aliases>UnityEngine</Aliases>
     </PackageReference>
-    <PackageReference Include="Rune580.Mods.LethalCompany.InputUtils" Version="0.7.12" IncludeAssets="compile">
+    <PackageReference Include="Rune580.Mods.LethalCompany.InputUtils" Version="0.7.13" IncludeAssets="compile">
       <Aliases>LethalCompanyInputUtils</Aliases>
     </PackageReference>
 

--- a/CruiserJumpPractice/packages.lock.json
+++ b/CruiserJumpPractice/packages.lock.json
@@ -26,22 +26,22 @@
       },
       "LethalCompany.GameLibs.Steam": {
         "type": "Direct",
-        "requested": "[73.0.0-ngd.0, )",
-        "resolved": "73.0.0-ngd.0",
-        "contentHash": "iaHCHoJTFiTnAyAYIrEbjCJOOuhcJ42+KJnEbmCmf4UdkhjSwwio2bcdPCbchodB9kEp+3v3ATgkBwYn56/Gdw==",
+        "requested": "[81.0.5-ngd.0, )",
+        "resolved": "81.0.5-ngd.0",
+        "contentHash": "q1+j5z4lP0TKO16uZ2NclNr9/mb3BUgl6mUO7zbPwbyEHIPJ4m6805rxP0w8mxe4NWNcQRoBkWrIpiNrwak8Hg==",
         "dependencies": {
           "Newtonsoft.JSON": "13.0.3",
-          "UnityEngine.Modules": "2022.3.9"
+          "UnityEngine.Modules": "2022.3.62"
         }
       },
       "Rune580.Mods.LethalCompany.InputUtils": {
         "type": "Direct",
-        "requested": "[0.7.12, )",
-        "resolved": "0.7.12",
-        "contentHash": "WjNgfydv5/3DlSIHrl24CTJSkPFVbkeWshmfrwpKCBXWneuoM0+WEj4mxLRPOdidRkakb6nJwvD+65zHH05GRg==",
+        "requested": "[0.7.13, )",
+        "resolved": "0.7.13",
+        "contentHash": "Hebm2vcU6R+02x27MJMAAnKwe9H6iIOSYB4bIVAaAPcv0vOqUktiG6FRQkN9v+POGRgAp6E2qTuuw09eAY40Lg==",
         "dependencies": {
           "BepInEx.Core": "5.4.21",
-          "BepInEx.PluginInfoProps": "1.1.0",
+          "BepInEx.PluginInfoProps": "2.1.0",
           "UnityEngine.Modules": "2022.3.62"
         }
       },

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -8,7 +8,7 @@ No functional changes are introduced.
 
 - Compatiable with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID: `6423525044216269478`).
     - NOTE: Imperium v1.3.0 appears to have some cruiser-related issues. See this issue comment for a workaround: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735
-    - Lethal Company v73: It still seems to work, but support will be dropped as future updates may break it.
+    - Lethal Company v73: It still seems to work.
     - Lethal Company v56: Major features work as expected, but there is a minor known issue: https://github.com/aoirint/CruiserJumpPractice/issues/5
 
 ### Changed

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -1,34 +1,49 @@
 ## Unreleased
 
-This is a maintenance release reflecting internal improvements. No functional or compatibility changes are introduced, so you likely don’t need to update immediately, but staying up to date is recommended.
+This is a maintenance release reflecting internal improvements.
+
+No functional changes are introduced.
+
+You likely don’t need to update immediately as CruiserJumpPractice v0.1.4 also seems to work with both of Lethal Company v73 and Lethal Company v81.5, but staying up to date is recommended.
+
+### Compatibility
+
+- Compatiable with Lethal Company v81.5.
+    - NOTE: Imperium v1.3.0 appears to have some cruiser-related issues. See this issue comment for a workaround: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735
+- Drop support for Lethal Company v73 and earlier.
+    - Lethal Company v73: It still seems to work, but support will be dropped as future updates may break it.
+    - Lethal Company v56: Basic features seem to work, but there is a known issue: https://github.com/aoirint/CruiserJumpPractice/issues/5
 
 ### Changed
 
 - Drops backward compatibility with CruiserJumpPractice v0.1.4 and earlier.
     - The internal NetworkBehaviour name has been changed.
-- Explicitly declare support for Lethal Company v81 (2026-04-17 UTC, Manifest ID: `6423525044216269478`).
-    - Test environment
-        - BepInExPack v5.4.2305 (2026-03-17 UTC)
-        - Imperium v1.3.0 (2026-04-08 UTC)
-        - LethalCompany_InputUtils v0.7.13 (2026-03-31 UTC)
-        - LethalNetworkAPI v3.3.3 (2026-04-02 UTC)
-        - OdinSerializer v2024.2.2700 (2025-05-18 UTC)
-        - BepInEx_MonoMod_Debug_Patcher v1.1.1 (2025-04-03 UTC)
-    - NOTE: Imperium v1.3.0 appears to have some cruiser-related issues. See this issue comment for a workaround: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735
-- Explicitly declare support for Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
-    - Test environment
-        - BepInExPack v5.4.2305 (2026-03-17 UTC)
-        - Imperium v1.1.1 (2025-10-27 UTC)
-        - LethalCompany_InputUtils v0.7.12 (2025-10-24 UTC)
-        - LethalNetworkAPI v3.3.2 (2024-12-29 UTC)
-        - OdinSerializer v2024.2.2700 (2025-05-18 UTC)
 - Refactored internal architecture to improve maintainability.
+
+### Test environment
+
+- Lethal Company v81.5 (2026-04-17 UTC, Manifest ID: `6423525044216269478`)
+- BepInExPack v5.4.2305 (2026-03-17 UTC)
+- Imperium v1.3.0 (2026-04-08 UTC)
+- LethalCompany_InputUtils v0.7.13 (2026-03-31 UTC)
+- LethalNetworkAPI v3.3.3 (2026-04-02 UTC)
+- OdinSerializer v2024.2.2700 (2025-05-18 UTC)
+- BepInEx_MonoMod_Debug_Patcher v1.1.1 (2025-04-03 UTC)
 
 ## v0.1.4 - 2025-11-30 UTC
 
 ### Changed
 
 - Enables keybind actions while the player is dead, same as Imperium.
+
+### Test environment
+
+- Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`)
+- BepInExPack v5.4.2304 (2025-11-05 UTC)
+- Imperium v1.1.1 (2025-10-27 UTC)
+- LethalCompany_InputUtils v0.7.12 (2025-10-24 UTC)
+- LethalNetworkAPI v3.3.2 (2024-12-29 UTC)
+- OdinSerializer v2024.2.2700 (2025-05-18 UTC)
 
 ## v0.1.3 - 2025-11-30 UTC
 

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -4,15 +4,12 @@ This is a maintenance release reflecting internal improvements.
 
 No functional changes are introduced.
 
-You likely don’t need to update immediately as CruiserJumpPractice v0.1.4 also seems to work with both of Lethal Company v73 and Lethal Company v81.5, but staying up to date is recommended.
-
 ### Compatibility
 
-- Compatiable with Lethal Company v81.5.
+- Compatiable with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID: `6423525044216269478`).
     - NOTE: Imperium v1.3.0 appears to have some cruiser-related issues. See this issue comment for a workaround: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735
-- Drop support for Lethal Company v73 and earlier.
     - Lethal Company v73: It still seems to work, but support will be dropped as future updates may break it.
-    - Lethal Company v56: Basic features seem to work, but there is a known issue: https://github.com/aoirint/CruiserJumpPractice/issues/5
+    - Lethal Company v56: Major features work as expected, but there is a minor known issue: https://github.com/aoirint/CruiserJumpPractice/issues/5
 
 ### Changed
 
@@ -31,6 +28,10 @@ You likely don’t need to update immediately as CruiserJumpPractice v0.1.4 also
 - BepInEx_MonoMod_Debug_Patcher v1.1.1 (2025-04-03 UTC)
 
 ## v0.1.4 - 2025-11-30 UTC
+
+### Compatibility
+
+- Compatiable with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
 
 ### Changed
 
@@ -51,6 +52,10 @@ Yanked release due to a build issue.
 
 ## v0.1.2 - 2025-11-29 UTC
 
+### Compatibility
+
+- Compatiable with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
+
 ### Changed
 
 - Disables keybind actions while the player is in a menu, using the terminal, typing in chat, or is dead.
@@ -61,11 +66,19 @@ Yanked release due to a build issue.
 
 ## v0.1.1 - 2025-11-29 UTC
 
+### Compatibility
+
+- Compatiable with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
+
 ### Changed
 
 - Updated documentation.
 
 ## v0.1.0 - 2025-11-29 UTC
+
+### Compatibility
+
+- Compatiable with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
 
 ### Added
 


### PR DESCRIPTION
## Summary (Auto generated)

**Dependency Updates:**

- Updated `LethalCompany.GameLibs.Steam` from version `73.0.0-ngd.0` to `81.0.5-ngd.0` in both the project file and `packages.lock.json`, ensuring compatibility with Lethal Company v81.5. [[1]](diffhunk://#diff-ceb493f6d6b5125dd91d5b3b4f72d12ae5167b8c5187469cee5b52737023352cL20-R26) [[2]](diffhunk://#diff-3cfd102aed8f21a5a7a911cd91353d43633877f755bac15f208aa495d30324adL29-R44)
- Updated `Rune580.Mods.LethalCompany.InputUtils` from version `0.7.12` to `0.7.13` in both the project file and `packages.lock.json`. [[1]](diffhunk://#diff-ceb493f6d6b5125dd91d5b3b4f72d12ae5167b8c5187469cee5b52737023352cL20-R26) [[2]](diffhunk://#diff-3cfd102aed8f21a5a7a911cd91353d43633877f755bac15f208aa495d30324adL29-R44)
- Updated transitive dependency `BepInEx.PluginInfoProps` from `1.1.0` to `2.1.0` via the new InputUtils version.
- Updated `UnityEngine.Modules` dependency for Steam to `2022.3.62` in `packages.lock.json`.

**Documentation and Changelog Improvements:**

- Expanded `CHANGELOG.md` to clearly document compatibility with Lethal Company v81.5, v73, and v56, including manifest IDs, known issues, and links to relevant bug reports or workarounds. Also added explicit compatibility and test environment sections for previous releases. [[1]](diffhunk://#diff-5ee8ec82754e09f327132c380dd043c1719c511869f2d8e205ce57473edaaea8L3-R58) [[2]](diffhunk://#diff-5ee8ec82754e09f327132c380dd043c1719c511869f2d8e205ce57473edaaea8R69-R82)