### PR TITLE
docs(skills): add code quality check skill

### DIFF
--- a/.agents/skills/code-quality-check/SKILL.md
+++ b/.agents/skills/code-quality-check/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: code-quality-check
+description: Review code changes for maintainability, clarity, design intent, comments, tests, and verification before committing or requesting review.
+---
+
+# Code Quality Check
+
+## When to Use
+
+- Use this skill when reviewing source-code changes before committing, pushing, or opening a pull request.
+- Use this skill when adding or revising comments, XML documentation, adapters, boundary types, result types, exception handling, reflection, lifecycle-sensitive code, or other code that future readers must navigate.
+- Use this skill when a review should start from a blank reading of the diff instead of only checking whether the implementation matches the original plan.
+
+## Goals
+
+- Confirm that the change is correct, scoped, and understandable to a first-time reader.
+- Make design boundaries, ownership, data shapes, exceptions, and external constraints visible where they matter.
+- Prefer comments that explain why a boundary, exception, adapter, or data shape exists, not comments that restate what the code already says.
+- Prefer XML documentation for types and members whose design intent should appear in IDE navigation or completion, even when they are not public APIs.
+- Avoid mechanical comment templates. Repeated table-like documentation is acceptable only when the repeated shape is the clearest form, such as attribute lists, key assignments, or input-action tables like `InputUtilsActions`; keep the reason for that shape nearby.
+- Keep comments concentrated at entry points: classes, interfaces, adapters, boundary/result types, and non-obvious integration surfaces. Use method-body comments only for non-obvious synchronization, side effects, reflection, lifecycle dependencies, or external API constraints.
+- Verify behavior with the checks that fit the risk of the change, and make skipped checks explicit.
+
+## Workflow
+
+1. Re-read the skill trigger and the changed files. Check that this review is about code quality, not only formatting or commit-message style.
+2. Build a blank-reader checklist before judging the diff:
+   - What problem or boundary is this change responsible for?
+   - Which files are the main entry points for a future reader?
+   - Which behavior, lifecycle, external API, or data-shape constraints are non-obvious?
+   - Which tests, builds, searches, or manual checks would prove the change is safe?
+3. Review correctness and scope:
+   - Look for behavioral regressions, missed edge cases, null or lifecycle hazards, ordering assumptions, reflection fragility, concurrency assumptions, and error handling gaps.
+   - Check that the implementation follows existing local patterns and does not introduce unrelated refactors.
+   - Check that names describe current responsibilities and do not preserve obsolete design terms.
+4. Review comments and documentation:
+   - Prefer XML documentation on navigable types and members when the intent should be visible from call sites or IDE hover text.
+   - Replace implementation paraphrases with design-intent comments, or remove them when the code is already clear.
+   - Check for mechanical repetition across files. If a repeated shape is intentional table-like documentation, confirm the surrounding text explains why repetition helps.
+   - Do not require comments in every file. Missing comments are a problem only when a first-time reader cannot infer responsibility, boundary, or reason from code and names.
+5. Review tests and verification:
+   - Run the repository checks appropriate to the risk, such as builds, tests, formatters, or targeted manual checks.
+   - Search for duplicated comment templates, obsolete design names, banned wording, and stale references introduced by the change.
+   - Exclude intentional table-like repetition from duplicate-comment findings only when its purpose is documented near the table.
+6. Iterate on findings:
+   - Fix the smallest coherent set of issues, then re-run the relevant checks.
+   - After each revision, re-read the diff as if it were new and confirm the original checklist still passes.
+   - Stop when no new ambiguity, template repetition, scope creep, or verification gap remains, or record the residual risk explicitly.
+7. Report results in review order:
+   - Lead with bugs, regressions, missing tests, or maintainability risks, with file and line references when available.
+   - Then list open questions or assumptions.
+   - Summarize the changes and verification only after the findings.

--- a/.agents/skills/code-quality-check/SKILL.md
+++ b/.agents/skills/code-quality-check/SKILL.md
@@ -1,52 +1,66 @@
 ---
 name: code-quality-check
