### PR TITLE
docs(changelog): add release note workflow

### DIFF
--- a/.agents/skills/changelog-workflow/SKILL.md
+++ b/.agents/skills/changelog-workflow/SKILL.md
@@ -45,6 +45,9 @@ Reference:
      known.
 4. Use Keep a Changelog categories when applicable: `Added`, `Changed`,
    `Deprecated`, `Removed`, `Fixed`, and `Security`.
+   - Put supplemental release metadata that is not itself a change type, such as
+     compatibility notes and test environments, under `Notes` instead of making
+     separate top-level change-category headings.
 5. Keep versioned sections newest first, with headings such as
    `## v1.2.3 - 2026-05-03 UTC`.
 6. Record developer-facing details that help future maintainers, including:

--- a/.agents/skills/changelog-workflow/SKILL.md
+++ b/.agents/skills/changelog-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: Unlicense
 name: changelog-workflow
-description: Create and update this repository's canonical developer changelog and Thunderstore-facing user release notes. Use when preparing release notes, updating stable-release notes, or deriving Thunderstore package changelog text from CHANGELOG.md.
+description: Create and update this repository's canonical developer changelog in CHANGELOG.md. Use when adding developer-facing release history, maintaining Keep a Changelog sections, or preparing canonical version entries.
 ---
 
 # Changelog Workflow
@@ -9,19 +9,20 @@ description: Create and update this repository's canonical developer changelog a
 ## When to Use
 
 - Use this skill when updating `CHANGELOG.md`.
-- Use this skill when preparing or reviewing `assets/CHANGELOG.md` for a
-  Thunderstore package.
-- Use this skill when stable release notes should be derived from developer
-  changelog entries.
+- Use this skill when preparing canonical versioned release history before a
+  release.
+- Use this skill when preserving developer-facing prerelease, compatibility,
+  migration, CI/build/package, or implementation context.
 
 ## Goals
 
 - Keep `CHANGELOG.md` as the canonical Keep a Changelog-style release history.
-- Keep `assets/CHANGELOG.md` stable-release-only, user-facing, and suitable for
-  Thunderstore packaging.
-- Preserve prerelease and maintainer context in the canonical changelog without
-  publishing prerelease-only noise to Thunderstore.
-- Make derivation and release verification reviewable before publishing.
+- Record notable changes for maintainers in a human-readable, newest-first
+  format.
+- Preserve prerelease and internal context in the canonical changelog even when
+  it will not appear in Thunderstore-facing release notes.
+- Keep Thunderstore-specific derivation and release-readiness checks in
+  `release-note-workflow`.
 
 Reference:
 
@@ -29,72 +30,37 @@ Reference:
 
 ## Workflow
 
-1. Update `CHANGELOG.md` first with notable developer-facing release history.
-2. Use Keep a Changelog categories when applicable: `Added`, `Changed`,
+1. Update `CHANGELOG.md` first when a release-history change is needed.
+2. Keep `Unreleased` at the top.
+3. Move `Unreleased` entries into a versioned section only when the maintainer
+   has selected the release version and UTC release date.
+   - Do not create placeholder version headings with `TBD`,
+     `<maintainer-selected date>`, or similar unfinished release metadata.
+     Keep draft material under `Unreleased` until the version and date are
+     known.
+4. Use Keep a Changelog categories when applicable: `Added`, `Changed`,
    `Deprecated`, `Removed`, `Fixed`, and `Security`.
-3. Keep `Unreleased` at the top and move entries into a versioned section with
-   a release date when preparing a release.
-   - Do not finalize a versioned section until the maintainer has selected the
-     stable version and UTC release date.
-4. Decide whether the release is stable:
-   - Stable releases use a version without a prerelease suffix, such as
-     `1.2.3`.
-   - Prerelease versions, such as `1.2.3-alpha.1`, remain developer-facing and
-     are not published to Thunderstore because Thunderstore does not support
-     prerelease package versions for this project.
-5. Roll prerelease entries into the next stable release when they still affect
-   stable users.
-6. Omit prerelease-only details from `assets/CHANGELOG.md` when they were
-   internal, superseded before stable release, or useful only to maintainers.
-7. Keep `assets/CHANGELOG.md` as the cumulative Thunderstore-facing stable
-   release history, with the latest stable release at the top.
-   - Before packaging, the top section must be a stable version heading, not
-     `Unreleased`.
-8. Derive `assets/CHANGELOG.md` from exact stable entries in `CHANGELOG.md` and
-   rewrite the text around user-visible behavior, installation, compatibility,
-   and known limitations.
-   - If the exact canonical changelog section is unavailable, write draft
-     Thunderstore notes and list the missing inputs instead of presenting the
-     output as final.
-9. Preserve user-critical notes in `assets/CHANGELOG.md`, including breaking
-   changes, compatibility changes, installation or update notes, removals,
-   deprecations, security fixes, yanked releases, and known limitations.
-10. Keep test environment details in `CHANGELOG.md`. Include them in
-    `assets/CHANGELOG.md` only when they are needed as user-facing compatibility
-    or support context.
-    - Use maintainer-confirmed compatibility metadata from the canonical
-      changelog, prior release notes, tested game/dependency versions, or
-      explicit maintainer input. Do not invent compatibility claims.
-11. Before release packaging, verify:
-   - `CruiserJumpPractice/CruiserJumpPractice.csproj` contains the intended
-     release version.
-   - The intended stable tag, using this repository's `v<version>` convention
-     from the `generate-version` action, does not already exist locally or
-     remotely. Existing versions are treated as edge builds. If remote tag
-     verification cannot be performed, report it as a release-readiness blocker.
-   - `assets/manifest.json` will receive the same version through the
-     `generate-version` action.
-   - `assets/CHANGELOG.md` contains only Thunderstore-appropriate stable
-     release notes.
-   - `.github/workflows/build.yml` packages `assets/CHANGELOG.md`.
-   - `dotnet build CruiserJumpPractice.sln` succeeds after any related changes.
+5. Keep versioned sections newest first, with headings such as
+   `## v1.2.3 - 2026-05-03 UTC`.
+6. Record developer-facing details that help future maintainers, including:
+   - Internal migrations or architecture changes.
+   - CI, build, packaging, or dependency context.
+   - Prerelease entries and why they matter.
+   - Compatibility notes, test environments, known limitations, yanked
+     releases, and migration constraints.
+7. When prerelease entries are later superseded, keep enough canonical history
+   to explain what changed and what reached the stable release. If the stable
+   release is still only planned, leave the stable roll-up material under
+   `Unreleased` instead of creating an unfinished stable heading.
+8. If the user asks for Thunderstore-facing notes, derive only the canonical
+   source material here, then use `release-note-workflow` for the user-facing
+   rewrite and release-readiness checks.
 
 ## Boundaries
 
-- This skill covers changelog and release-note preparation, not publishing.
-- Do not upload to Thunderstore, create GitHub releases, or tag releases unless
-  the user explicitly asks for those side effects.
+- This skill owns `CHANGELOG.md`; it does not own `assets/CHANGELOG.md`.
+- Do not publish, tag, create GitHub releases, upload to Thunderstore, or edit
+  package metadata unless another workflow and explicit user request call for
+  those side effects.
 - Keep private workspace paths, temporary worktree names, command transcripts,
-  and authentication details out of public changelog or release-note text.
-
-## Review-Only Output
-
-When the user asks for a release-readiness review instead of edits, return:
-
-1. Current state of `CHANGELOG.md`, `assets/CHANGELOG.md`, project version,
-   local and remote tag readiness, manifest version flow, and package workflow
-   inclusion.
-2. Required updates before packaging.
-3. Blockers or missing inputs, especially stable version, UTC release date,
-   exact canonical changelog text, and compatibility metadata.
-4. Confirmation that no publishing side effects were performed.
+  and authentication details out of public changelog text.

--- a/.agents/skills/changelog-workflow/SKILL.md
+++ b/.agents/skills/changelog-workflow/SKILL.md
@@ -22,8 +22,8 @@ description: Create and update a canonical developer changelog. Use when adding 
   format.
 - Preserve prerelease and internal context in the canonical changelog even when
   it will not appear in user-facing release notes.
-- Keep package-registry-specific derivation and release-readiness checks in the
-  dedicated release-note workflow for that package target.
+- Keep user-facing release-note rewriting and release-readiness checks in the
+  dedicated release-note workflow.
 
 Reference:
 
@@ -55,23 +55,23 @@ Reference:
    to explain what changed and what reached the stable release. If the stable
    release is still only planned, leave the stable roll-up material under
    `Unreleased` instead of creating an unfinished stable heading.
-8. If the user asks for package-registry-facing notes, derive only the
-   canonical source material here, then use the appropriate release-note
-   workflow for the user-facing rewrite and release-readiness checks.
+8. If the user asks for user-facing release notes, derive only the canonical
+   source material here, then use the appropriate release-note workflow for the
+   user-facing rewrite and release-readiness checks.
    - Update the canonical changelog only when the source material is missing,
      stale, or needs maintainer-facing correction.
-   - Identify the package-specific release-note workflow by name when it exists;
-     otherwise discover the relevant release-note guidance before producing
-     package-facing notes.
-   - If confirmed version, UTC release date, package target, or release-note
-     workflow are missing, state those as input gaps and stop after canonical
-     source preparation.
+   - Identify the release-note workflow by name when it exists; otherwise
+     discover the relevant release-note guidance before producing user-facing
+     notes.
+   - If confirmed version, UTC release date, target audience, publication
+     channel, or release-note workflow are missing, state those as input gaps
+     and stop after canonical source preparation.
 
 ## Boundaries
 
 - This skill owns the canonical developer changelog; it does not own generated
