### PR TITLE
docs(skills): add SPDX notices

### DIFF
--- a/.agents/skills/code-quality-check/SKILL.md
+++ b/.agents/skills/code-quality-check/SKILL.md
@@ -1,4 +1,5 @@
 ---
+# SPDX-License-Identifier: Unlicense
 name: code-quality-check
 description: Language-agnostic code quality review for implementation, SPDX/license notices, and supply-chain-sensitive changes. Use when editing source code, generated code, tests, scripts, configuration-as-code, examples, dependencies, downloaded tools, or CI actions to improve readability, preserve maintainability, decide when design intent should be captured in comments, and apply shared verification discipline.
 ---

--- a/.agents/skills/code-quality-check/agents/openai.yaml
+++ b/.agents/skills/code-quality-check/agents/openai.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Unlicense
 interface:
   display_name: "Code Quality Check"
   short_description: "Review code quality, maintainability, verification, and supply-chain-sensitive changes."

--- a/.agents/skills/code-quality-check/references/spdx-license-notices.md
+++ b/.agents/skills/code-quality-check/references/spdx-license-notices.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Unlicense -->
+
 # SPDX License Notice Decision Guide
 
 ## Purpose

--- a/.agents/skills/code-quality-check/references/spdx-license-notices.md
+++ b/.agents/skills/code-quality-check/references/spdx-license-notices.md
@@ -45,7 +45,7 @@ For files created wholly for this repository, use the repository's existing noti
 nearby files, `LICENSE*`, package metadata, repository docs, templates, generation scripts, and task
 instructions before adding a new header style.
 
