### PR TITLE
refactor: Simplify network role guards

### DIFF
--- a/CruiserJumpPractice/Application/Runtime/FrameHandler.cs
+++ b/CruiserJumpPractice/Application/Runtime/FrameHandler.cs
@@ -24,11 +24,6 @@ internal sealed class FrameHandler
 
     public void HandleFrame()
     {
-        if (!gameInterop.IsClient())
-        {
-            return;
-        }
-
         if (gameInterop.IsLocalPlayerBusy())
         {
             return;

--- a/CruiserJumpPractice/Interop/Adapters/Current/NetworkAdapterCurrent.cs
+++ b/CruiserJumpPractice/Interop/Adapters/Current/NetworkAdapterCurrent.cs
@@ -17,19 +17,6 @@ internal sealed class NetworkAdapterCurrent
         this.gameObjects = gameObjects;
     }
 
-    public bool IsServer()
-    {
-        try
-        {
-            return gameObjects.GetNetworkManager().IsServer;
-        }
-        catch (System.Exception error)
-        {
-            logger.LogError($"Exception while getting 'IsServer': {error}");
-            throw new GameInteropException($"Exception while getting 'IsServer': {error}");
-        }
-    }
-
     public bool IsClient()
     {
         try

--- a/CruiserJumpPractice/Interop/Adapters/Current/NetworkAdapterCurrent.cs
+++ b/CruiserJumpPractice/Interop/Adapters/Current/NetworkAdapterCurrent.cs
@@ -17,19 +17,6 @@ internal sealed class NetworkAdapterCurrent
         this.gameObjects = gameObjects;
     }
 
-    public bool IsClient()
-    {
-        try
-        {
-            return gameObjects.GetNetworkManager().IsClient;
-        }
-        catch (System.Exception error)
-        {
-            logger.LogError($"Exception while getting 'IsClient': {error}");
-            throw new GameInteropException($"Exception while getting 'IsClient': {error}");
-        }
-    }
-
     public bool IsHost()
     {
         try

--- a/CruiserJumpPractice/Interop/Behaviours/RpcSurrogateBehaviour.cs
+++ b/CruiserJumpPractice/Interop/Behaviours/RpcSurrogateBehaviour.cs
@@ -16,12 +16,6 @@ internal class RpcSurrogateBehaviour : NetworkBehaviour
     [ServerRpc(RequireOwnership = true)]
     public void SaveCruiserStateServerRpc()
     {
-        if (!HasServerRole())
-        {
-            Logger.LogError("SaveCruiserStateServerRpc called on client. Ignoring.");
-            return;
-        }
-
         var result = CruiserJumpPractice.CruiserStateService.SaveCruiserState();
         SaveCruiserStateDoneClientRpc(result);
     }
@@ -29,24 +23,12 @@ internal class RpcSurrogateBehaviour : NetworkBehaviour
     [ClientRpc]
     public void SaveCruiserStateDoneClientRpc(SaveCruiserStateResult result)
     {
-        if (!HasClientRole())
-        {
-            Logger.LogError("SaveCruiserStateDoneClientRpc called on server. Ignoring.");
-            return;
-        }
-
         CruiserJumpPractice.RequestCruiserStateService.PresentSaveResult(result);
     }
 
     [ServerRpc(RequireOwnership = true)]
     public void LoadCruiserStateServerRpc()
     {
-        if (!HasServerRole())
-        {
-            Logger.LogError("LoadCruiserStateServerRpc called on client. Ignoring.");
-            return;
-        }
-
         var result = CruiserJumpPractice.CruiserStateService.LoadCruiserState();
         LoadCruiserStateDoneClientRpc(result);
     }
@@ -54,22 +36,6 @@ internal class RpcSurrogateBehaviour : NetworkBehaviour
     [ClientRpc]
     public void LoadCruiserStateDoneClientRpc(LoadCruiserStateResult result)
     {
-        if (!HasClientRole())
-        {
-            Logger.LogError("LoadCruiserStateDoneClientRpc called on server. Ignoring.");
-            return;
-        }
-
         CruiserJumpPractice.RequestCruiserStateService.PresentLoadResult(result);
-    }
-
-    private static bool HasServerRole()
-    {
-        return CruiserJumpPractice.GameInterop.IsServer();
-    }
-
-    private static bool HasClientRole()
-    {
-        return CruiserJumpPractice.GameInterop.IsClient();
     }
 }

--- a/CruiserJumpPractice/Interop/GameInteropCurrent.cs
+++ b/CruiserJumpPractice/Interop/GameInteropCurrent.cs
@@ -28,11 +28,6 @@ internal sealed class GameInteropCurrent : IGameInterop
         shipMagnetInterop = new ShipMagnetAdapterCurrent(logger, gameObjects);
     }
 
-    public bool IsClient()
-    {
-        return networkInterop.IsClient();
-    }
-
     public bool IsHost()
     {
         return networkInterop.IsHost();

--- a/CruiserJumpPractice/Interop/GameInteropCurrent.cs
+++ b/CruiserJumpPractice/Interop/GameInteropCurrent.cs
@@ -28,11 +28,6 @@ internal sealed class GameInteropCurrent : IGameInterop
         shipMagnetInterop = new ShipMagnetAdapterCurrent(logger, gameObjects);
     }
 
-    public bool IsServer()
-    {
-        return networkInterop.IsServer();
-    }
-
     public bool IsClient()
     {
         return networkInterop.IsClient();

--- a/CruiserJumpPractice/Interop/IGameInterop.cs
+++ b/CruiserJumpPractice/Interop/IGameInterop.cs
@@ -7,8 +7,6 @@ namespace CruiserJumpPractice.Interop;
 
 internal interface IGameInterop
 {
-    bool IsServer();
-
     bool IsClient();
 
     bool IsHost();

--- a/CruiserJumpPractice/Interop/IGameInterop.cs
+++ b/CruiserJumpPractice/Interop/IGameInterop.cs
@@ -7,8 +7,6 @@ namespace CruiserJumpPractice.Interop;
 
 internal interface IGameInterop
 {
-    bool IsClient();
-
     bool IsHost();
 
     bool IsLocalPlayerBusy();


### PR DESCRIPTION
> [!WARNING]
> This pull request was generated with assistance from an LLM. Please review the changes carefully.

## Summary
- Remove redundant role guards from RPC surrogate methods
- Remove unused `IsServer()` and `IsClient()` interop methods
- Let `HandleFrame()` proceed without the extra client role check

## Verification
- `dotnet build CruiserJumpPractice.sln`