-  or package-registry-facing release-note files.
-- Do not publish, tag, create releases, upload packages, or edit package
+  or user-facing release-note files.
+- Do not publish, tag, create releases, upload artifacts, or edit release
   metadata unless another workflow and explicit user request call for those
   side effects.
 - Keep private workspace paths, temporary worktree names, command transcripts,

--- a/.agents/skills/changelog-workflow/SKILL.md
+++ b/.agents/skills/changelog-workflow/SKILL.md
@@ -23,6 +23,10 @@ description: Create and update this repository's canonical developer changelog a
   publishing prerelease-only noise to Thunderstore.
 - Make derivation and release verification reviewable before publishing.
 
+Reference:
+
+- Keep a Changelog 1.1.0: http://keepachangelog.com/en/1.1.0/
+
 ## Workflow
 
 1. Update `CHANGELOG.md` first with notable developer-facing release history.
@@ -30,6 +34,8 @@ description: Create and update this repository's canonical developer changelog a
    `Deprecated`, `Removed`, `Fixed`, and `Security`.
 3. Keep `Unreleased` at the top and move entries into a versioned section with
    a release date when preparing a release.
+   - Do not finalize a versioned section until the maintainer has selected the
+     stable version and UTC release date.
 4. Decide whether the release is stable:
    - Stable releases use a version without a prerelease suffix, such as
      `1.2.3`.
@@ -40,15 +46,32 @@ description: Create and update this repository's canonical developer changelog a
    stable users.
 6. Omit prerelease-only details from `assets/CHANGELOG.md` when they were
    internal, superseded before stable release, or useful only to maintainers.
-7. Derive `assets/CHANGELOG.md` from stable entries in `CHANGELOG.md` and
+7. Keep `assets/CHANGELOG.md` as the cumulative Thunderstore-facing stable
+   release history, with the latest stable release at the top.
+   - Before packaging, the top section must be a stable version heading, not
+     `Unreleased`.
+8. Derive `assets/CHANGELOG.md` from exact stable entries in `CHANGELOG.md` and
    rewrite the text around user-visible behavior, installation, compatibility,
    and known limitations.
-8. Preserve user-critical notes in `assets/CHANGELOG.md`, including breaking
+   - If the exact canonical changelog section is unavailable, write draft
+     Thunderstore notes and list the missing inputs instead of presenting the
+     output as final.
+9. Preserve user-critical notes in `assets/CHANGELOG.md`, including breaking
    changes, compatibility changes, installation or update notes, removals,
    deprecations, security fixes, yanked releases, and known limitations.
-9. Before release packaging, verify:
+10. Keep test environment details in `CHANGELOG.md`. Include them in
+    `assets/CHANGELOG.md` only when they are needed as user-facing compatibility
+    or support context.
+    - Use maintainer-confirmed compatibility metadata from the canonical
+      changelog, prior release notes, tested game/dependency versions, or
+      explicit maintainer input. Do not invent compatibility claims.
+11. Before release packaging, verify:
    - `CruiserJumpPractice/CruiserJumpPractice.csproj` contains the intended
      release version.
+   - The intended stable tag, using this repository's `v<version>` convention
+     from the `generate-version` action, does not already exist locally or
+     remotely. Existing versions are treated as edge builds. If remote tag
+     verification cannot be performed, report it as a release-readiness blocker.
    - `assets/manifest.json` will receive the same version through the
      `generate-version` action.
    - `assets/CHANGELOG.md` contains only Thunderstore-appropriate stable
@@ -63,3 +86,15 @@ description: Create and update this repository's canonical developer changelog a
   the user explicitly asks for those side effects.
 - Keep private workspace paths, temporary worktree names, command transcripts,
   and authentication details out of public changelog or release-note text.
+
+## Review-Only Output
+
+When the user asks for a release-readiness review instead of edits, return:
+
+1. Current state of `CHANGELOG.md`, `assets/CHANGELOG.md`, project version,
+   local and remote tag readiness, manifest version flow, and package workflow
+   inclusion.
+2. Required updates before packaging.
+3. Blockers or missing inputs, especially stable version, UTC release date,
+   exact canonical changelog text, and compatibility metadata.
+4. Confirmation that no publishing side effects were performed.

--- a/.agents/skills/changelog-workflow/SKILL.md
+++ b/.agents/skills/changelog-workflow/SKILL.md
@@ -1,0 +1,65 @@
+---
+# SPDX-License-Identifier: Unlicense
+name: changelog-workflow
+description: Create and update this repository's canonical developer changelog and Thunderstore-facing user release notes. Use when preparing release notes, updating stable-release notes, or deriving Thunderstore package changelog text from CHANGELOG.md.
+---
+
+# Changelog Workflow
+
+## When to Use
+
+- Use this skill when updating `CHANGELOG.md`.
+- Use this skill when preparing or reviewing `assets/CHANGELOG.md` for a
+  Thunderstore package.
+- Use this skill when stable release notes should be derived from developer
+  changelog entries.
+
+## Goals
+
+- Keep `CHANGELOG.md` as the canonical Keep a Changelog-style release history.
+- Keep `assets/CHANGELOG.md` stable-release-only, user-facing, and suitable for
+  Thunderstore packaging.
+- Preserve prerelease and maintainer context in the canonical changelog without
+  publishing prerelease-only noise to Thunderstore.
+- Make derivation and release verification reviewable before publishing.
+
+## Workflow
+
+1. Update `CHANGELOG.md` first with notable developer-facing release history.
+2. Use Keep a Changelog categories when applicable: `Added`, `Changed`,
+   `Deprecated`, `Removed`, `Fixed`, and `Security`.
+3. Keep `Unreleased` at the top and move entries into a versioned section with
+   a release date when preparing a release.
+4. Decide whether the release is stable:
+   - Stable releases use a version without a prerelease suffix, such as
+     `1.2.3`.
+   - Prerelease versions, such as `1.2.3-alpha.1`, remain developer-facing and
+     are not published to Thunderstore because Thunderstore does not support
+     prerelease package versions for this project.
+5. Roll prerelease entries into the next stable release when they still affect
+   stable users.
+6. Omit prerelease-only details from `assets/CHANGELOG.md` when they were
+   internal, superseded before stable release, or useful only to maintainers.
+7. Derive `assets/CHANGELOG.md` from stable entries in `CHANGELOG.md` and
+   rewrite the text around user-visible behavior, installation, compatibility,
+   and known limitations.
+8. Preserve user-critical notes in `assets/CHANGELOG.md`, including breaking
+   changes, compatibility changes, installation or update notes, removals,
+   deprecations, security fixes, yanked releases, and known limitations.
+9. Before release packaging, verify:
+   - `CruiserJumpPractice/CruiserJumpPractice.csproj` contains the intended
+     release version.
+   - `assets/manifest.json` will receive the same version through the
+     `generate-version` action.
+   - `assets/CHANGELOG.md` contains only Thunderstore-appropriate stable
+     release notes.
+   - `.github/workflows/build.yml` packages `assets/CHANGELOG.md`.
+   - `dotnet build CruiserJumpPractice.sln` succeeds after any related changes.
+
+## Boundaries
+
+- This skill covers changelog and release-note preparation, not publishing.
+- Do not upload to Thunderstore, create GitHub releases, or tag releases unless
+  the user explicitly asks for those side effects.
+- Keep private workspace paths, temporary worktree names, command transcripts,
+  and authentication details out of public changelog or release-note text.

--- a/.agents/skills/changelog-workflow/SKILL.md
+++ b/.agents/skills/changelog-workflow/SKILL.md
@@ -51,15 +51,21 @@ Reference:
    - Prerelease entries and why they matter.
    - Compatibility notes, test environments, known limitations, yanked
      releases, and migration constraints.
+   - Record compatibility, support, environment, and migration claims only when
+     they are maintainer-confirmed or clearly sourced. Otherwise list them as
+     missing inputs or draft source material needing confirmation, not as final
+     compatibility facts.
 7. When prerelease entries are later superseded, keep enough canonical history
    to explain what changed and what reached the stable release. If the stable
    release is still only planned, leave the stable roll-up material under
    `Unreleased` instead of creating an unfinished stable heading.
-8. If the user asks for user-facing release notes, derive only the canonical
-   source material here, then use the appropriate release-note workflow for the
-   user-facing rewrite and release-readiness checks.
+8. If the user asks for user-facing release notes, verify or prepare only the
+   canonical source material here, then use the appropriate release-note
+   workflow for the user-facing rewrite and release-readiness checks.
    - Update the canonical changelog only when the source material is missing,
      stale, or needs maintainer-facing correction.
+   - If the canonical changelog already contains enough source material, stop
+     there and hand off user-facing rewriting and readiness checks.
    - Identify the release-note workflow by name when it exists; otherwise
      discover the relevant release-note guidance before producing user-facing
      notes.

--- a/.agents/skills/changelog-workflow/SKILL.md
+++ b/.agents/skills/changelog-workflow/SKILL.md
@@ -1,14 +1,14 @@
 ---
 # SPDX-License-Identifier: Unlicense
 name: changelog-workflow
-description: Create and update this repository's canonical developer changelog in CHANGELOG.md. Use when adding developer-facing release history, maintaining Keep a Changelog sections, or preparing canonical version entries.
+description: Create and update a canonical developer changelog. Use when adding developer-facing release history, maintaining Keep a Changelog sections, or preparing canonical version entries.
 ---
 
 # Changelog Workflow
 
 ## When to Use
 