-Default to [`MIT`](https://spdx.org/licenses/MIT.html) only when both checks are true:
+Default to [`Unlicense`](https://spdx.org/licenses/Unlicense.html) only when both checks are true:
 
 1. No project-specific instruction overrides it.
 2. The file is not copied, translated, generated from, adapted from, vendored from, or substantially
@@ -108,7 +108,7 @@ for the new file. Cite the source only when it materially helps reviewers unders
 
 ```python
 # SPDX-FileCopyrightText: 2026 Example Maintainer
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Unlicense
 # Design note: behavior cross-checked against Example Tool v2.0 documentation.
 ```
 
@@ -123,7 +123,7 @@ that one license identifier.
 
 ```shell
 # SPDX-FileCopyrightText: 2026 Example Maintainer
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Unlicense
 ```
 
 For a copied file:
@@ -156,8 +156,8 @@ reviewable in a nearby source comment or PR note:
  */
 ```
 
-Do not rewrite `MIT OR Apache-2.0` to `MIT` just because the repository default is MIT unless the
-upstream grant allows that choice and the project intentionally makes it.
+Do not rewrite `MIT OR Apache-2.0` to `Unlicense` just because the repository default is Unlicense
+unless the upstream grant allows that choice and the project intentionally makes it.
 
 ### Mixed Original and Copyleft Code
 
@@ -204,7 +204,7 @@ file.
 Use this when neighboring files use license-only headers and provenance is fully project-local:
 
 ```python
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Unlicense
 ```
 
 ### Recommended Header
@@ -213,7 +213,7 @@ Use this for most new reusable source, scripts, templates, and examples:
 
 ```python
 # SPDX-FileCopyrightText: 2026 Example Maintainer
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Unlicense
 ```
 
 ### Derivative Header
@@ -250,7 +250,7 @@ For generated files, prefer generator metadata when available:
 
 ```typescript
 // SPDX-FileCopyrightText: 2026 Example Maintainer
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Unlicense
 // Generated from schemas/widget.schema.json by scripts/generate-widget-types.ts.
 ```
 
@@ -272,28 +272,28 @@ Do not remove upstream notices:
 ```python
 # Bad: replaced the upstream copyright holder.
 # SPDX-FileCopyrightText: 2026 Example Maintainer
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Unlicense
 ```
 
 Do not change licenses casually:
 
 ```python
 # Bad: file was copied from Apache-2.0 upstream but relicensed without permission.
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Unlicense
 ```
 
 Do not erase dual-license choices without a recorded decision:
 
 ```python
 # Bad: upstream said MIT OR Apache-2.0, but the choice is not documented.
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Unlicense
 ```
 
 Do not label a file as original when it contains adapted copyleft code:
 
 ```python
 # Bad: adapted GPL logic cannot be hidden under a project-default permissive header.
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Unlicense
 ```
 
 ## Decision Flow

--- a/.agents/skills/commit-message-quality-check/agents/openai.yaml
+++ b/.agents/skills/commit-message-quality-check/agents/openai.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Unlicense
 interface:
   display_name: "Commit Message Quality Check"
   short_description: "Quality-check repository commit messages."

--- a/.agents/skills/git-worktree-workflow/agents/openai.yaml
+++ b/.agents/skills/git-worktree-workflow/agents/openai.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Unlicense
 interface:
   display_name: "Git Worktree Workflow"
   short_description: "Use Git worktrees for repository implementation tasks."

--- a/.agents/skills/gitignore-workflow/SKILL.md
+++ b/.agents/skills/gitignore-workflow/SKILL.md
@@ -1,4 +1,5 @@
 ---
+# SPDX-License-Identifier: Unlicense
 name: gitignore-workflow
 description: "Create or update .gitignore files. Use when editing ignore rules."
 ---

--- a/.agents/skills/gitignore-workflow/agents/openai.yaml
+++ b/.agents/skills/gitignore-workflow/agents/openai.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Unlicense
 interface:
   display_name: "Gitignore Workflow"
   short_description: "Create or update .gitignore files."

--- a/.agents/skills/issue-quality-check/agents/openai.yaml
+++ b/.agents/skills/issue-quality-check/agents/openai.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Unlicense
 interface:
   display_name: "Issue Quality Check"
   short_description: "Quality-check repository issues and issue replies."

--- a/.agents/skills/pull-request-quality-check/agents/openai.yaml
+++ b/.agents/skills/pull-request-quality-check/agents/openai.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Unlicense
 interface:
   display_name: "Pull Request Quality Check"
   short_description: "Quality-check repository pull requests."

--- a/.agents/skills/skill-quality-check/SKILL.md
+++ b/.agents/skills/skill-quality-check/SKILL.md
@@ -1,4 +1,5 @@
 ---
+# SPDX-License-Identifier: Unlicense
 name: skill-quality-check
 description: Quality-check Agent Skills for trigger clarity, scope, structure, progressive disclosure, domain separation, validation, and scenario-readiness. Use when creating, updating, reviewing, or splitting Agent Skills, SKILL.md files, skill references, bundled scripts, or skill metadata.
 ---

--- a/.agents/skills/skill-quality-check/agents/openai.yaml
+++ b/.agents/skills/skill-quality-check/agents/openai.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Unlicense
 interface:
   display_name: "Skill Quality Check"
   short_description: "Quality-check Agent Skills."

--- a/.agents/skills/skill-quality-check/references/authoring-best-practices.md
+++ b/.agents/skills/skill-quality-check/references/authoring-best-practices.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Unlicense -->
+
 # Agent Skill Authoring Best Practices
 
 ## Purpose


### PR DESCRIPTION
> [!WARNING]
> This pull request was generated with LLMs.

## Summary
- Add `SPDX-License-Identifier: Unlicense` notices to files introduced by PR #28.
- Preserve Agent Skill frontmatter and YAML structure while adding notices as comments.
- Align the SPDX notice guide's project-local default examples with this repository's Unlicense context.

## Verification
- `git diff --check`
- `git diff --cached --check`
- `dotnet build CruiserJumpPractice.sln`
- Checked that each PR #28 file has an SPDX license identifier.

## Notes
- The changes are split into separate commits for notice additions and SPDX guide default-license alignment.
