### PR TITLE
docs: add git worktree workflow skill

### DIFF
--- a/.agents/skills/git-worktree-implementation/SKILL.md
+++ b/.agents/skills/git-worktree-implementation/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: git-worktree-implementation
+description: Use Git worktrees for implementation tasks. Use when asked to implement code changes, create a branch, or prepare a pull request from the latest main branch.
+---
+
+# Git Worktree Implementation
+
+## When to Use
+
+- Use this skill when implementing repository changes that should be isolated from the user's current working tree.
+- Use this skill when the user asks to create a pull request from the latest `main` branch.
+- Use this skill when the user explicitly asks to work in a Git worktree.
+
+## Worktree Location
+
+Create implementation worktrees under:
+
+```text
+.agents/worktrees/
+```
+
+Use a short, descriptive branch and directory name, such as:
+
+```text
+.agents/worktrees/fix-cruiser-state-load
+```
+
+## Starting Point
+
+Start from the latest `main` branch unless the user names another base:
+
+```powershell
+git fetch origin main
+git worktree add -b <branch-name> .agents/worktrees/<branch-name> origin/main
+```
+
+If network access or Git metadata writes require approval, request it and continue after approval.
+
+## Safety Rules
+
+- Check the original worktree with `git status --short --branch` before creating a new worktree.
+- Treat uncommitted or untracked files in the original worktree as user work.
+- Do not edit implementation files in the original worktree after creating the task worktree.
+- Do not remove another worktree unless the user explicitly asks.
+- If the branch or worktree path already exists, choose a new descriptive name or inspect it before reuse.
+- If Git reports dubious ownership for the new worktree, add only that worktree path as a `safe.directory`.
+
+## Implementation Flow
+
+1. Fetch the latest base branch.
+2. Create a branch and worktree under `.agents/worktrees/`.
+3. Do all implementation, formatting, and verification inside the new worktree.
+4. Commit changes using `commit-message-quality-check`.
+5. Push the branch.
+6. Create or update the pull request using `pull-request-quality-check`.
+
+## Verification
+
+Run checks that match the change risk and repository conventions. For this repository, useful checks often include:
+
+```powershell
+dotnet build CruiserJumpPractice.sln
+```
+
+If verification is skipped, state why in the pull request body.
+
+## Pull Request Notes
+
+- Keep pull request titles and bodies consistent with `pull-request-quality-check`.
+- Mention the worktree path only when it helps the user find the local work.
+- Remove temporary PR body files from the worktree after creating or editing the pull request.

--- a/.agents/skills/git-worktree-workflow/SKILL.md
+++ b/.agents/skills/git-worktree-workflow/SKILL.md
@@ -7,8 +7,8 @@ description: Use Git worktrees for repository implementation tasks unless explic
 
 ## When to Use
 
-- Use this skill when implementing repository changes unless the user explicitly instructs you not to use Git worktrees.
-- This includes code, tests, build files, documentation, repository guidance, and pull-request preparation.
+- Use this skill for repository implementation work unless the user explicitly instructs you not to use Git worktrees.
+- Implementation work includes code, tests, build files, documentation, repository guidance, and pull-request preparation.
 
 ## Worktree Location
 
@@ -26,7 +26,7 @@ Use a short, descriptive branch and directory name, such as:
 
 ## Starting Point
 