-description: Review code changes for maintainability, clarity, design intent, comments, tests, and verification before committing or requesting review.
+description: Review code changes for correctness, maintainability, clarity, design intent, tests, documentation, and verification before committing or requesting review.
 ---
 
 # Code Quality Check
 
 ## When to Use
 
-- Use this skill when reviewing source-code changes before committing, pushing, or opening a pull request.
-- Use this skill when adding or revising comments, XML documentation, adapters, boundary types, result types, exception handling, reflection, lifecycle-sensitive code, or other code that future readers must navigate.
+- Use this skill when reviewing source-code changes before committing, pushing, opening a pull request, or replying to review feedback.
+- Use this skill for production code, tests, build glue, generated-code boundaries, adapters, data shapes, result types, exception handling, reflection, concurrency, lifecycle-sensitive code, and other code that future readers must safely change.
 - Use this skill when a review should start from a blank reading of the diff instead of only checking whether the implementation matches the original plan.
+- When a task asks you to both fix code and quality-check it, use the normal implementation workflow for the edit, then apply this skill before and after the fix as the review loop.
+- Do not use this skill as a substitute for repository-specific format, commit-message, issue, or pull-request quality checks. Run those skills separately when they apply.
 
 ## Goals
 
 - Confirm that the change is correct, scoped, and understandable to a first-time reader.
-- Make design boundaries, ownership, data shapes, exceptions, and external constraints visible where they matter.
-- Prefer comments that explain why a boundary, exception, adapter, or data shape exists, not comments that restate what the code already says.
-- Prefer XML documentation for types and members whose design intent should appear in IDE navigation or completion, even when they are not public APIs.
-- Avoid mechanical comment templates. Repeated table-like documentation is acceptable only when the repeated shape is the clearest form, such as attribute lists, key assignments, or input-action tables like `InputUtilsActions`; keep the reason for that shape nearby.
+- Make behavior, ownership, design boundaries, data shapes, failure modes, and external constraints visible where they matter.
+- Keep the implementation aligned with existing local patterns unless the diff clearly justifies a new pattern.
+- Find missing tests, verification gaps, stale names, hidden coupling, and accidental scope creep before review.
+- Prefer comments that explain why a boundary, exception, adapter, synchronization rule, or data shape exists, not comments that restate what the code already says.
+- Prefer XML documentation for types and members whose design intent should appear in IDE navigation or completion, even when they are not public APIs. Prioritize members whose callers need the intent; do not require XML documentation for local implementation details that are clear in place.
+- Avoid mechanical comment templates. Repeated table-like documentation is acceptable only when the repeated shape is the clearest form, such as attribute lists, key assignments, protocol fields, or input-action tables; keep the reason close enough that a reader sees why the repeated shape is intentional before or while reading the table.
 - Keep comments concentrated at entry points: classes, interfaces, adapters, boundary/result types, and non-obvious integration surfaces. Use method-body comments only for non-obvious synchronization, side effects, reflection, lifecycle dependencies, or external API constraints.
 - Verify behavior with the checks that fit the risk of the change, and make skipped checks explicit.
 
 ## Workflow
 
-1. Re-read the skill trigger and the changed files. Check that this review is about code quality, not only formatting or commit-message style.
-2. Build a blank-reader checklist before judging the diff:
+1. Re-read the skill trigger, description, and changed files. Confirm the body of this skill fits the actual task; if the task is only PR text, commit messages, or issue wording, switch to the more specific skill.
+   - For mixed tasks, separate the code-quality review from implementation, commit-message, issue, and pull-request checks. Record which parts were handled by this skill and which parts were delegated to another workflow or skill.
+2. Build a blank-reader checklist before judging the diff. Fix the checklist before editing so later iterations do not move the target:
    - What problem or boundary is this change responsible for?
    - Which files are the main entry points for a future reader?
