### PR TITLE
docs: add issue quality-check skill

### DIFF
--- a/.agents/skills/issue-quality-check/SKILL.md
+++ b/.agents/skills/issue-quality-check/SKILL.md
@@ -25,7 +25,7 @@ When the issue was prepared with LLM assistance, check that this GitHub alert ap
 
 ```markdown
 > [!WARNING]
-> This issue was generated with LLM assistance.
+> This issue was generated with LLMs.
 ```
 
 The alert should appear before every other heading, summary, checklist, template field, or metadata block.
@@ -36,7 +36,7 @@ Check that the body is concise and uses these sections when applicable:
 
 ```markdown
 > [!WARNING]
-> This issue was generated with LLM assistance.
+> This issue was generated with LLMs.
 
 ## Summary
 - ...
@@ -80,7 +80,7 @@ When the issue reply was prepared with LLM assistance, check that this GitHub al
 
 ```markdown
 > [!WARNING]
-> This issue reply was generated with LLM assistance.
+> This comment was generated with LLMs.
 ```
 
 The alert should appear before every other paragraph, heading, checklist, quote, or metadata block.
@@ -89,7 +89,7 @@ Check that the reply is concise and uses only the structure needed for the situa
 
 ```markdown
 > [!WARNING]
-> This issue reply was generated with LLM assistance.
+> This comment was generated with LLMs.
 
 Thanks for the report. I can reproduce this with ...
 

--- a/.agents/skills/issue-quality-check/SKILL.md
+++ b/.agents/skills/issue-quality-check/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: issue-quality-check
+description: Quality-check repository issues and issue replies. Use when creating or updating GitHub issues or comments on issues.
+---
+
+# Issue Quality Check
+
+## When to Use
+
+- Use this skill when creating, updating, reviewing, or validating GitHub issue titles or bodies for this repository.
+- Use this skill when creating, updating, reviewing, or validating replies or comments on GitHub issues for this repository.
+
+## Title
+
+Check that the title is concise, specific, and written as a problem or task:
+
+- Prefer a clear noun phrase or imperative task, such as `Add practice reset hotkey documentation` or `Fix cruiser state reload after scene transition`.
+- Include the affected area when it helps triage, such as `MagnetService:` or `docs:`.
+- Avoid vague titles such as `Bug`, `Question`, `Help`, or `Does not work`.
+- Do not force Conventional Commits format for issues unless the repository explicitly asks for it in that issue flow.
+
+## Required LLM Alert
+
+When the issue was prepared with LLM assistance, check that this GitHub alert appears at the very top of the issue body:
+
+```markdown
+> [!WARNING]
+> This issue was generated with LLM assistance.
+```
+
+The alert should appear before every other heading, summary, checklist, template field, or metadata block.
+
+## Body Structure
+
+Check that the body is concise and uses these sections when applicable:
+
+```markdown
+> [!WARNING]
+> This issue was generated with LLM assistance.
+
+## Summary
+- ...
+
+## Details
+- ...
+
+## Acceptance Criteria
+- ...
+```
+
+Recommend sections only when they carry useful information:
+
+- `Summary`: the problem, request, or outcome in maintainer-facing language.
+- `Details`: relevant context, reproduction notes, affected paths, logs, or constraints.
+- `Acceptance Criteria`: concrete checks that would make the issue complete.
+- `Verification`: commands, manual checks, or observations already performed.
+- `Notes`: limitations, related work, dependencies, or reviewer attention points.
+
+## Style
+
+- Keep issue bodies short and scannable.
+- Prefer bullets for facts, steps, and criteria.
+- Mention paths, commands, classes, and config keys in backticks.
+- Include exact expected and actual behavior for bugs.
+- Include reproduction steps only when they are known and useful.
+- Do not paste large logs, stack traces, or diffs; summarize and link or attach details when needed.
+- Be explicit when verification or reproduction was not run.
+
+## CLI Safety
+
+When creating or editing issue bodies with a shell command, avoid passing Markdown directly through command arguments if it contains backticks, quotes, dollar signs, backslashes, or multiple lines. Shells such as PowerShell and bash can interpret those characters and silently corrupt the body.
+
+- Prefer writing the body to a temporary Markdown file and passing it with `gh issue create --body-file <file>` or `gh issue edit --body-file <file>`.
+- After creating or editing an issue through `gh`, verify the stored body with `gh issue view --json body` and fix any quoting issues before finishing.
+- Remove any temporary body file from the worktree after verification.
+
+## Issue Replies
+
+When the issue reply was prepared with LLM assistance, check that this GitHub alert appears at the very top of the comment body:
+
+```markdown
+> [!WARNING]
+> This issue reply was generated with LLM assistance.
+```
+
+The alert should appear before every other paragraph, heading, checklist, quote, or metadata block.
+
+Check that the reply is concise and uses only the structure needed for the situation:
+
+```markdown
+> [!WARNING]
+> This issue reply was generated with LLM assistance.
+
+Thanks for the report. I can reproduce this with ...
+
+## Next Steps
+- ...
+```
+
+Recommend sections only when they carry useful information:
+
+- Opening sentence: acknowledge the report, question, or prior comment directly.
+- `Findings`: facts discovered from code, logs, reproduction, or maintainer investigation.
+- `Next Steps`: what will be done next, what is blocked, or what input is needed.
+- `Verification`: commands or manual checks run while investigating.
+- `Notes`: caveats, related issues, or constraints that should remain visible.
+
+For issue replies:
+
+- Keep replies focused on the current issue thread.
+- Answer direct questions before adding broader context.
+- Quote only the smallest useful part of a previous comment.
+- Mention paths, commands, classes, and config keys in backticks.
+- Be clear whether something is confirmed, inferred, untested, or still unknown.
+- Ask for specific missing information when needed, such as logs, mod versions, reproduction steps, or save data details.
+- Avoid large diffs, large logs, and unrelated implementation plans.
+- Do not promise timelines unless they are already agreed.
+
+When creating or editing issue replies with a shell command:
+
+- Prefer writing the reply to a temporary Markdown file and passing it with `gh issue comment --body-file <file>`.
+- After creating or editing a reply through `gh`, verify the stored comment body when possible and fix any quoting issues before finishing.
+- Remove any temporary body file from the worktree after verification.