-- Use this skill when updating `CHANGELOG.md`.
+- Use this skill when updating the canonical developer changelog.
 - Use this skill when preparing canonical versioned release history before a
   release.
 - Use this skill when preserving developer-facing prerelease, compatibility,
@@ -16,13 +16,14 @@ description: Create and update this repository's canonical developer changelog i
 
 ## Goals
 
-- Keep `CHANGELOG.md` as the canonical Keep a Changelog-style release history.
+- Keep the confirmed canonical changelog, often `CHANGELOG.md`, as the
+  Keep a Changelog-style release history.
 - Record notable changes for maintainers in a human-readable, newest-first
   format.
 - Preserve prerelease and internal context in the canonical changelog even when
-  it will not appear in Thunderstore-facing release notes.
-- Keep Thunderstore-specific derivation and release-readiness checks in
-  `release-note-workflow`.
+  it will not appear in user-facing release notes.
+- Keep package-registry-specific derivation and release-readiness checks in the
+  dedicated release-note workflow for that package target.
 
 Reference:
 
@@ -30,7 +31,9 @@ Reference:
 
 ## Workflow
 
-1. Update `CHANGELOG.md` first when a release-history change is needed.
+1. Update the canonical changelog first when a release-history change is
+   needed. If the file is not clearly `CHANGELOG.md`, locate or confirm the
+   canonical changelog before editing.
 2. Keep `Unreleased` at the top.
 3. Move `Unreleased` entries into a versioned section only when the maintainer
    has selected the release version and UTC release date.
@@ -52,15 +55,24 @@ Reference:
    to explain what changed and what reached the stable release. If the stable
    release is still only planned, leave the stable roll-up material under
    `Unreleased` instead of creating an unfinished stable heading.
-8. If the user asks for Thunderstore-facing notes, derive only the canonical
-   source material here, then use `release-note-workflow` for the user-facing
-   rewrite and release-readiness checks.
+8. If the user asks for package-registry-facing notes, derive only the
+   canonical source material here, then use the appropriate release-note
+   workflow for the user-facing rewrite and release-readiness checks.
+   - Update the canonical changelog only when the source material is missing,
+     stale, or needs maintainer-facing correction.
+   - Identify the package-specific release-note workflow by name when it exists;
+     otherwise discover the relevant release-note guidance before producing
+     package-facing notes.
+   - If confirmed version, UTC release date, package target, or release-note
+     workflow are missing, state those as input gaps and stop after canonical
+     source preparation.
 
 ## Boundaries
 
-- This skill owns `CHANGELOG.md`; it does not own `assets/CHANGELOG.md`.
-- Do not publish, tag, create GitHub releases, upload to Thunderstore, or edit
-  package metadata unless another workflow and explicit user request call for
-  those side effects.
+- This skill owns the canonical developer changelog; it does not own generated
+  or package-registry-facing release-note files.
+- Do not publish, tag, create releases, upload packages, or edit package
+  metadata unless another workflow and explicit user request call for those
+  side effects.
 - Keep private workspace paths, temporary worktree names, command transcripts,
   and authentication details out of public changelog text.

--- a/.agents/skills/changelog-workflow/SKILL.md
+++ b/.agents/skills/changelog-workflow/SKILL.md
@@ -22,6 +22,8 @@ description: Create and update a canonical developer changelog. Use when adding 
   format.
 - Preserve prerelease and internal context in the canonical changelog even when
   it will not appear in user-facing release notes.
+- Preserve enough rationale and history for user-facing release notes to explain
+  why each user-visible change matters.
 - Keep user-facing release-note rewriting and release-readiness checks in the
   dedicated release-note workflow.
 
@@ -49,6 +51,14 @@ Reference:
    - Internal migrations or architecture changes.
    - CI, build, packaging, or dependency context.
    - Prerelease entries and why they matter.
+   - User-impact rationale or history for each user-visible change, such as
+     the problem it solves, why behavior changed, compatibility constraints, or
+     migration reason.
+   - A sourced user impact statement may be enough when it explains why users
+     should care. Generic bullets such as documentation updates, dependency
+     updates, crash fixes, or save-format changes still need source material
+     describing the user-facing benefit, risk, security impact, compatibility
+     impact, or migration reason.
    - Compatibility notes, test environments, known limitations, yanked
      releases, and migration constraints.
    - Record compatibility, support, environment, and migration claims only when
@@ -64,6 +74,8 @@ Reference:
    workflow for the user-facing rewrite and release-readiness checks.
    - Update the canonical changelog only when the source material is missing,
      stale, or needs maintainer-facing correction.
+   - Treat missing rationale or history for a user-visible change as missing
+     canonical source material; add or request it before user-facing rewriting.
    - If the canonical changelog already contains enough source material, stop
      there and hand off user-facing rewriting and readiness checks.
    - Identify the release-note workflow by name when it exists; otherwise

--- a/.agents/skills/changelog-workflow/agents/openai.yaml
+++ b/.agents/skills/changelog-workflow/agents/openai.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Unlicense
+interface:
+  display_name: "Changelog Workflow"
+  short_description: "Update canonical changelog entries and Thunderstore-facing release notes."
+  default_prompt: "Update CHANGELOG.md first, then derive or review stable-release Thunderstore notes in assets/CHANGELOG.md with version and packaging verification."

--- a/.agents/skills/changelog-workflow/agents/openai.yaml
+++ b/.agents/skills/changelog-workflow/agents/openai.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Unlicense
 interface:
   display_name: "Changelog Workflow"
-  short_description: "Update canonical changelog entries and Thunderstore-facing release notes."
-  default_prompt: "Update CHANGELOG.md first, then derive or review stable-release Thunderstore notes in assets/CHANGELOG.md with version and packaging verification."
+  short_description: "Update the canonical developer changelog in CHANGELOG.md."
+  default_prompt: "Update CHANGELOG.md as the canonical Keep a Changelog-style release history, preserving developer-facing version, prerelease, compatibility, and maintainer context."

--- a/.agents/skills/changelog-workflow/agents/openai.yaml
+++ b/.agents/skills/changelog-workflow/agents/openai.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Unlicense
 interface:
   display_name: "Changelog Workflow"
-  short_description: "Update the canonical developer changelog in CHANGELOG.md."
-  default_prompt: "Update CHANGELOG.md as the canonical Keep a Changelog-style release history, preserving developer-facing version, prerelease, compatibility, and maintainer context."
+  short_description: "Update a canonical developer changelog."
+  default_prompt: "Update the canonical Keep a Changelog-style release history, preserving developer-facing version, prerelease, compatibility, and maintainer context."

--- a/.agents/skills/git-worktree-workflow/SKILL.md
+++ b/.agents/skills/git-worktree-workflow/SKILL.md
@@ -1,4 +1,5 @@
 ---
+# SPDX-License-Identifier: Unlicense
 name: git-worktree-workflow
 description: Use Git worktrees for repository implementation tasks unless explicitly told not to.
 ---

--- a/.agents/skills/git-worktree-workflow/SKILL.md
+++ b/.agents/skills/git-worktree-workflow/SKILL.md
@@ -34,7 +34,7 @@ Create implementation worktrees under:
 Use a short, descriptive branch and directory name, such as:
 
 ```text
-.agents/worktrees/fix-cruiser-state-load
+.agents/worktrees/fix-state-load
 ```
 
 Start from the latest base branch unless the user names a different base. The usual base is `main`:
@@ -55,13 +55,10 @@ If network access or Git metadata writes require approval, request it and contin
 
 ## Quality Check
 
-A quality check means formatting and verification appropriate to the change risk and repository conventions.
-
-For this repository, useful verification often includes:
-
-```powershell
-dotnet build CruiserJumpPractice.sln
-```
+A quality check means formatting and verification appropriate to the change
+risk and repository conventions. Prefer documented project commands such as
+builds, tests, linters, formatters, or structural validators that cover the
+files changed.
 
 If verification is skipped, state why in the pull request body.
 

--- a/.agents/skills/issue-quality-check/SKILL.md
+++ b/.agents/skills/issue-quality-check/SKILL.md
@@ -1,4 +1,5 @@
 ---
+# SPDX-License-Identifier: Unlicense
 name: issue-quality-check
 description: Quality-check repository issues and issue replies. Use when creating or updating GitHub issues or comments on issues.
 ---

--- a/.agents/skills/issue-quality-check/SKILL.md
+++ b/.agents/skills/issue-quality-check/SKILL.md
@@ -112,7 +112,8 @@ For issue replies:
 - Quote only the smallest useful part of a previous comment.
 - Mention paths, commands, classes, and config keys in backticks.
 - Be clear whether something is confirmed, inferred, untested, or still unknown.
-- Ask for specific missing information when needed, such as logs, mod versions, reproduction steps, or save data details.
+- Ask for specific missing information when needed, such as logs, package or
+  application versions, reproduction steps, or relevant data files.
 - Avoid large diffs, large logs, and unrelated implementation plans.
 - Do not promise timelines unless they are already agreed.
 

--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -7,7 +7,8 @@ description: Quality-check repository pull requests. Use when creating or updati
 
 ## When to Use
 
-- Use this skill when creating, updating, reviewing, or validating pull request titles or bodies for this repository.
+- Use this skill when creating, updating, reviewing, or validating pull request
+  titles or bodies.
 
 ## Title
 
