### PR TITLE
docs(skills): add AI agent commit attribution guidance

### DIFF
--- a/.agents/skills/commit-message-quality-check/SKILL.md
+++ b/.agents/skills/commit-message-quality-check/SKILL.md
@@ -5,10 +5,14 @@ description: Quality-check repository commit messages. Use when creating or upda
 
 # Commit Message Quality Check
 
-Check commit messages against Conventional Commits 1.0.0.
+## Goals
+
+- Check commit messages against Conventional Commits 1.0.0.
+- Check repository attribution policy, including AI agent co-author trailers.
 
 Reference:
 - Conventional Commits 1.0.0: https://www.conventionalcommits.org/en/v1.0.0/
+- GitHub co-authored commits: https://docs.github.com/articles/creating-a-commit-with-multiple-authors
 
 ## When to Use
 
@@ -39,7 +43,7 @@ Verify that an optional body starts after one blank line, and optional footer li
 - `!`: optional marker immediately before `:` for a breaking change.
 - `description`: required short summary after `: `. Use imperative mood, lowercase after the type unless a proper noun is needed, and no trailing period.
 - `body`: optional free-form explanation of what changed and why. Start it one blank line after the description.
-- `footer`: optional trailer-style metadata. Use tokens such as `Refs`, `Reviewed-by`, or `BREAKING CHANGE`.
+- `footer`: optional trailer-style metadata. Use tokens such as `Refs`, `Reviewed-by`, `Co-authored-by`, or `BREAKING CHANGE`.
 
 ## Breaking Changes
 
@@ -58,6 +62,38 @@ BREAKING CHANGE: legacy save endpoint is no longer available.
 ```
 
 `BREAKING CHANGE` must be uppercase when used as a footer. `BREAKING-CHANGE` is equivalent when used as a footer token.
+
+## AI Agent Co-Author Trailers
+
+When an AI agent materially created or changed content in the commit, check for
+an appropriate `Co-authored-by:` trailer unless repository or user instructions
+explicitly say not to add one. Do not add AI co-author attribution for passive
+lookup, review-only advice, formatting a user-written message, or incidental
+autocomplete unless the project policy requires it.
+
+Use this selection order:
+
+1. Prefer an explicit repository, organization, tool, or user-provided
+   attribution string.
+2. If the active agent/tool has a documented or configured default, use that
+   exact value.
+3. If no exact value is available, use a stable, privacy-preserving service
+   identity for the agent type.
+4. If the agent identity is unknown, use a generic local policy value only when
+   the repository defines one; otherwise omit the trailer and note the missing
+   attribution source.
+
+Known default examples:
+
+- Codex: `Co-authored-by: Codex <noreply@openai.com>`
+- Claude Code: `Co-authored-by: Claude <noreply@anthropic.com>`
+- GitHub Copilot: `Co-authored-by: Copilot <copilot@github.com>`
+
+If multiple AI agents materially contributed, add one `Co-authored-by:` trailer
+per agent. Put each trailer on its own line in the footer block, with no blank
+lines between consecutive trailer lines. Keep `BREAKING CHANGE` before ordinary
+metadata when it explains the change, and keep co-author trailers at the end
+unless another project rule says otherwise.
 
 ## Type Selection
 
@@ -95,4 +131,10 @@ fix(input): ignore hotkeys while local player is busy
 feat!: require current game interop adapters
 
 BREAKING CHANGE: legacy versioned adapters are no longer loaded.
+```
+
+```text
+docs: document agent attribution policy
+
+Co-authored-by: Codex <noreply@openai.com>
 ```


### PR DESCRIPTION
> [!WARNING]
> This pull request was generated with LLMs.

## Summary
- Add AI agent co-author attribution guidance to the commit-message skill.
- Generalize attribution selection by repository/tool defaults, with Codex, Claude Code, and GitHub Copilot as examples.

## Verification
- `git diff --check`
- Manual Skill frontmatter validation with PowerShell

## Notes
- `quick_validate.py` was not run because `python` and `python3` resolve to Windows Store aliases in this environment.