--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -27,7 +27,7 @@ When the PR was prepared with LLM assistance, check that this GitHub alert appea
 
 ```markdown
 > [!WARNING]
-> This pull request was generated with LLM assistance.
+> This pull request was generated with LLMs.
 ```
 
 The alert should appear before every other heading, summary, checklist, or metadata block.
@@ -38,7 +38,7 @@ Check that the body is concise and uses these sections when applicable:
 
 ```markdown
 > [!WARNING]
-> This pull request was generated with LLM assistance.
+> This pull request was generated with LLMs.
 
 ## Summary
 - ...
@@ -62,6 +62,17 @@ Recommend sections only when they carry useful information:
 - Do not paste large diffs.
 - Be explicit when verification was not run.
 - Align the PR title type with the dominant change: for example, `docs:` for documentation-only skill additions and `refactor:` for behavior-preserving code cleanup.
+
+## Pull Request Replies and Reviews
+
+When a pull request reply or review was prepared with LLM assistance, check that this GitHub alert appears at the very top of the comment or review body:
+
+```markdown
+> [!WARNING]
+> This comment was generated with LLMs.
+```
+
+The alert should appear before every other paragraph, heading, checklist, quote, finding, or metadata block.
 
 ## CLI Safety
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /profiles
 /build
 /CruiserJumpPractice/Generated/
+# Local Git worktrees used by coding agents
 /.agents/worktrees/
 
 # https://github.com/github/gitignore/blob/86922aee426c32ffb6098f9a38c42da75169501e/VisualStudio.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /profiles
 /build
 /CruiserJumpPractice/Generated/
+/.agents/worktrees/
 
 # https://github.com/github/gitignore/blob/86922aee426c32ffb6098f9a38c42da75169501e/VisualStudio.gitignore
 ## Ignore Visual Studio temporary files, build results, and


### PR DESCRIPTION
> [!WARNING]
> This pull request was generated with LLMs.

## Summary
- Add `.agents/worktrees/` to `.gitignore` for local Git worktree storage.
- Add `issue-quality-check` for GitHub issue titles, bodies, and issue replies.
- Standardize repository LLM alert wording for issues, comments, pull requests, and pull request replies/reviews.

## Verification
- Reviewed the updated skill content directly.
- `git status --short --branch` in the worktree showed only the temporary PR body file before cleanup.