-Start from the latest base branch, usually `main`, unless the user names another base:
+Start from the latest base branch unless the user names a different base. The usual base is `main`:
 
 ```powershell
 git fetch origin main
@@ -38,26 +38,26 @@ If network access or Git metadata writes require approval, request it and contin
 ## Safety Rules
 
 - Treat uncommitted or untracked files in the original worktree as user work.
-- Do not edit implementation files in the original worktree after creating the task worktree.
+- After creating the task worktree, make implementation changes there.
 - Do not remove another worktree unless the user explicitly asks.
-- If the branch or worktree path already exists, choose a new descriptive name or inspect it before reuse.
+- If the branch or worktree path already exists, inspect it before reuse or choose a new descriptive name.
 
 ## Implementation Flow
 
 1. Check the current repository state.
 2. Fetch the latest base branch.
 3. Create a branch and worktree under `.agents/worktrees/`.
-4. Before editing, make an implementation plan split into practical phases.
-5. For each phase, do only that phase's implementation and quality check inside the new worktree.
-6. Commit that phase immediately using `commit-message-quality-check` before starting the next phase.
-7. Repeat steps 5 and 6 until the planned phases are complete.
-8. After all phases are complete, run a final quality check before pushing.
+4. Before editing, split the implementation plan into practical phases.
+5. For each phase, implement only that phase, then run its quality check inside the worktree.
+6. Commit the completed phase immediately using `commit-message-quality-check`.
+7. Repeat steps 5 and 6 until every planned phase is complete.
+8. Before pushing, run the final quality check.
 9. Push the branch.
 10. Create or update the pull request using `pull-request-quality-check`.
 
 ## Quality Check
 
-A quality check means formatting plus verification appropriate to the change risk and repository conventions.
+A quality check means formatting and verification appropriate to the change risk and repository conventions.
 
 For this repository, useful verification often includes:
 
@@ -67,7 +67,7 @@ dotnet build CruiserJumpPractice.sln
 
 If verification is skipped, state why in the pull request body.
 
-Before pushing, also review the complete diff and recent commits for accidental scope creep, missing verification, and commit-message quality.
+The final quality check also includes reviewing the complete diff and recent commits for accidental scope creep, missing verification, and commit-message quality.
 
 ## Pull Request Notes
 

--- a/.agents/skills/git-worktree-workflow/SKILL.md
+++ b/.agents/skills/git-worktree-workflow/SKILL.md
@@ -41,7 +41,6 @@ If network access or Git metadata writes require approval, request it and contin
 - Do not edit implementation files in the original worktree after creating the task worktree.
 - Do not remove another worktree unless the user explicitly asks.
 - If the branch or worktree path already exists, choose a new descriptive name or inspect it before reuse.
-- Do not change Git safety settings casually. If Git reports dubious ownership and the task cannot continue otherwise, add only the specific new worktree's absolute path as a `safe.directory`.
 
 ## Implementation Flow
 

--- a/.agents/skills/git-worktree-workflow/SKILL.md
+++ b/.agents/skills/git-worktree-workflow/SKILL.md
@@ -10,7 +10,20 @@ description: Use Git worktrees for repository implementation tasks unless explic
 - Use this skill for repository implementation work unless the user explicitly instructs you not to use Git worktrees.
 - Implementation work includes code, tests, build files, documentation, repository guidance, and pull-request preparation.
 
-## Worktree Location
+## Workflow
+
+1. Check the current repository state.
+2. Fetch the latest base branch.
+3. Create a branch and worktree under `.agents/worktrees/`.
+4. Before editing, split the implementation plan into practical phases.
+5. For each phase, implement only that phase, then run its quality check inside the worktree.
+6. Commit the completed phase immediately using `commit-message-quality-check`.
+7. Repeat steps 5 and 6 until every planned phase is complete.
+8. Before pushing, run the final quality check.
+9. Push the branch.
+10. Create or update the pull request using `pull-request-quality-check`.
+
+## Worktree Setup
 
 Create implementation worktrees under:
 
@@ -23,8 +36,6 @@ Use a short, descriptive branch and directory name, such as:
 ```text
 .agents/worktrees/fix-cruiser-state-load
 ```
-
-## Starting Point
 
 Start from the latest base branch unless the user names a different base. The usual base is `main`:
 
@@ -41,19 +52,6 @@ If network access or Git metadata writes require approval, request it and contin
 - After creating the task worktree, make implementation changes there.
 - Do not remove another worktree unless the user explicitly asks.
 - If the branch or worktree path already exists, inspect it before reuse or choose a new descriptive name.
-
-## Implementation Flow
-
-1. Check the current repository state.
-2. Fetch the latest base branch.
-3. Create a branch and worktree under `.agents/worktrees/`.
-4. Before editing, split the implementation plan into practical phases.
-5. For each phase, implement only that phase, then run its quality check inside the worktree.
-6. Commit the completed phase immediately using `commit-message-quality-check`.
-7. Repeat steps 5 and 6 until every planned phase is complete.
-8. Before pushing, run the final quality check.
-9. Push the branch.
-10. Create or update the pull request using `pull-request-quality-check`.
 
 ## Quality Check
 

--- a/.agents/skills/git-worktree-workflow/SKILL.md
+++ b/.agents/skills/git-worktree-workflow/SKILL.md
@@ -49,10 +49,11 @@ If network access or Git metadata writes require approval, request it and contin
 2. Fetch the latest base branch.
 3. Create a branch and worktree under `.agents/worktrees/`.
 4. Before editing, make an implementation plan split into practical phases.
-5. Do implementation, formatting, and verification inside the new worktree.
-6. Commit each completed phase using `commit-message-quality-check` instead of waiting until all changes are finished.
-7. Push the branch.
-8. Create or update the pull request using `pull-request-quality-check`.
+5. For each phase, do only that phase's implementation, formatting, and verification inside the new worktree.
+6. Commit that phase immediately using `commit-message-quality-check` before starting the next phase.
+7. Repeat steps 5 and 6 until the planned phases are complete.
+8. Push the branch.
+9. Create or update the pull request using `pull-request-quality-check`.
 
 ## Verification
 

--- a/.agents/skills/git-worktree-workflow/SKILL.md
+++ b/.agents/skills/git-worktree-workflow/SKILL.md
@@ -41,7 +41,7 @@ If network access or Git metadata writes require approval, request it and contin
 - Do not edit implementation files in the original worktree after creating the task worktree.
 - Do not remove another worktree unless the user explicitly asks.
 - If the branch or worktree path already exists, choose a new descriptive name or inspect it before reuse.
-- If Git reports dubious ownership for the new worktree, add only that worktree path as a `safe.directory`.
+- Do not change Git safety settings casually. If Git reports dubious ownership and the task cannot continue otherwise, add only the specific new worktree's absolute path as a `safe.directory`.
 
 ## Implementation Flow
 
@@ -52,8 +52,9 @@ If network access or Git metadata writes require approval, request it and contin
 5. For each phase, do only that phase's implementation, formatting, and verification inside the new worktree.
 6. Commit that phase immediately using `commit-message-quality-check` before starting the next phase.
 7. Repeat steps 5 and 6 until the planned phases are complete.
-8. Push the branch.
-9. Create or update the pull request using `pull-request-quality-check`.
+8. After all phases are complete, run a final quality check before pushing.
+9. Push the branch.
+10. Create or update the pull request using `pull-request-quality-check`.
 
 ## Verification
 
@@ -64,6 +65,8 @@ dotnet build CruiserJumpPractice.sln
 ```
 
 If verification is skipped, state why in the pull request body.