@@ -50,7 +51,8 @@ Check that the body is concise and uses these sections when applicable:
 Recommend sections only when they carry useful information:
 
 - `Summary`: user-facing or maintainer-facing changes, grouped by behavior or area.
-- `Verification`: commands run and their results, such as `dotnet build CruiserJumpPractice.sln`.
+- `Verification`: commands run and their results, such as project builds,
+  tests, linters, formatters, or structural validators.
 - `Notes`: limitations, skipped checks, migration notes, or reviewer attention points.
 - `Breaking Changes`: required when the title or commits include `!` or `BREAKING CHANGE`.
 

--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -1,4 +1,5 @@
 ---
+# SPDX-License-Identifier: Unlicense
 name: pull-request-quality-check
 description: Quality-check repository pull requests. Use when creating or updating pull requests.
 ---

--- a/.agents/skills/release-note-workflow/SKILL.md
+++ b/.agents/skills/release-note-workflow/SKILL.md
@@ -1,112 +1,145 @@
 ---
 # SPDX-License-Identifier: Unlicense
 name: release-note-workflow
-description: Create, update, or review Thunderstore-facing release notes. Use when deriving user-facing stable release notes from a canonical changelog or checking release-note readiness before packaging.
+description: Create, update, or review user-facing release notes. Use when deriving stable release notes from a canonical changelog or checking release-note readiness before publication.
 ---
 
 # Release Note Workflow
 
 ## When to Use
 
-- Use this skill when preparing or reviewing Thunderstore package release notes.
+- Use this skill when preparing or reviewing user-facing release notes.
 - Use this skill when deriving stable release notes from canonical
   changelog entries.
-- Use this skill when checking release-note readiness before packaging.
+- Use this skill when checking release-note readiness before publication.
 
 ## Goals
 
-- Keep the Thunderstore-facing release-note file as the cumulative stable
-  release history, with the latest stable release at the top.
+- Keep the user-facing release-note file as the cumulative stable release
+  history, with the latest stable release at the top.
 - Derive release notes from the canonical developer changelog instead of making
   a second source of truth.
 - Rewrite stable release notes for users, focusing on behavior, installation,
   compatibility, update impact, known limitations, and security.
-- Make version, tag, manifest, and packaging readiness explicit before release.
+- Make version, source material, publication-channel requirements, and release
+  readiness explicit before publication.
 
 ## Workflow
 
-1. Locate the canonical developer changelog, Thunderstore-facing release-note
-   file, package metadata, manifest source or output path, packaging workflow,
-   and verification command from repository evidence such as docs, configs,
-   scripts, or workflow files. Report anything undiscoverable as a missing input
-   or blocker.
+1. Locate the canonical developer changelog, user-facing release-note file,
+   release version source, publication channel, release workflow, and
+   verification command from repository evidence such as docs, configs, scripts,
+   or workflow files. Report anything undiscoverable as a missing input or
+   blocker.
+   - Prefer evidence in this order: explicit maintainer input, release or
+     publication docs, existing release-note history, workflow or config
+     behavior, then scripts or source metadata.
+   - When multiple candidate version sources, publication channels, tag
+     conventions, or workflows conflict, report all candidates and treat the
+     conflict as a blocker unless repository docs establish precedence.
 2. Read the exact stable release section in the canonical developer changelog.
-   - If the exact canonical section is unavailable, write draft Thunderstore
-     notes and list the missing inputs instead of presenting the output as
-     final.
+   - If the exact canonical section is unavailable, write draft release notes
+     and list the missing inputs instead of presenting the output as final.
    - If the UTC release date is missing, keep the output clearly marked as
-     draft review text. Do not create a package-ready heading with `TBD`,
+     draft review text. Do not create a release-ready heading with `TBD`,
      `<date>`, or similar placeholder release metadata.
 3. Confirm the release is stable:
    - Stable releases use a version without a prerelease suffix, such as
      `1.2.3`.
    - Prerelease versions, such as `1.2.3-alpha.1`, remain developer-facing and
-     are not published to Thunderstore unless the package target explicitly
-     supports prerelease versions.
-   - Accept prerelease support only from maintained package-target policy,
-     package documentation, explicit maintainer input, or existing package
+     are not published as stable user-facing notes unless the publication
+     channel explicitly supports prerelease notes.
+   - Accept prerelease support only from maintained publication-channel policy,
+     release documentation, explicit maintainer input, or existing release-note
      history.
 4. Roll prerelease entries into the next stable release when they still affect
    stable users.
-5. Omit prerelease-only details from the Thunderstore-facing release notes when
+5. Omit prerelease-only details from the user-facing release notes when
    they were internal, superseded before stable release, or useful only to
    maintainers.
 6. Rewrite the stable entries around user-visible behavior, installation,
    compatibility, update impact, security, and known limitations.
-7. Preserve user-critical notes in the Thunderstore-facing release notes,
+7. Preserve user-critical notes in the user-facing release notes,
    including breaking changes, compatibility changes, installation or update
    notes, removals, deprecations, security fixes, yanked releases, and known
    limitations.
 8. Keep test environment details in the canonical developer changelog. Include
-   them in Thunderstore-facing release notes only when they are needed as
+   them in user-facing release notes only when they are needed as
    user-facing compatibility or support context.
    - Use maintainer-confirmed compatibility metadata from the canonical
-     changelog, prior release notes, tested game/dependency versions, or
+     changelog, prior release notes, tested product/dependency versions, or
      explicit maintainer input. Do not invent compatibility claims.
-9. Before packaging, verify:
-   - The Thunderstore-facing release-note file has a stable version heading at
+9. Before publication, verify:
+   - The user-facing release-note file has a stable version heading at
      the top, not `Unreleased`, and does not contain placeholder release
      metadata such as `TBD`.
-   - Project package metadata contains the intended release version.
-   - The intended package or manifest version is not already present in a way
-     that would collide with the planned stable release.
+   - The release version source contains the intended stable version.
+   - The intended release version is not already present in a way that would
+     collide with the planned stable release.
    - The intended stable tag, using the repository's documented tag convention,
      does not already exist locally or remotely. Existing versions or tags are
-     blockers for stable packaging until the maintainer chooses a new version or
-     a documented edge-release path. If remote tag verification cannot be
+     blockers for stable publication until the maintainer chooses a new version
+     or a documented edge-release path. If remote tag verification cannot be
      performed, report it as a release-readiness blocker.
-   - The Thunderstore manifest will receive the same version as the package
-     metadata.
-   - The packaging workflow includes the Thunderstore-facing release-note file.
-   - The repository's documented build or packaging verification succeeds after
-     any related changes.
+   - The release workflow will publish or include the user-facing release-note
+     file in the intended destination.
+   - Manual publication is allowed, but report it as a manual workflow state
+     and required maintainer action unless docs confirm automated inclusion.
+   - Undocumented publication or a missing user-facing release-note destination
+     is a blocker until docs or maintainer input confirm where release notes are
+     published and how they are included.
+   - The repository's documented build, release-note, or publication
+     verification succeeds after any related changes.
 
 ## Review-Only Output
 
 When the user asks for a release-readiness review instead of edits, do not edit
 files. Return:
 
-1. Current state of the Thunderstore-facing release-note file, source changelog
-   section, project version, local and remote tag readiness, manifest version
-   flow, and package workflow inclusion.
-2. Required updates before packaging.
+1. Current state of the user-facing release-note file, source changelog section,
+   release version, local and remote tag readiness, publication-channel
+   requirements, and release workflow inclusion.
+2. Required updates before publication.
 3. Blockers or missing inputs, especially stable version, UTC release date,
    exact canonical changelog text, and compatibility metadata.
 4. Confirmation that no publishing side effects were performed.
 
+For hypothetical readiness reviews, use explicit scenario facts or
+maintainer-provided facts as the highest-priority evidence, even when they
+conflict with the current checkout.
+
+For readiness reviews, include a compact status matrix covering:
+
+- Source changelog section.
+- User-facing release-note destination.
+- Version source and discovered version.
+- Tag convention, intended tag, local tag state, and remote tag state.
+- Publication channel and required release-note format.
+- Release workflow inclusion.
+- Verification command and result, or the missing verification input.
+
+Classify review items as:
+
+- `Blocker`: prevents release-ready notes or publication readiness.
+- `Required update`: must be changed before publication but has a clear owner
+  and path.
+- `Required maintainer action`: needs maintainer confirmation or manual action.
+- `Informational`: useful context that does not block readiness.
+
 ## Output Shape
 
-- Package-ready stable notes use the package target's required heading format
-  with a confirmed stable version and UTC release date.
+- Release-ready stable notes use the publication channel's required heading
+  format with a confirmed stable version and UTC release date.
 - Draft notes are clearly labeled as draft review text and list missing inputs
   before any proposed user-facing wording.
 - Blockers name the missing or failed readiness item directly, such as stable
-  metadata, tag convention, local or remote tag availability, manifest version
-  flow, packaging inclusion, or verification command.
+  metadata, user-facing release-note destination, tag convention, local or
+  remote tag availability, publication channel, release workflow inclusion, or
+  verification command.
 
 ## Boundaries
 
-- This skill owns Thunderstore-facing release notes and release-note readiness,
+- This skill owns user-facing release notes and release-note readiness,
   not canonical developer changelog authoring.
 - Use `changelog-workflow` first when the canonical developer changelog itself
   needs new entries or version-section changes.
@@ -114,7 +147,7 @@ files. Return:
   publishing, release creation, or tag creation. Use a dedicated publishing or
   release workflow for those side effects.
 - Treat missing stable metadata, missing tag convention, failed local or remote
