### PR TITLE
docs: guard PR bodies against shell quoting issues

### DIFF
--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -62,3 +62,11 @@ Recommend sections only when they carry useful information:
 - Do not paste large diffs.
 - Be explicit when verification was not run.
 - Align the PR title type with the dominant change: for example, `docs:` for documentation-only skill additions and `refactor:` for behavior-preserving code cleanup.
+
+## CLI Safety
+
+When creating or editing PR bodies with a shell command, avoid passing Markdown directly through command arguments if it contains backticks, quotes, dollar signs, backslashes, or multiple lines. Shells such as PowerShell and bash can interpret those characters and silently corrupt the body.
+
+- Prefer writing the body to a temporary Markdown file and passing it with `gh pr create --body-file <file>` or `gh pr edit --body-file <file>`.
+- After creating or editing a PR through `gh`, verify the stored body with `gh pr view --json body` and fix any quoting issues before finishing.
+- Remove any temporary body file from the worktree after verification.


### PR DESCRIPTION
> [!WARNING]
> This pull request was generated with LLM assistance.

## Summary
- Add CLI safety guidance to `pull-request-quality-check`.
- Prefer `gh --body-file` workflows and post-create verification so Markdown backticks and other shell-sensitive characters do not get corrupted by PowerShell or bash.

## Verification
- Reviewed the updated skill guidance.
- Not run: build/tests, because this only updates Agent Skill documentation.
