### PR TITLE
refactor: Rename V73 -> Current

### DIFF
--- a/CruiserJumpPractice/Application/ApplicationComposition.cs
+++ b/CruiserJumpPractice/Application/ApplicationComposition.cs
@@ -68,7 +68,7 @@ internal sealed class ApplicationComposition
 
     public static ApplicationComposition Create(ManualLogSource logger)
     {
-        IGameInterop gameInterop = new GameInteropV73(logger);
+        IGameInterop gameInterop = new GameInteropCurrent(logger);
 
         var cruiserStateStore = new CruiserStateStore();
         var saveCruiserStateUseCase = new SaveCruiserStateUseCase(gameInterop, cruiserStateStore);

--- a/CruiserJumpPractice/Interop/Adapters/Current/CruiserAdapterCurrent.cs
+++ b/CruiserJumpPractice/Interop/Adapters/Current/CruiserAdapterCurrent.cs
@@ -10,14 +10,14 @@ using UnityEngine::UnityEngine;
 
 using CruiserJumpPractice.Domain;
 
-namespace CruiserJumpPractice.Interop.Adapters.V73;
+namespace CruiserJumpPractice.Interop.Adapters.Current;
 
-internal sealed class CruiserAdapterV73
+internal sealed class CruiserAdapterCurrent
 {
     private readonly ManualLogSource logger;
-    private readonly GameObjectAdapterV73 gameObjects;
+    private readonly GameObjectAdapterCurrent gameObjects;
 
-    public CruiserAdapterV73(ManualLogSource logger, GameObjectAdapterV73 gameObjects)
+    public CruiserAdapterCurrent(ManualLogSource logger, GameObjectAdapterCurrent gameObjects)
     {
         this.logger = logger;
         this.gameObjects = gameObjects;

--- a/CruiserJumpPractice/Interop/Adapters/Current/GameObjectAdapterCurrent.cs
+++ b/CruiserJumpPractice/Interop/Adapters/Current/GameObjectAdapterCurrent.cs
@@ -9,13 +9,13 @@ using LethalCompany::Unity.Netcode;
 
 using CruiserJumpPractice.Domain;
 
-namespace CruiserJumpPractice.Interop.Adapters.V73;
+namespace CruiserJumpPractice.Interop.Adapters.Current;
 
-internal sealed class GameObjectAdapterV73
+internal sealed class GameObjectAdapterCurrent
 {
     private readonly ManualLogSource logger;
 
-    public GameObjectAdapterV73(ManualLogSource logger)
+    public GameObjectAdapterCurrent(ManualLogSource logger)
     {
         this.logger = logger;
     }

--- a/CruiserJumpPractice/Interop/Adapters/Current/HudAdapterCurrent.cs
+++ b/CruiserJumpPractice/Interop/Adapters/Current/HudAdapterCurrent.cs
@@ -4,14 +4,14 @@ using BepInEx.Logging;
 
 using CruiserJumpPractice.Domain;
 
-namespace CruiserJumpPractice.Interop.Adapters.V73;
+namespace CruiserJumpPractice.Interop.Adapters.Current;
 
-internal sealed class HudAdapterV73
+internal sealed class HudAdapterCurrent
 {
     private readonly ManualLogSource logger;
-    private readonly GameObjectAdapterV73 gameObjects;
+    private readonly GameObjectAdapterCurrent gameObjects;
 
-    public HudAdapterV73(ManualLogSource logger, GameObjectAdapterV73 gameObjects)
+    public HudAdapterCurrent(ManualLogSource logger, GameObjectAdapterCurrent gameObjects)
     {
         this.logger = logger;
         this.gameObjects = gameObjects;

--- a/CruiserJumpPractice/Interop/Adapters/Current/NetworkAdapterCurrent.cs
+++ b/CruiserJumpPractice/Interop/Adapters/Current/NetworkAdapterCurrent.cs
@@ -4,14 +4,14 @@ using BepInEx.Logging;
 
 using CruiserJumpPractice.Domain;
 
-namespace CruiserJumpPractice.Interop.Adapters.V73;
+namespace CruiserJumpPractice.Interop.Adapters.Current;
 
-internal sealed class NetworkAdapterV73
+internal sealed class NetworkAdapterCurrent
 {
     private readonly ManualLogSource logger;
-    private readonly GameObjectAdapterV73 gameObjects;
+    private readonly GameObjectAdapterCurrent gameObjects;
 
-    public NetworkAdapterV73(ManualLogSource logger, GameObjectAdapterV73 gameObjects)
+    public NetworkAdapterCurrent(ManualLogSource logger, GameObjectAdapterCurrent gameObjects)
     {
         this.logger = logger;
         this.gameObjects = gameObjects;

--- a/CruiserJumpPractice/Interop/Adapters/Current/PlayerAdapterCurrent.cs
+++ b/CruiserJumpPractice/Interop/Adapters/Current/PlayerAdapterCurrent.cs
@@ -4,14 +4,14 @@ using BepInEx.Logging;
 
 using CruiserJumpPractice.Domain;
 
-namespace CruiserJumpPractice.Interop.Adapters.V73;
+namespace CruiserJumpPractice.Interop.Adapters.Current;
 
-internal sealed class PlayerAdapterV73
+internal sealed class PlayerAdapterCurrent
 {
     private readonly ManualLogSource logger;
-    private readonly GameObjectAdapterV73 gameObjects;
+    private readonly GameObjectAdapterCurrent gameObjects;
 
-    public PlayerAdapterV73(ManualLogSource logger, GameObjectAdapterV73 gameObjects)
+    public PlayerAdapterCurrent(ManualLogSource logger, GameObjectAdapterCurrent gameObjects)
     {
         this.logger = logger;
         this.gameObjects = gameObjects;

--- a/CruiserJumpPractice/Interop/Adapters/Current/RpcSurrogateAdapterCurrent.cs
+++ b/CruiserJumpPractice/Interop/Adapters/Current/RpcSurrogateAdapterCurrent.cs
@@ -5,16 +5,16 @@ using CruiserJumpPractice.Interop.Behaviours;
 
 using CruiserJumpPractice.Domain;
 
-namespace CruiserJumpPractice.Interop.Adapters.V73;
+namespace CruiserJumpPractice.Interop.Adapters.Current;
 
-internal sealed class RpcSurrogateAdapterV73
+internal sealed class RpcSurrogateAdapterCurrent
 {
     private readonly ManualLogSource logger;
-    private readonly GameObjectAdapterV73 gameObjects;
+    private readonly GameObjectAdapterCurrent gameObjects;
 
     private RpcSurrogateBehaviour? cachedRpcSurrogateBehaviour;
 
-    public RpcSurrogateAdapterV73(ManualLogSource logger, GameObjectAdapterV73 gameObjects)
+    public RpcSurrogateAdapterCurrent(ManualLogSource logger, GameObjectAdapterCurrent gameObjects)
     {
         this.logger = logger;
         this.gameObjects = gameObjects;

--- a/CruiserJumpPractice/Interop/Adapters/Current/ShipMagnetAdapterCurrent.cs
+++ b/CruiserJumpPractice/Interop/Adapters/Current/ShipMagnetAdapterCurrent.cs
@@ -4,14 +4,14 @@ using BepInEx.Logging;
 
 using CruiserJumpPractice.Domain;
 
-namespace CruiserJumpPractice.Interop.Adapters.V73;
+namespace CruiserJumpPractice.Interop.Adapters.Current;
 
-internal sealed class ShipMagnetAdapterV73
+internal sealed class ShipMagnetAdapterCurrent
 {
     private readonly ManualLogSource logger;
-    private readonly GameObjectAdapterV73 gameObjects;
+    private readonly GameObjectAdapterCurrent gameObjects;
 
-    public ShipMagnetAdapterV73(ManualLogSource logger, GameObjectAdapterV73 gameObjects)
+    public ShipMagnetAdapterCurrent(ManualLogSource logger, GameObjectAdapterCurrent gameObjects)
     {
         this.logger = logger;
         this.gameObjects = gameObjects;

--- a/CruiserJumpPractice/Interop/GameInteropCurrent.cs
+++ b/CruiserJumpPractice/Interop/GameInteropCurrent.cs
@@ -1,31 +1,31 @@
 #nullable enable
 
 using BepInEx.Logging;
-using CruiserJumpPractice.Interop.Adapters.V73;
+using CruiserJumpPractice.Interop.Adapters.Current;
 using CruiserJumpPractice.Interop.Behaviours;
 using CruiserJumpPractice.Domain;
 
 namespace CruiserJumpPractice.Interop;
 
-internal sealed class GameInteropV73 : IGameInterop
+internal sealed class GameInteropCurrent : IGameInterop
 {
-    private readonly NetworkAdapterV73 networkInterop;
-    private readonly PlayerAdapterV73 playerInterop;
-    private readonly HudAdapterV73 hudInterop;
-    private readonly RpcSurrogateAdapterV73 rpcSurrogateInterop;
-    private readonly CruiserAdapterV73 cruiserInterop;
-    private readonly ShipMagnetAdapterV73 shipMagnetInterop;
+    private readonly NetworkAdapterCurrent networkInterop;
+    private readonly PlayerAdapterCurrent playerInterop;
+    private readonly HudAdapterCurrent hudInterop;
+    private readonly RpcSurrogateAdapterCurrent rpcSurrogateInterop;
+    private readonly CruiserAdapterCurrent cruiserInterop;
+    private readonly ShipMagnetAdapterCurrent shipMagnetInterop;
 
-    public GameInteropV73(ManualLogSource logger)
+    public GameInteropCurrent(ManualLogSource logger)
     {
-        var gameObjects = new GameObjectAdapterV73(logger);
+        var gameObjects = new GameObjectAdapterCurrent(logger);
 
-        networkInterop = new NetworkAdapterV73(logger, gameObjects);
-        playerInterop = new PlayerAdapterV73(logger, gameObjects);
-        hudInterop = new HudAdapterV73(logger, gameObjects);
-        rpcSurrogateInterop = new RpcSurrogateAdapterV73(logger, gameObjects);
-        cruiserInterop = new CruiserAdapterV73(logger, gameObjects);
-        shipMagnetInterop = new ShipMagnetAdapterV73(logger, gameObjects);
+        networkInterop = new NetworkAdapterCurrent(logger, gameObjects);
+        playerInterop = new PlayerAdapterCurrent(logger, gameObjects);
+        hudInterop = new HudAdapterCurrent(logger, gameObjects);
+        rpcSurrogateInterop = new RpcSurrogateAdapterCurrent(logger, gameObjects);
+        cruiserInterop = new CruiserAdapterCurrent(logger, gameObjects);
+        shipMagnetInterop = new ShipMagnetAdapterCurrent(logger, gameObjects);
     }
 
     public bool IsServer()


### PR DESCRIPTION
This pull request refactors the interop adapter layer to transition from version-specific (`V73`) to a generalized, current version naming scheme. The main goal is to make the codebase easier to maintain and extend for future game versions by standardizing adapter names and namespaces.

### Adapter and Interop Layer Refactor

* All interop adapter classes and their files have been renamed from the `V73` suffix to `Current`, and their namespaces updated from `.V73` to `.Current`. This includes classes like `GameObjectAdapterCurrent`, `PlayerAdapterCurrent`, `HudAdapterCurrent`, `NetworkAdapterCurrent`, `RpcSurrogateAdapterCurrent`, `CruiserAdapterCurrent`, and `ShipMagnetAdapterCurrent`.

* The main interop entry point class was renamed from `GameInteropV73` to `GameInteropCurrent`, with all internal references and constructor usage updated accordingly.

* As a naming convention going forward, adapters will use the `Current` suffix by default. Version-specific classes (e.g., `VXX`) will only be introduced when strictly necessary for backporting or compatibility reasons.

These changes prepare the codebase for supporting multiple game versions more easily and clarify that the adapters now target the current version of the game, rather than being tied to a specific version number.