-  tag verification, and missing prerelease-support evidence as release-readiness
-  blockers.
+  tag verification, missing publication-channel requirements, and missing
+  prerelease-support evidence as release-readiness blockers.
 - Keep private workspace paths, temporary worktree names, command transcripts,
   and authentication details out of public release-note text.

--- a/.agents/skills/release-note-workflow/SKILL.md
+++ b/.agents/skills/release-note-workflow/SKILL.md
@@ -37,6 +37,17 @@ description: Create, update, or review user-facing release notes. Use when deriv
    - When multiple candidate version sources, publication channels, tag
      conventions, or workflows conflict, report all candidates and treat the
      conflict as a blocker unless repository docs establish precedence.
+   - Separate the discovered publication channel from the channel's release-note
+     format requirements. If the channel is known but its required format is
+     not, report the missing format as a blocker or required maintainer action.
+     Do not infer format requirements from the channel name alone; use
+     maintained docs, existing release-note history, workflow/config behavior,
+     or maintainer input.
+   - Use read-only evidence gathering for readiness reviews. Useful examples
+     include reading version metadata, listing local tags with `git tag --list`,
+     checking remote tags with `git ls-remote --tags <remote>`, inspecting
+     workflow or release scripts for release-note inclusion, and reading docs
+     for verification commands.
 2. Read the exact stable release section in the canonical developer changelog.
    - If the exact canonical section is unavailable, write draft release notes
      and list the missing inputs instead of presenting the output as final.
@@ -49,6 +60,8 @@ description: Create, update, or review user-facing release notes. Use when deriv
    - Prerelease versions, such as `1.2.3-alpha.1`, remain developer-facing and
      are not published as stable user-facing notes unless the publication
      channel explicitly supports prerelease notes.
+   - Do not infer an intended stable version from a prerelease version without
+     maintainer confirmation.
    - Accept prerelease support only from maintained publication-channel policy,
      release documentation, explicit maintainer input, or existing release-note
      history.

--- a/.agents/skills/release-note-workflow/SKILL.md
+++ b/.agents/skills/release-note-workflow/SKILL.md
@@ -104,6 +104,10 @@ description: Create, update, or review user-facing release notes. Use when deriv
    - Use maintainer-confirmed compatibility metadata from the canonical
      changelog, prior release notes, tested product/dependency versions, or
      explicit maintainer input. Do not invent compatibility claims.
+   - Place user-facing supplemental metadata under a `Notes` section, with
+     labeled bullets such as `Compatibility:` or `Known limitations:`, instead
+     of creating standalone headings for metadata that is not a Keep a
+     Changelog change category.
 10. Before publication, verify:
    - The user-facing release-note file has a stable version heading at
      the top, not `Unreleased`, and does not contain placeholder release
@@ -165,6 +169,11 @@ Classify review items as:
 
 - Release-ready stable notes use the publication channel's required heading
   format with a confirmed stable version and UTC release date.
+- User-facing supplemental metadata that is not itself a change type, such as
+  compatibility notes or known limitations, appears under `Notes` with labeled
+  bullets. Do not use standalone `Compatibility`, `Test Environment`, or
+  similar metadata headings unless the publication channel explicitly requires
+  them.
 - Each user-visible change includes one concise reason or background sentence,
   sourced from the canonical changelog or maintainer input.
   This applies to the target release; untouched historical entries in a

--- a/.agents/skills/release-note-workflow/SKILL.md
+++ b/.agents/skills/release-note-workflow/SKILL.md
@@ -1,0 +1,93 @@
+---
+# SPDX-License-Identifier: Unlicense
+name: release-note-workflow
+description: Create, update, or review this repository's Thunderstore-facing release notes in assets/CHANGELOG.md. Use when deriving user-facing stable release notes from CHANGELOG.md or checking release-note readiness before packaging.
+---
+
+# Release Note Workflow
+
+## When to Use
+
+- Use this skill when preparing or reviewing `assets/CHANGELOG.md` for a
+  Thunderstore package.
+- Use this skill when deriving stable release notes from canonical
+  `CHANGELOG.md` entries.
+- Use this skill when checking release-note readiness before packaging.
+
+## Goals
+
+- Keep `assets/CHANGELOG.md` as the cumulative Thunderstore-facing stable
+  release history, with the latest stable release at the top.
+- Derive release notes from `CHANGELOG.md` instead of making a second source of
+  truth.
+- Rewrite stable release notes for users, focusing on behavior, installation,
+  compatibility, update impact, known limitations, and security.
+- Make version, tag, manifest, and packaging readiness explicit before release.
+
+## Workflow
+
+1. Read the exact stable release section in `CHANGELOG.md`.
+   - If the exact canonical section is unavailable, write draft Thunderstore
+     notes and list the missing inputs instead of presenting the output as
+     final.
+   - If the UTC release date is missing, keep the output clearly marked as
+     draft review text. Do not create a package-ready heading with `TBD`,
+     `<date>`, or similar placeholder release metadata.
+2. Confirm the release is stable:
+   - Stable releases use a version without a prerelease suffix, such as
+     `1.2.3`.
+   - Prerelease versions, such as `1.2.3-alpha.1`, remain developer-facing and
+     are not published to Thunderstore because Thunderstore does not support
+     prerelease package versions for this project.
+3. Roll prerelease entries into the next stable release when they still affect
+   stable users.
+4. Omit prerelease-only details from `assets/CHANGELOG.md` when they were
+   internal, superseded before stable release, or useful only to maintainers.
+5. Rewrite the stable entries around user-visible behavior, installation,
+   compatibility, update impact, security, and known limitations.
+6. Preserve user-critical notes in `assets/CHANGELOG.md`, including breaking
+   changes, compatibility changes, installation or update notes, removals,
+   deprecations, security fixes, yanked releases, and known limitations.
+7. Keep test environment details in `CHANGELOG.md`. Include them in
+   `assets/CHANGELOG.md` only when they are needed as user-facing compatibility
+   or support context.
+   - Use maintainer-confirmed compatibility metadata from the canonical
+     changelog, prior release notes, tested game/dependency versions, or
+     explicit maintainer input. Do not invent compatibility claims.
+8. Before packaging, verify:
+   - `assets/CHANGELOG.md` has a stable version heading at the top, not
+     `Unreleased`, and does not contain placeholder release metadata such as
+     `TBD`.
+   - `CruiserJumpPractice/CruiserJumpPractice.csproj` contains the intended
+     release version.
+   - The intended stable tag, using this repository's `v<version>` convention
+     from the `generate-version` action, does not already exist locally or
+     remotely. Existing versions are treated as edge builds. If remote tag
+     verification cannot be performed, report it as a release-readiness blocker.
+   - `assets/manifest.json` will receive the same version through the
+     `generate-version` action.
+   - `.github/workflows/build.yml` packages `assets/CHANGELOG.md`.
+   - `dotnet build CruiserJumpPractice.sln` succeeds after any related changes.
+
+## Review-Only Output
+
+When the user asks for a release-readiness review instead of edits, return:
+
+1. Current state of `assets/CHANGELOG.md`, source `CHANGELOG.md` section,
+   project version, local and remote tag readiness, manifest version flow, and
+   package workflow inclusion.
+2. Required updates before packaging.
+3. Blockers or missing inputs, especially stable version, UTC release date,
+   exact canonical changelog text, and compatibility metadata.
+4. Confirmation that no publishing side effects were performed.
+
+## Boundaries
+
+- This skill owns Thunderstore-facing release notes and release-note readiness,
+  not canonical developer changelog authoring.
+- Use `changelog-workflow` first when `CHANGELOG.md` itself needs new
+  canonical entries or version-section changes.
+- Do not upload to Thunderstore, create GitHub releases, or tag releases unless
+  the user explicitly asks for those side effects.
+- Keep private workspace paths, temporary worktree names, command transcripts,
+  and authentication details out of public release-note text.

--- a/.agents/skills/release-note-workflow/SKILL.md
+++ b/.agents/skills/release-note-workflow/SKILL.md
@@ -1,93 +1,120 @@
 ---
 # SPDX-License-Identifier: Unlicense
 name: release-note-workflow
-description: Create, update, or review this repository's Thunderstore-facing release notes in assets/CHANGELOG.md. Use when deriving user-facing stable release notes from CHANGELOG.md or checking release-note readiness before packaging.
+description: Create, update, or review Thunderstore-facing release notes. Use when deriving user-facing stable release notes from a canonical changelog or checking release-note readiness before packaging.
 ---
 
 # Release Note Workflow
 
 ## When to Use
 
-- Use this skill when preparing or reviewing `assets/CHANGELOG.md` for a
-  Thunderstore package.
+- Use this skill when preparing or reviewing Thunderstore package release notes.
 - Use this skill when deriving stable release notes from canonical
-  `CHANGELOG.md` entries.
+  changelog entries.
 - Use this skill when checking release-note readiness before packaging.
 
 ## Goals
 
-- Keep `assets/CHANGELOG.md` as the cumulative Thunderstore-facing stable
+- Keep the Thunderstore-facing release-note file as the cumulative stable
   release history, with the latest stable release at the top.
-- Derive release notes from `CHANGELOG.md` instead of making a second source of
-  truth.
+- Derive release notes from the canonical developer changelog instead of making
+  a second source of truth.
 - Rewrite stable release notes for users, focusing on behavior, installation,
   compatibility, update impact, known limitations, and security.
 - Make version, tag, manifest, and packaging readiness explicit before release.
 
 ## Workflow
 