-   - Which behavior, lifecycle, external API, or data-shape constraints are non-obvious?
+   - Which behavior, lifecycle, external API, data-shape, performance, or compatibility constraints are non-obvious?
+   - Which edge cases, failure modes, or rollback paths could be missed?
    - Which tests, builds, searches, or manual checks would prove the change is safe?
 3. Review correctness and scope:
    - Look for behavioral regressions, missed edge cases, null or lifecycle hazards, ordering assumptions, reflection fragility, concurrency assumptions, and error handling gaps.
    - Check that the implementation follows existing local patterns and does not introduce unrelated refactors.
    - Check that names describe current responsibilities and do not preserve obsolete design terms.
-4. Review comments and documentation:
+   - Check tests for both meaningful assertions and overfitting to implementation details.
+4. Review maintainability and structure:
+   - Check whether responsibilities are placed at the right boundary, such as caller versus callee, adapter versus core, or parser versus model.
+   - Check whether data shapes make invalid states hard to represent, or at least obvious to validate.
+   - Check whether new abstractions remove real complexity instead of hiding a one-off case.
+   - Check whether dependencies, side effects, logging, allocation, and error propagation are proportionate to the risk of the code path.
+5. Review comments and documentation:
    - Prefer XML documentation on navigable types and members when the intent should be visible from call sites or IDE hover text.
    - Replace implementation paraphrases with design-intent comments, or remove them when the code is already clear.
    - Check for mechanical repetition across files. If a repeated shape is intentional table-like documentation, confirm the surrounding text explains why repetition helps.
    - Do not require comments in every file. Missing comments are a problem only when a first-time reader cannot infer responsibility, boundary, or reason from code and names.
-5. Review tests and verification:
-   - Run the repository checks appropriate to the risk, such as builds, tests, formatters, or targeted manual checks.
-   - Search for duplicated comment templates, obsolete design names, banned wording, and stale references introduced by the change.
+6. Review tests and verification:
+   - Run the repository checks appropriate to the risk, such as builds, tests, formatters, or targeted manual checks. Do not invent a universal required command list; choose checks from the repository conventions and the changed behavior.
+   - Search for duplicated comment templates, obsolete design names, stale references, and known project-specific wording that the task or repository guidance forbids.
    - Exclude intentional table-like repetition from duplicate-comment findings only when its purpose is documented near the table.
-6. Iterate on findings:
+7. Iterate on findings:
    - Fix the smallest coherent set of issues, then re-run the relevant checks.
+   - Before each revision, state which checklist item the change is meant to satisfy. This keeps fixes tied to observed gaps instead of general taste.
    - After each revision, re-read the diff as if it were new and confirm the original checklist still passes.
    - Stop when no new ambiguity, template repetition, scope creep, or verification gap remains, or record the residual risk explicitly.
-7. Report results in review order:
-   - Lead with bugs, regressions, missing tests, or maintainability risks, with file and line references when available.
+8. Report results in review order:
+   - Lead with bugs, regressions, missing tests, or maintainability risks, with file and line references when available. Use the repository or review tool's severity style when one exists; otherwise order findings by practical impact without inventing heavy labels.
    - Then list open questions or assumptions.
+   - For recurring ambiguity in the code, task, or review guidance, report `Issue`, `Cause`, and `General Fix Rule` so the finding can become durable guidance instead of a one-off note. If it is not an actionable bug or risk, place it under open questions or assumptions.
    - Summarize the changes and verification only after the findings.

--- a/.agents/skills/code-quality-check/SKILL.md
+++ b/.agents/skills/code-quality-check/SKILL.md
@@ -19,8 +19,10 @@ description: Review code changes for correctness, maintainability, clarity, desi
 - Make behavior, ownership, design boundaries, data shapes, failure modes, and external constraints visible where they matter.
 - Keep the implementation aligned with existing local patterns unless the diff clearly justifies a new pattern.
 - Find missing tests, verification gaps, stale names, hidden coupling, and accidental scope creep before review.