+
+Before pushing, review the complete diff and recent commits for accidental scope creep, missing verification, and commit-message quality.
 
 ## Pull Request Notes
 

--- a/.agents/skills/git-worktree-workflow/SKILL.md
+++ b/.agents/skills/git-worktree-workflow/SKILL.md
@@ -1,13 +1,14 @@
 ---
-name: git-worktree-implementation
-description: Use Git worktrees for implementation tasks. Use when asked to implement code changes, create a branch, or prepare a pull request from the latest main branch.
+name: git-worktree-workflow
+description: Use Git worktrees for implementation tasks unless explicitly told not to. Use when asked to implement code changes, create a branch, or prepare a pull request from the latest main branch.
 ---
 
-# Git Worktree Implementation
+# Git Worktree Workflow
 
 ## When to Use
 
-- Use this skill when implementing repository changes that should be isolated from the user's current working tree.
+- Use this skill when implementing repository changes unless the user explicitly instructs you not to use Git worktrees.
+- Use this skill when implementation work should be isolated from the user's current working tree.
 - Use this skill when the user asks to create a pull request from the latest `main` branch.
 - Use this skill when the user explicitly asks to work in a Git worktree.
 

--- a/.agents/skills/git-worktree-workflow/SKILL.md
+++ b/.agents/skills/git-worktree-workflow/SKILL.md
@@ -48,16 +48,18 @@ If network access or Git metadata writes require approval, request it and contin
 2. Fetch the latest base branch.
 3. Create a branch and worktree under `.agents/worktrees/`.
 4. Before editing, make an implementation plan split into practical phases.
-5. For each phase, do only that phase's implementation, formatting, and verification inside the new worktree.
+5. For each phase, do only that phase's implementation and quality check inside the new worktree.
 6. Commit that phase immediately using `commit-message-quality-check` before starting the next phase.
 7. Repeat steps 5 and 6 until the planned phases are complete.
 8. After all phases are complete, run a final quality check before pushing.
 9. Push the branch.
 10. Create or update the pull request using `pull-request-quality-check`.
 
-## Verification
+## Quality Check
 