-1. Read the exact stable release section in `CHANGELOG.md`.
+1. Locate the canonical developer changelog, Thunderstore-facing release-note
+   file, package metadata, manifest source or output path, packaging workflow,
+   and verification command from repository evidence such as docs, configs,
+   scripts, or workflow files. Report anything undiscoverable as a missing input
+   or blocker.
+2. Read the exact stable release section in the canonical developer changelog.
    - If the exact canonical section is unavailable, write draft Thunderstore
      notes and list the missing inputs instead of presenting the output as
      final.
    - If the UTC release date is missing, keep the output clearly marked as
      draft review text. Do not create a package-ready heading with `TBD`,
      `<date>`, or similar placeholder release metadata.
-2. Confirm the release is stable:
+3. Confirm the release is stable:
    - Stable releases use a version without a prerelease suffix, such as
      `1.2.3`.
    - Prerelease versions, such as `1.2.3-alpha.1`, remain developer-facing and
-     are not published to Thunderstore because Thunderstore does not support
-     prerelease package versions for this project.
-3. Roll prerelease entries into the next stable release when they still affect
+     are not published to Thunderstore unless the package target explicitly
+     supports prerelease versions.
+   - Accept prerelease support only from maintained package-target policy,
+     package documentation, explicit maintainer input, or existing package
+     history.
+4. Roll prerelease entries into the next stable release when they still affect
    stable users.
-4. Omit prerelease-only details from `assets/CHANGELOG.md` when they were
-   internal, superseded before stable release, or useful only to maintainers.
-5. Rewrite the stable entries around user-visible behavior, installation,
+5. Omit prerelease-only details from the Thunderstore-facing release notes when
+   they were internal, superseded before stable release, or useful only to
+   maintainers.
+6. Rewrite the stable entries around user-visible behavior, installation,
    compatibility, update impact, security, and known limitations.
-6. Preserve user-critical notes in `assets/CHANGELOG.md`, including breaking
-   changes, compatibility changes, installation or update notes, removals,
-   deprecations, security fixes, yanked releases, and known limitations.
-7. Keep test environment details in `CHANGELOG.md`. Include them in
-   `assets/CHANGELOG.md` only when they are needed as user-facing compatibility
-   or support context.
+7. Preserve user-critical notes in the Thunderstore-facing release notes,
+   including breaking changes, compatibility changes, installation or update
+   notes, removals, deprecations, security fixes, yanked releases, and known
+   limitations.
+8. Keep test environment details in the canonical developer changelog. Include
+   them in Thunderstore-facing release notes only when they are needed as
+   user-facing compatibility or support context.
    - Use maintainer-confirmed compatibility metadata from the canonical
      changelog, prior release notes, tested game/dependency versions, or
      explicit maintainer input. Do not invent compatibility claims.
-8. Before packaging, verify:
-   - `assets/CHANGELOG.md` has a stable version heading at the top, not
-     `Unreleased`, and does not contain placeholder release metadata such as
-     `TBD`.
-   - `CruiserJumpPractice/CruiserJumpPractice.csproj` contains the intended
-     release version.
-   - The intended stable tag, using this repository's `v<version>` convention
-     from the `generate-version` action, does not already exist locally or
-     remotely. Existing versions are treated as edge builds. If remote tag
-     verification cannot be performed, report it as a release-readiness blocker.
-   - `assets/manifest.json` will receive the same version through the
-     `generate-version` action.
-   - `.github/workflows/build.yml` packages `assets/CHANGELOG.md`.
-   - `dotnet build CruiserJumpPractice.sln` succeeds after any related changes.
+9. Before packaging, verify:
+   - The Thunderstore-facing release-note file has a stable version heading at
+     the top, not `Unreleased`, and does not contain placeholder release
+     metadata such as `TBD`.
+   - Project package metadata contains the intended release version.
+   - The intended package or manifest version is not already present in a way
+     that would collide with the planned stable release.
+   - The intended stable tag, using the repository's documented tag convention,
+     does not already exist locally or remotely. Existing versions or tags are
+     blockers for stable packaging until the maintainer chooses a new version or
+     a documented edge-release path. If remote tag verification cannot be
+     performed, report it as a release-readiness blocker.
+   - The Thunderstore manifest will receive the same version as the package
+     metadata.
+   - The packaging workflow includes the Thunderstore-facing release-note file.
+   - The repository's documented build or packaging verification succeeds after
+     any related changes.
 
 ## Review-Only Output
 
-When the user asks for a release-readiness review instead of edits, return:
+When the user asks for a release-readiness review instead of edits, do not edit
+files. Return:
 
-1. Current state of `assets/CHANGELOG.md`, source `CHANGELOG.md` section,
-   project version, local and remote tag readiness, manifest version flow, and
-   package workflow inclusion.
+1. Current state of the Thunderstore-facing release-note file, source changelog
+   section, project version, local and remote tag readiness, manifest version
+   flow, and package workflow inclusion.
 2. Required updates before packaging.
 3. Blockers or missing inputs, especially stable version, UTC release date,
    exact canonical changelog text, and compatibility metadata.
 4. Confirmation that no publishing side effects were performed.
 
+## Output Shape
+
+- Package-ready stable notes use the package target's required heading format
+  with a confirmed stable version and UTC release date.
+- Draft notes are clearly labeled as draft review text and list missing inputs
+  before any proposed user-facing wording.
+- Blockers name the missing or failed readiness item directly, such as stable
+  metadata, tag convention, local or remote tag availability, manifest version
+  flow, packaging inclusion, or verification command.
+
 ## Boundaries
 
 - This skill owns Thunderstore-facing release notes and release-note readiness,
   not canonical developer changelog authoring.
-- Use `changelog-workflow` first when `CHANGELOG.md` itself needs new
-  canonical entries or version-section changes.
-- Do not upload to Thunderstore, create GitHub releases, or tag releases unless
-  the user explicitly asks for those side effects.
+- Use `changelog-workflow` first when the canonical developer changelog itself
+  needs new entries or version-section changes.
+- This skill may review publishing and tag readiness, but it does not perform
+  publishing, release creation, or tag creation. Use a dedicated publishing or
+  release workflow for those side effects.
+- Treat missing stable metadata, missing tag convention, failed local or remote
+  tag verification, and missing prerelease-support evidence as release-readiness
+  blockers.
 - Keep private workspace paths, temporary worktree names, command transcripts,
   and authentication details out of public release-note text.

--- a/.agents/skills/release-note-workflow/SKILL.md
+++ b/.agents/skills/release-note-workflow/SKILL.md
@@ -21,6 +21,8 @@ description: Create, update, or review user-facing release notes. Use when deriv
   a second source of truth.
 - Rewrite stable release notes for users, focusing on behavior, installation,
   compatibility, update impact, known limitations, and security.
+- Include a concise reason or background sentence for each user-visible change
+  so users can understand why the change was made or why it affects them.
 - Make version, source material, publication-channel requirements, and release
   readiness explicit before publication.
 
@@ -72,17 +74,37 @@ description: Create, update, or review user-facing release notes. Use when deriv
    maintainers.
 6. Rewrite the stable entries around user-visible behavior, installation,
    compatibility, update impact, security, and known limitations.
-7. Preserve user-critical notes in the user-facing release notes,
+7. For each user-visible change, include one concise reason or background
+   sentence from the canonical changelog or maintainer input.
+   - Apply this requirement to the target release being prepared or reviewed.
+     Improve older cumulative entries when they are touched, but do not block
+     the target release only because untouched historical entries lack
+     rationale.
+   - Good source material includes the user problem being solved, why behavior
+     changed, compatibility or migration constraints, known limitation context,
+     or why a release was yanked.
+   - A sourced user impact statement can serve as the reason/background sentence
+     only when it explains why users should care.
+   - Use conservative negative-impact summaries, such as "no gameplay changes",
+     only when the canonical changelog or maintainer input supports that
+     conclusion for the target release.
+   - Generic source bullets such as documentation updates, dependency updates,
+     crash fixes, or save-format changes are draft-only until the canonical
+     changelog or maintainer input explains the user-facing benefit, risk,
+     security impact, compatibility impact, or migration reason.
+   - If a change lacks enough rationale or history, mark it as draft or a
+     missing input instead of inventing an explanation.
+8. Preserve user-critical notes in the user-facing release notes,
    including breaking changes, compatibility changes, installation or update
    notes, removals, deprecations, security fixes, yanked releases, and known
    limitations.
-8. Keep test environment details in the canonical developer changelog. Include
+9. Keep test environment details in the canonical developer changelog. Include
    them in user-facing release notes only when they are needed as
    user-facing compatibility or support context.
    - Use maintainer-confirmed compatibility metadata from the canonical
      changelog, prior release notes, tested product/dependency versions, or
      explicit maintainer input. Do not invent compatibility claims.
-9. Before publication, verify:
+10. Before publication, verify:
    - The user-facing release-note file has a stable version heading at
      the top, not `Unreleased`, and does not contain placeholder release
      metadata such as `TBD`.
@@ -143,6 +165,10 @@ Classify review items as:
 
 - Release-ready stable notes use the publication channel's required heading
   format with a confirmed stable version and UTC release date.
+- Each user-visible change includes one concise reason or background sentence,
+  sourced from the canonical changelog or maintainer input.
+  This applies to the target release; untouched historical entries in a
+  cumulative file are not blockers solely because they predate this rule.
 - Draft notes are clearly labeled as draft review text and list missing inputs
   before any proposed user-facing wording.
 - Blockers name the missing or failed readiness item directly, such as stable