-- Prefer comments that explain why a boundary, exception, adapter, synchronization rule, or data shape exists, not comments that restate what the code already says.
-- Prefer XML documentation for types and members whose design intent should appear in IDE navigation or completion, even when they are not public APIs. Prioritize members whose callers need the intent; do not require XML documentation for local implementation details that are clear in place.
+- Follow standard comment best practices first: prefer clear names, types, and structure, then add comments or documentation where intent, summary, boundary, ordering, external constraints, or safe-change guidance would otherwise be hard to read.
+- Preserve or add concise summary comments when they give readers a useful entry point into responsibility, structure, or non-obvious behavior. Improve or remove only comments that are misleading, stale, mechanically duplicated, or low-value paraphrases of obvious code.
+- Prefer comments that explain why a boundary, exception, adapter, synchronization rule, or data shape exists. Include short what/context summaries when they reduce reading cost; avoid comments that merely restate an obvious operation.
+- Prefer XML documentation for types and members whose design intent should appear in IDE navigation or completion, even when they are not public APIs. Prioritize members whose callers need the intent; do not require XML documentation for local implementation details that are clear in place. In C# XML docs, use or revise `<summary>` when the type or member needs a concise call-site explanation.
 - Avoid mechanical comment templates. Repeated table-like documentation is acceptable only when the repeated shape is the clearest form, such as attribute lists, key assignments, protocol fields, or input-action tables; keep the reason close enough that a reader sees why the repeated shape is intentional before or while reading the table.
 - Keep comments concentrated at entry points: classes, interfaces, adapters, boundary/result types, and non-obvious integration surfaces. Use method-body comments only for non-obvious synchronization, side effects, reflection, lifecycle dependencies, or external API constraints.
 - Verify behavior with the checks that fit the risk of the change, and make skipped checks explicit.
@@ -47,7 +49,10 @@ description: Review code changes for correctness, maintainability, clarity, desi
    - Check whether dependencies, side effects, logging, allocation, and error propagation are proportionate to the risk of the code path.
 5. Review comments and documentation:
    - Prefer XML documentation on navigable types and members when the intent should be visible from call sites or IDE hover text.
-   - Replace implementation paraphrases with design-intent comments, or remove them when the code is already clear.
+   - Preserve concise summaries that orient a reader to responsibility, structure, or non-obvious behavior.
+   - Improve comments that are useful but too focused on low-level what by adding the missing context, intent, or constraint.
+   - Replace or remove comments that are misleading, stale, mechanically duplicated, or only paraphrase obvious implementation details.
+   - Classify comments as `Keep` when they reduce navigation or change risk, `Revise` when the useful idea is present but missing context or current names, and `Remove` when maintenance cost exceeds reading value.
    - Check for mechanical repetition across files. If a repeated shape is intentional table-like documentation, confirm the surrounding text explains why repetition helps.
    - Do not require comments in every file. Missing comments are a problem only when a first-time reader cannot infer responsibility, boundary, or reason from code and names.
 6. Review tests and verification:

--- a/.agents/skills/code-quality-check/SKILL.md
+++ b/.agents/skills/code-quality-check/SKILL.md
@@ -12,6 +12,7 @@ description: Review code changes for correctness, maintainability, clarity, desi
 - Use this skill when a review should start from a blank reading of the diff instead of only checking whether the implementation matches the original plan.
 - When a task asks you to both fix code and quality-check it, use the normal implementation workflow for the edit, then apply this skill before and after the fix as the review loop.
 - Do not use this skill as a substitute for repository-specific format, commit-message, issue, or pull-request quality checks. Run those skills separately when they apply.
+- Treat this as a language-agnostic code quality review skill. Language-specific documentation forms are examples; map them to the target language and repository conventions.
 
 ## Goals
 
@@ -22,10 +23,17 @@ description: Review code changes for correctness, maintainability, clarity, desi
 - Follow standard comment best practices first: prefer clear names, types, and structure, then add comments or documentation where intent, summary, boundary, ordering, external constraints, or safe-change guidance would otherwise be hard to read.
 - Preserve or add concise summary comments when they give readers a useful entry point into responsibility, structure, or non-obvious behavior. Improve or remove only comments that are misleading, stale, mechanically duplicated, or low-value paraphrases of obvious code.
 - Prefer comments that explain why a boundary, exception, adapter, synchronization rule, or data shape exists. Include short what/context summaries when they reduce reading cost; avoid comments that merely restate an obvious operation.
