### PR TITLE
docs: standardize LLM assistance notices

### DIFF
--- a/.agents/skills/issue-quality-check/SKILL.md
+++ b/.agents/skills/issue-quality-check/SKILL.md
@@ -25,7 +25,14 @@ When the issue was prepared with LLM assistance, check that this GitHub alert ap
 
 ```markdown
 > [!WARNING]
-> This issue was generated with LLMs.
+> This issue was created with assistance from LLMs.
+```
+
+For Japanese issue bodies, use this alert text instead:
+
+```markdown
+> [!WARNING]
+> このIssueはLLMの支援を受けて作成されました。
 ```
 
 The alert should appear before every other heading, summary, checklist, template field, or metadata block.
@@ -36,7 +43,7 @@ Check that the body is concise and uses these sections when applicable:
 
 ```markdown
 > [!WARNING]
-> This issue was generated with LLMs.
+> This issue was created with assistance from LLMs.
 
 ## Summary
 - ...
@@ -80,7 +87,14 @@ When the issue reply was prepared with LLM assistance, check that this GitHub al
 
 ```markdown
 > [!WARNING]
-> This comment was generated with LLMs.
+> This comment was created with assistance from LLMs.
+```
+
+For Japanese issue replies, use this alert text instead:
+
+```markdown
+> [!WARNING]
+> このコメントはLLMの支援を受けて作成されました。
 ```
 
 The alert should appear before every other paragraph, heading, checklist, quote, or metadata block.
@@ -89,7 +103,7 @@ Check that the reply is concise and uses only the structure needed for the situa
 
 ```markdown
 > [!WARNING]
-> This comment was generated with LLMs.
+> This comment was created with assistance from LLMs.
 
 Thanks for the report. I can reproduce this with ...
 

--- a/.agents/skills/issue-quality-check/SKILL.md
+++ b/.agents/skills/issue-quality-check/SKILL.md
@@ -28,13 +28,6 @@ When the issue was prepared with LLM assistance, check that this GitHub alert ap
 > This issue was created with assistance from LLMs.
 ```
 
-For Japanese issue bodies, use this alert text instead:
-
-```markdown
-> [!WARNING]
-> このIssueはLLMの支援を受けて作成されました。
-```
-
 The alert should appear before every other heading, summary, checklist, template field, or metadata block.
 
 ## Body Structure
@@ -65,6 +58,8 @@ Recommend sections only when they carry useful information:
 
 ## Style
 
+- Write issue titles, issue bodies, and issue comments in English by default.
+- Use another language only when the user explicitly requests it, when preserving quoted or source text, or when the existing maintainer conversation has already chosen that language.
 - Keep issue bodies short and scannable.
 - Prefer bullets for facts, steps, and criteria.
 - Mention paths, commands, classes, and config keys in backticks.
@@ -88,13 +83,6 @@ When the issue reply was prepared with LLM assistance, check that this GitHub al
 ```markdown
 > [!WARNING]
 > This comment was created with assistance from LLMs.
-```
-
-For Japanese issue replies, use this alert text instead:
-
-```markdown
-> [!WARNING]
-> このコメントはLLMの支援を受けて作成されました。
 ```
 
 The alert should appear before every other paragraph, heading, checklist, quote, or metadata block.

--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -27,7 +27,14 @@ When the PR was prepared with LLM assistance, check that this GitHub alert appea
 
 ```markdown
 > [!WARNING]
-> This pull request was generated with LLMs.
+> This pull request was created with assistance from LLMs.
+```
+
+For Japanese pull request bodies, use this alert text instead:
+
+```markdown
+> [!WARNING]
+> このプルリクエストはLLMの支援を受けて作成されました。
 ```
 
 The alert should appear before every other heading, summary, checklist, or metadata block.
@@ -38,7 +45,7 @@ Check that the body is concise and uses these sections when applicable:
 
 ```markdown
 > [!WARNING]
-> This pull request was generated with LLMs.
+> This pull request was created with assistance from LLMs.
 
 ## Summary
 - ...
@@ -69,7 +76,14 @@ When a pull request reply or review was prepared with LLM assistance, check that
 
 ```markdown
 > [!WARNING]
-> This comment was generated with LLMs.
+> This comment was created with assistance from LLMs.
+```
+
+For Japanese pull request replies or reviews, use this alert text instead:
+
+```markdown
+> [!WARNING]
+> このコメントはLLMの支援を受けて作成されました。
 ```
 
 The alert should appear before every other paragraph, heading, checklist, quote, finding, or metadata block.

--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -30,13 +30,6 @@ When the PR was prepared with LLM assistance, check that this GitHub alert appea
 > This pull request was created with assistance from LLMs.
 ```
 
-For Japanese pull request bodies, use this alert text instead:
-
-```markdown
-> [!WARNING]
-> このプルリクエストはLLMの支援を受けて作成されました。
-```
-
 The alert should appear before every other heading, summary, checklist, or metadata block.
 
 ## Body Structure
@@ -63,6 +56,8 @@ Recommend sections only when they carry useful information:
 
 ## Style
 
+- Write pull request titles, pull request bodies, review comments, and replies in English by default.
+- Use another language only when the user explicitly requests it, when preserving quoted or source text, or when the existing maintainer conversation has already chosen that language.
 - Keep PR bodies short and reviewable.
 - Prefer bullets over long paragraphs.
 - Mention paths or commands in backticks.
@@ -77,13 +72,6 @@ When a pull request reply or review was prepared with LLM assistance, check that
 ```markdown
 > [!WARNING]
 > This comment was created with assistance from LLMs.
-```
-
-For Japanese pull request replies or reviews, use this alert text instead:
-
-```markdown
-> [!WARNING]
-> このコメントはLLMの支援を受けて作成されました。
 ```
 
 The alert should appear before every other paragraph, heading, checklist, quote, finding, or metadata block.


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary
- Standardize issue, pull request, and comment LLM notices on `created with assistance from LLMs` wording.
- Add default-English guidance for issue titles/bodies/comments and pull request titles/bodies/review comments/replies.
- Remove the Japanese LLM notice examples from the issue and pull request skills.

## Verification
- `rg --hidden -n --glob '!.agents/worktrees/**' "generated with LLMs|This (issue|pull request|comment) was generated|自動生成.*LLM|LLM.*自動生成" .`
- `rg --hidden -n --glob '!.agents/worktrees/**' "このIssue|このプルリクエスト|このコメント|支援を受けて作成|generated with LLMs|This (issue|pull request|comment) was generated|自動生成.*LLM|LLM.*自動生成" .agents/skills/issue-quality-check .agents/skills/pull-request-quality-check`
- `git diff --check -- .agents/skills/issue-quality-check/SKILL.md .agents/skills/pull-request-quality-check/SKILL.md`
- Empirical prompt tuning with fresh subagents for `issue-quality-check` and `pull-request-quality-check`: both reported all requirements satisfied, no unclear points, and zero retries.