--- a/.agents/skills/release-note-workflow/agents/openai.yaml
+++ b/.agents/skills/release-note-workflow/agents/openai.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Unlicense
+interface:
+  display_name: "Release Note Workflow"
+  short_description: "Derive Thunderstore-facing stable release notes from CHANGELOG.md."
+  default_prompt: "Derive or review stable Thunderstore release notes in assets/CHANGELOG.md from canonical CHANGELOG.md entries, then check version, tag, manifest, and packaging readiness."

--- a/.agents/skills/release-note-workflow/agents/openai.yaml
+++ b/.agents/skills/release-note-workflow/agents/openai.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Unlicense
 interface:
   display_name: "Release Note Workflow"
-  short_description: "Derive Thunderstore-facing stable release notes."
-  default_prompt: "Derive or review stable Thunderstore release notes from canonical changelog entries, then check version, tag, manifest, and packaging readiness."
+  short_description: "Derive user-facing stable release notes."
+  default_prompt: "Derive or review stable user-facing release notes from canonical changelog entries, then check version, tag, publication-channel, workflow, and verification readiness."

--- a/.agents/skills/release-note-workflow/agents/openai.yaml
+++ b/.agents/skills/release-note-workflow/agents/openai.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Unlicense
 interface:
   display_name: "Release Note Workflow"
-  short_description: "Derive Thunderstore-facing stable release notes from CHANGELOG.md."
-  default_prompt: "Derive or review stable Thunderstore release notes in assets/CHANGELOG.md from canonical CHANGELOG.md entries, then check version, tag, manifest, and packaging readiness."
+  short_description: "Derive Thunderstore-facing stable release notes."
+  default_prompt: "Derive or review stable Thunderstore release notes from canonical changelog entries, then check version, tag, manifest, and packaging readiness."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - LethalNetworkAPI v3.3.2 (2024-12-29 UTC)
   - OdinSerializer v2024.2.2700 (2025-05-18 UTC)
 
-## v0.1.3 - 2025-11-30 UTC
+## v0.1.3 - 2025-11-30 UTC [YANKED]
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,26 +18,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Dropped backward compatibility with CruiserJumpPractice v0.1.4 and earlier
   because the internal NetworkBehaviour name changed.
 
-### Compatibility
+### Notes
 
-- Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
-  `6423525044216269478`).
-- Lethal Company v73 still appears to work.
-- Lethal Company v56 mostly works, with a known minor issue tracked in
-  <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
-- Imperium v1.3.0 appears to have some cruiser-related issues; see
-  <https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735>
-  for a workaround.
-
-### Test Environment
-
-- Lethal Company v81.5 (2026-04-17 UTC, Manifest ID: `6423525044216269478`)
-- BepInExPack v5.4.2305 (2026-03-17 UTC)
-- Imperium v1.3.0 (2026-04-08 UTC)
-- LethalCompany_InputUtils v0.7.13 (2026-03-31 UTC)
-- LethalNetworkAPI v3.3.3 (2026-04-02 UTC)
-- OdinSerializer v2024.2.2700 (2025-05-18 UTC)
-- BepInEx_MonoMod_Debug_Patcher v1.1.1 (2025-04-03 UTC)
+- Compatibility:
+  - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
+    `6423525044216269478`).
+  - Lethal Company v73 still appears to work.
+  - Lethal Company v56 mostly works, with a known minor issue tracked in
+    <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
+  - Imperium v1.3.0 appears to have some cruiser-related issues; see
+    <https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735>
+    for a workaround.
+- Test environment:
+  - Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
+    `6423525044216269478`)
+  - BepInExPack v5.4.2305 (2026-03-17 UTC)
+  - Imperium v1.3.0 (2026-04-08 UTC)
+  - LethalCompany_InputUtils v0.7.13 (2026-03-31 UTC)
+  - LethalNetworkAPI v3.3.3 (2026-04-02 UTC)
+  - OdinSerializer v2024.2.2700 (2025-05-18 UTC)
+  - BepInEx_MonoMod_Debug_Patcher v1.1.1 (2025-04-03 UTC)
 
 ## v0.1.4 - 2025-11-30 UTC
 
@@ -45,19 +45,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Enabled keybind actions while the player is dead, same as Imperium.
 
-### Compatibility
+### Notes
 
-- Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
-  `1749099131234587692`).
-
-### Test Environment
-
-- Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`)
-- BepInExPack v5.4.2304 (2025-11-05 UTC)
-- Imperium v1.1.1 (2025-10-27 UTC)
-- LethalCompany_InputUtils v0.7.12 (2025-10-24 UTC)
-- LethalNetworkAPI v3.3.2 (2024-12-29 UTC)
-- OdinSerializer v2024.2.2700 (2025-05-18 UTC)
+- Compatibility:
+  - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
+    `1749099131234587692`).
+- Test environment:
+  - Lethal Company v73 (2025-10-04 UTC, Manifest ID:
+    `1749099131234587692`)
+  - BepInExPack v5.4.2304 (2025-11-05 UTC)
+  - Imperium v1.1.1 (2025-10-27 UTC)
+  - LethalCompany_InputUtils v0.7.12 (2025-10-24 UTC)
+  - LethalNetworkAPI v3.3.2 (2024-12-29 UTC)
+  - OdinSerializer v2024.2.2700 (2025-05-18 UTC)
 
 ## v0.1.3 - 2025-11-30 UTC
 
@@ -77,10 +77,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed an issue where the magnet lever on the ship wall did not reflect the
   magnet status when toggled via keybind.
 
-### Compatibility
+### Notes
 
-- Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
-  `1749099131234587692`).
+- Compatibility:
+  - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
+    `1749099131234587692`).
 
 ## v0.1.1 - 2025-11-29 UTC
 
@@ -88,10 +89,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Updated documentation.
 
-### Compatibility
+### Notes
 
-- Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
-  `1749099131234587692`).
+- Compatibility:
+  - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
+    `1749099131234587692`).
 
 ## v0.1.0 - 2025-11-29 UTC
 
@@ -99,7 +101,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Initial Thunderstore release.
 
-### Compatibility
+### Notes
 
-- Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
-  `1749099131234587692`).
+- Compatibility:
+  - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
+    `1749099131234587692`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,105 @@
+<!-- SPDX-License-Identifier: Unlicense -->
+
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+This changelog is the canonical developer-facing release history. The
+Thunderstore-facing package changelog in `assets/CHANGELOG.md` is derived from
+stable release entries in this file and rewritten for users.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## Unreleased
+
+### Changed
+
+- Refactored internal architecture to improve maintainability.
+- Dropped backward compatibility with CruiserJumpPractice v0.1.4 and earlier
+  because the internal NetworkBehaviour name changed.
+
+### Compatibility
+
+- Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
+  `6423525044216269478`).
+- Lethal Company v73 still appears to work.
+- Lethal Company v56 mostly works, with a known minor issue tracked in
+  <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
+- Imperium v1.3.0 appears to have some cruiser-related issues; see
+  <https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735>
+  for a workaround.
+
+### Test Environment
+
+- Lethal Company v81.5 (2026-04-17 UTC, Manifest ID: `6423525044216269478`)
+- BepInExPack v5.4.2305 (2026-03-17 UTC)
+- Imperium v1.3.0 (2026-04-08 UTC)
+- LethalCompany_InputUtils v0.7.13 (2026-03-31 UTC)
+- LethalNetworkAPI v3.3.3 (2026-04-02 UTC)
+- OdinSerializer v2024.2.2700 (2025-05-18 UTC)
+- BepInEx_MonoMod_Debug_Patcher v1.1.1 (2025-04-03 UTC)
+
+## v0.1.4 - 2025-11-30 UTC
+
+### Changed
+
+- Enabled keybind actions while the player is dead, same as Imperium.
+
+### Compatibility
+
+- Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
+  `1749099131234587692`).
+
+### Test Environment
+
+- Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`)
+- BepInExPack v5.4.2304 (2025-11-05 UTC)
+- Imperium v1.1.1 (2025-10-27 UTC)
+- LethalCompany_InputUtils v0.7.12 (2025-10-24 UTC)
+- LethalNetworkAPI v3.3.2 (2024-12-29 UTC)
+- OdinSerializer v2024.2.2700 (2025-05-18 UTC)
+
+## v0.1.3 - 2025-11-30 UTC
+
+### Removed
+
+- Yanked release due to a build issue.
+
+## v0.1.2 - 2025-11-29 UTC
+
+### Changed
+
+- Disabled keybind actions while the player is in a menu, using the terminal,
+  typing in chat, or dead.
+
+### Fixed
+
+- Fixed an issue where the magnet lever on the ship wall did not reflect the
+  magnet status when toggled via keybind.
+
+### Compatibility
+
+- Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
+  `1749099131234587692`).
+
+## v0.1.1 - 2025-11-29 UTC
+
+### Changed
+
+- Updated documentation.
+
+### Compatibility
+
+- Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
+  `1749099131234587692`).
+
+## v0.1.0 - 2025-11-29 UTC
+
+### Added
+
+- Initial Thunderstore release.
+
+### Compatibility
+
+- Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
+  `1749099131234587692`).

--- a/README.md
+++ b/README.md
@@ -69,11 +69,16 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
 
 ## Release
 