-- Prefer XML documentation for types and members whose design intent should appear in IDE navigation or completion, even when they are not public APIs. Prioritize members whose callers need the intent; do not require XML documentation for local implementation details that are clear in place. In C# XML docs, use or revise `<summary>` when the type or member needs a concise call-site explanation.
+- Prefer the target language's documentation convention for APIs, types, functions, members, modules, or commands whose design intent should appear in IDE navigation, completion, hover text, generated docs, or call-site help. Prioritize surfaces whose callers need the intent; do not require formal documentation for local implementation details that are clear in place.
 - Avoid mechanical comment templates. Repeated table-like documentation is acceptable only when the repeated shape is the clearest form, such as attribute lists, key assignments, protocol fields, or input-action tables; keep the reason close enough that a reader sees why the repeated shape is intentional before or while reading the table.
 - Keep comments concentrated at entry points: classes, interfaces, adapters, boundary/result types, and non-obvious integration surfaces. Use method-body comments only for non-obvious synchronization, side effects, reflection, lifecycle dependencies, or external API constraints.
 - Verify behavior with the checks that fit the risk of the change, and make skipped checks explicit.
+
+## Language-Specific Notes
+
+- Apply the same review principles across languages, then use the documentation form expected by that language and repository.
+- For C#, XML documentation is a common way to surface intent in IDE navigation and generated docs. Use or revise `<summary>` when a type or member needs a concise call-site explanation.
+- For other ecosystems, use their local equivalents, such as JSDoc or TSDoc in TypeScript, docstrings in Python, Javadoc in Java, Rustdoc in Rust, Go doc comments in Go, or the repository's established convention.
+- Do not transfer a language-specific form across languages. For example, do not ask a Python or TypeScript project for C# XML documentation; ask whether the relevant docstring, JSDoc, or local convention communicates the same intent.
 
 ## Workflow
 
@@ -48,7 +56,7 @@ description: Review code changes for correctness, maintainability, clarity, desi
    - Check whether new abstractions remove real complexity instead of hiding a one-off case.
    - Check whether dependencies, side effects, logging, allocation, and error propagation are proportionate to the risk of the code path.
 5. Review comments and documentation:
-   - Prefer XML documentation on navigable types and members when the intent should be visible from call sites or IDE hover text.
+   - Prefer the target language's documentation convention on navigable surfaces when intent should be visible from call sites, generated docs, or IDE help.
    - Preserve concise summaries that orient a reader to responsibility, structure, or non-obvious behavior.
    - Improve comments that are useful but too focused on low-level what by adding the missing context, intent, or constraint.
    - Replace or remove comments that are misleading, stale, mechanically duplicated, or only paraphrase obvious implementation details.


### PR DESCRIPTION
> [!WARNING]
> This pull request was generated with LLMs.

## Summary
- Add a repository-local `code-quality-check` skill for repeatable code quality review.
- Generalize the skill beyond comment design to cover correctness, maintainability, boundaries, tests, documentation, and verification.
- Clarify that comment review follows standard best practices first: prefer clear code, preserve useful summaries, add missing context where intent is hard to read, and improve or remove only misleading, stale, duplicated, or low-value paraphrases.
- Make the documentation guidance language-agnostic, with language-specific forms such as C# XML docs, JSDoc/TSDoc, Python docstrings, Javadoc, Rustdoc, and Go doc comments marked as examples.
- Cover comment-template exceptions, mixed implementation/review tasks, and durable ambiguity reporting.
- Improve the skill through empirical prompt tuning with blank-reader subagent scenarios.

## Verification
- `git diff --check`
- `git diff --cached --check`
- `dotnet build CruiserJumpPractice.sln`
- Empirical prompt tuning scenarios:
  - General code review
  - Comments/XML documentation review
  - Mixed implementation/review task
  - XML documentation/table repetition re-evaluation
  - Recurring ambiguity reporting
  - Comment guidance baseline, re-evaluation, and hold-out scenarios
  - Language-agnostic documentation baseline: TypeScript, Python, and C#
  - Language-agnostic documentation re-evaluation: TypeScript, Python, and C#
  - Language-agnostic documentation hold-out: Go/Rust CLI library