-Run checks that match the change risk and repository conventions. For this repository, useful checks often include:
+A quality check means formatting plus verification appropriate to the change risk and repository conventions.
+
+For this repository, useful verification often includes:
 
 ```powershell
 dotnet build CruiserJumpPractice.sln
@@ -65,7 +67,7 @@ dotnet build CruiserJumpPractice.sln
 
 If verification is skipped, state why in the pull request body.
 
-Before pushing, review the complete diff and recent commits for accidental scope creep, missing verification, and commit-message quality.
+Before pushing, also review the complete diff and recent commits for accidental scope creep, missing verification, and commit-message quality.
 
 ## Pull Request Notes
 

--- a/.agents/skills/git-worktree-workflow/SKILL.md
+++ b/.agents/skills/git-worktree-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-worktree-workflow
-description: Use Git worktrees for implementation tasks unless explicitly told not to. Use when asked to implement code changes, create a branch, or prepare a pull request from the latest main branch.
+description: Use Git worktrees for repository implementation tasks unless explicitly told not to.
 ---
 
 # Git Worktree Workflow
@@ -8,9 +8,7 @@ description: Use Git worktrees for implementation tasks unless explicitly told n
 ## When to Use
 
 - Use this skill when implementing repository changes unless the user explicitly instructs you not to use Git worktrees.
-- Use this skill when implementation work should be isolated from the user's current working tree.
-- Use this skill when the user asks to create a pull request from the latest `main` branch.
-- Use this skill when the user explicitly asks to work in a Git worktree.
+- This includes code, tests, build files, documentation, repository guidance, and pull-request preparation.
 
 ## Worktree Location
 
@@ -28,7 +26,7 @@ Use a short, descriptive branch and directory name, such as:
 
 ## Starting Point
 
-Start from the latest `main` branch unless the user names another base:
+Start from the latest base branch, usually `main`, unless the user names another base:
 
 ```powershell
 git fetch origin main
@@ -39,7 +37,6 @@ If network access or Git metadata writes require approval, request it and contin
 
 ## Safety Rules
 
-- Check the original worktree with `git status --short --branch` before creating a new worktree.
 - Treat uncommitted or untracked files in the original worktree as user work.
 - Do not edit implementation files in the original worktree after creating the task worktree.
 - Do not remove another worktree unless the user explicitly asks.
@@ -48,12 +45,13 @@ If network access or Git metadata writes require approval, request it and contin
 
 ## Implementation Flow
 
-1. Fetch the latest base branch.
-2. Create a branch and worktree under `.agents/worktrees/`.
-3. Do all implementation, formatting, and verification inside the new worktree.
-4. Commit changes using `commit-message-quality-check`.
-5. Push the branch.
-6. Create or update the pull request using `pull-request-quality-check`.
+1. Check the current repository state.
+2. Fetch the latest base branch.
+3. Create a branch and worktree under `.agents/worktrees/`.
+4. Do all implementation, formatting, and verification inside the new worktree.
+5. Commit changes using `commit-message-quality-check`.
+6. Push the branch.
+7. Create or update the pull request using `pull-request-quality-check`.
 
 ## Verification
 
@@ -68,5 +66,4 @@ If verification is skipped, state why in the pull request body.
 ## Pull Request Notes
 
 - Keep pull request titles and bodies consistent with `pull-request-quality-check`.
-- Mention the worktree path only when it helps the user find the local work.
 - Remove temporary PR body files from the worktree after creating or editing the pull request.

--- a/.agents/skills/git-worktree-workflow/SKILL.md
+++ b/.agents/skills/git-worktree-workflow/SKILL.md
@@ -48,10 +48,11 @@ If network access or Git metadata writes require approval, request it and contin
 1. Check the current repository state.
 2. Fetch the latest base branch.
 3. Create a branch and worktree under `.agents/worktrees/`.
-4. Do all implementation, formatting, and verification inside the new worktree.
-5. Commit changes using `commit-message-quality-check`.
-6. Push the branch.
-7. Create or update the pull request using `pull-request-quality-check`.
+4. Before editing, make an implementation plan split into practical phases.
+5. Do implementation, formatting, and verification inside the new worktree.
+6. Commit each completed phase using `commit-message-quality-check` instead of waiting until all changes are finished.
+7. Push the branch.
+8. Create or update the pull request using `pull-request-quality-check`.
 
 ## Verification
 


### PR DESCRIPTION
> [!WARNING]
> This pull request was generated with LLMs.

## Summary
- Add `git-worktree-workflow` as a repository-local Agent Skill.
- Define Git worktrees as the default workflow for implementation tasks unless explicitly disabled.
- Put the workflow first, then document setup, safety, quality checks, and PR notes.
- Require phased planning, per-phase quality checks, immediate commits, and a final diff and commit review before push.

## Verification
- Reviewed the updated skill content directly.
- `git diff origin/main...HEAD --stat`
- `git log --oneline origin/main..HEAD`
- `git status --short --branch`