-1. Replace version in `CruiserJumpPractice/CruiserJumpPractice.csproj` as semver format, e.g. `1.2.3`.
-2. Commit and push the changes.
-3. CI will create a GitHub Release automatically.
-4. Download the release artifact from the GitHub Release page.
-5. Upload the artifact to Thunderstore. **NOTE: prerelease version is not supported, e.g. `1.2.3-beta.1`.**
+1. Update the canonical developer changelog in `CHANGELOG.md`.
+2. For a stable release, derive the Thunderstore-facing release notes in `assets/CHANGELOG.md` from stable entries in
+   `CHANGELOG.md`.
+3. Replace version in `CruiserJumpPractice/CruiserJumpPractice.csproj` as semver format, e.g. `1.2.3`.
+4. Verify that `.github/workflows/build.yml` packages `assets/CHANGELOG.md` and that the `generate-version`
+   action updates `assets/manifest.json` from the project version.
+5. Commit and push the changes.
+6. CI will create a GitHub Release automatically.
+7. Download the release artifact from the GitHub Release page.
+8. Upload the artifact to Thunderstore. **NOTE: prerelease version is not supported, e.g. `1.2.3-beta.1`.**
 
 ### AI Disclosure
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Unlicense -->
+
 # CruiserJumpPractice
 
 A Lethal Company mod that saves/loads cruiser position, rotation, and condition, and lets you toggle the magnet remotely.

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This is a maintenance release reflecting internal improvements.
 
-No functional changes are introduced.
+No gameplay changes are introduced.
 
 ### Compatibility
 
@@ -13,19 +13,7 @@ No functional changes are introduced.
 
 ### Changed
 
-- Drops backward compatibility with CruiserJumpPractice v0.1.4 and earlier.
-    - The internal NetworkBehaviour name has been changed.
-- Refactored internal architecture to improve maintainability.
-
-### Test environment
-
-- Lethal Company v81.5 (2026-04-17 UTC, Manifest ID: `6423525044216269478`)
-- BepInExPack v5.4.2305 (2026-03-17 UTC)
-- Imperium v1.3.0 (2026-04-08 UTC)
-- LethalCompany_InputUtils v0.7.13 (2026-03-31 UTC)
-- LethalNetworkAPI v3.3.3 (2026-04-02 UTC)
-- OdinSerializer v2024.2.2700 (2025-05-18 UTC)
-- BepInEx_MonoMod_Debug_Patcher v1.1.1 (2025-04-03 UTC)
+- This release is not backward-compatible with CruiserJumpPractice v0.1.4 and earlier.
 
 ## v0.1.4 - 2025-11-30 UTC
 
@@ -36,15 +24,6 @@ No functional changes are introduced.
 ### Changed
 
 - Enables keybind actions while the player is dead, same as Imperium.
-
-### Test environment
-
-- Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`)
-- BepInExPack v5.4.2304 (2025-11-05 UTC)
-- Imperium v1.1.1 (2025-10-27 UTC)
-- LethalCompany_InputUtils v0.7.12 (2025-10-24 UTC)
-- LethalNetworkAPI v3.3.2 (2024-12-29 UTC)
-- OdinSerializer v2024.2.2700 (2025-05-18 UTC)
 
 ## v0.1.3 - 2025-11-30 UTC
 

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -6,7 +6,7 @@ No functional changes are introduced.
 
 ### Compatibility
 
-- Compatiable with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID: `6423525044216269478`).
+- Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID: `6423525044216269478`).
     - NOTE: Imperium v1.3.0 appears to have some cruiser-related issues. See this issue comment for a workaround: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735
     - Lethal Company v73: It still seems to work.
     - Lethal Company v56: Major features work as expected, but there is a minor known issue: https://github.com/aoirint/CruiserJumpPractice/issues/5
@@ -31,7 +31,7 @@ No functional changes are introduced.
 
 ### Compatibility
 
-- Compatiable with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
+- Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
 
 ### Changed
 
@@ -54,7 +54,7 @@ Yanked release due to a build issue.
 
 ### Compatibility
 
-- Compatiable with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
+- Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
 
 ### Changed
 
@@ -68,7 +68,7 @@ Yanked release due to a build issue.
 
 ### Compatibility
 
-- Compatiable with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
+- Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
 
 ### Changed
 
@@ -78,7 +78,7 @@ Yanked release due to a build issue.
 
 ### Compatibility
 
-- Compatiable with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
+- Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
 
 ### Added
 

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -25,7 +25,7 @@ No gameplay changes are introduced.
 
 - Enables keybind actions while the player is dead, same as Imperium.
 
-## v0.1.3 - 2025-11-30 UTC
+## v0.1.3 - 2025-11-30 UTC [YANKED]
 
 Yanked release due to a build issue.
 

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -4,10 +4,11 @@ This is a maintenance release reflecting internal improvements.
 
 No gameplay changes are introduced.
 
-### Compatibility
+### Notes
 
-- Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID: `6423525044216269478`).
-    - NOTE: Imperium v1.3.0 appears to have some cruiser-related issues. See this issue comment for a workaround: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735
+- Compatibility:
+    - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID: `6423525044216269478`).
+    - Imperium v1.3.0 appears to have some cruiser-related issues. See this issue comment for a workaround: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735
     - Lethal Company v73: It still seems to work.
     - Lethal Company v56: Major features work as expected, but there is a minor known issue: https://github.com/aoirint/CruiserJumpPractice/issues/5
 
@@ -17,9 +18,10 @@ No gameplay changes are introduced.
 
 ## v0.1.4 - 2025-11-30 UTC
 
-### Compatibility
+### Notes
 
-- Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
+- Compatibility:
+    - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
 
 ### Changed
 
@@ -31,9 +33,10 @@ Yanked release due to a build issue.
 
 ## v0.1.2 - 2025-11-29 UTC
 
-### Compatibility
+### Notes
 
-- Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
+- Compatibility:
+    - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
 
 ### Changed
 
@@ -45,9 +48,10 @@ Yanked release due to a build issue.
 
 ## v0.1.1 - 2025-11-29 UTC
 
-### Compatibility
+### Notes
 
-- Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
+- Compatibility:
+    - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
 
 ### Changed
 
@@ -55,9 +59,10 @@ Yanked release due to a build issue.
 
 ## v0.1.0 - 2025-11-29 UTC
 
-### Compatibility
+### Notes
 
-- Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
+- Compatibility:
+    - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
 
 ### Added
 

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Unlicense -->
+
 ## Unreleased
 
 This is a maintenance release reflecting internal improvements.


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary
- Add `CHANGELOG.md` as the canonical developer-facing Keep a Changelog-style release history.
- Add repository-local `changelog-workflow` guidance for canonical changelog maintenance.
- Add `release-note-workflow` for deriving and reviewing user-facing stable release notes from the canonical changelog without creating a second source of truth.
- Group canonical compatibility and test-environment metadata, plus user-facing compatibility metadata, under `Notes` instead of separate change-type headings, following Keep a Changelog's standard change categories.
- Clarify in `release-note-workflow` that user-facing supplemental metadata belongs under `Notes` with labeled bullets unless a publication channel explicitly requires standalone metadata headings.
- Mark the yanked v0.1.3 release with Keep a Changelog's `[YANKED]` heading marker in both canonical and user-facing changelogs.
- Require user-facing release notes to include a sourced reason or background sentence for each target-release user-visible change, with the canonical developer changelog accumulating that rationale/history first.
- Keep release-note readiness publication-channel-neutral, including version source discovery, tag readiness, release workflow inclusion, review-only matrices, blocker severity, and manual publication handling.
- Add SPDX `Unlicense` notices to every file touched by this PR.
- Update release guidance to verify changelog/release-note derivation, version metadata, and packaged release-note inclusion.
- Tune the workflow skills with empirical real-file, hypothetical, and hold-out scenarios, including stable/prerelease filtering, draft-note handling, placeholder-heading avoidance, tag readiness, compatibility provenance, publication-channel discovery, read-only readiness evidence, rationale sufficiency, user-facing metadata grouping, and review-only checks.
- Fix `Compatible` spelling in the user-facing changelog.

## Verification
- `git diff --check`
- PowerShell structure check for split changelog/release-note workflow files and release guidance references
- PowerShell check confirming every `git diff --name-only main...HEAD` file contains `SPDX-License-Identifier`
- `rg` checks confirming repository-specific and Thunderstore-specific skill wording was removed from the generalized workflow guidance
- `rg` check confirming `CHANGELOG.md` no longer has standalone `### Compatibility` or `### Test Environment` headings
- `rg` check confirming `assets/CHANGELOG.md` no longer has standalone `### Compatibility` headings
- `rg` check confirming `release-note-workflow` now documents user-facing supplemental metadata under `Notes` and the publication-channel exception
- Blank-slate whole-PR review: no findings; residual gap is absence of a repository-provided Markdown/Agent Skill validator
- Empirical prompt tuning using blank-slate executor scenarios:
  - `changelog-workflow`: current canonical changelog update, hypothetical prerelease/stable source shaping, placeholder-heading hold-out, user-facing release-note handoff checks, rationale/history accumulation, and real-file checks against `CHANGELOG.md` / `assets/CHANGELOG.md`
  - `release-note-workflow`: current release-readiness review, hypothetical user-facing release-note derivation, draft-note hold-out, publication-channel-neutral website/GitHub Release readiness checks, missing destination handling, conflicting version sources, remote tag collision handling, rationale-sufficiency checks for target-release entries, user-facing metadata grouping under `Notes`, publication-channel metadata-heading exceptions, and real-file checks against `CHANGELOG.md`, `assets/CHANGELOG.md`, `README.md`, `.github/workflows/build.yml`, and the project version source
- `dotnet build CruiserJumpPractice.sln`

## Notes
- Closes #29.
- `changelog-workflow` references Keep a Changelog 1.1.0 directly: http://keepachangelog.com/en/1.1.0/