### PR TITLE
docs(skills): require English GitHub comments

### DIFF
--- a/.agents/skills/issue-quality-check/SKILL.md
+++ b/.agents/skills/issue-quality-check/SKILL.md
@@ -59,8 +59,9 @@ Recommend sections only when they carry useful information:
 
 ## Style
 
-- Write issue titles, issue bodies, and issue comments in English by default.
-- Use another language only when the user explicitly requests it, when preserving quoted or source text, or when the existing maintainer conversation has already chosen that language.
+- Write issue titles, issue bodies, and issue comments in English.
+- Preserve non-English text only when quoting source text, branch names, commit messages, file
+  contents, logs, or existing discussion snippets that must remain exact.
 - Keep issue bodies short and scannable.
 - Prefer bullets for facts, steps, and criteria.
 - Mention paths, commands, classes, and config keys in backticks.

--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -59,8 +59,9 @@ Recommend sections only when they carry useful information:
 
 ## Style
 
-- Write pull request titles, pull request bodies, review comments, and replies in English by default.
-- Use another language only when the user explicitly requests it, when preserving quoted or source text, or when the existing maintainer conversation has already chosen that language.
+- Write pull request titles, pull request bodies, review comments, and replies in English.
+- Preserve non-English text only when quoting source text, branch names, commit messages, file
+  contents, logs, or existing discussion snippets that must remain exact.
 - Keep PR bodies short and reviewable.
 - Prefer bullets over long paragraphs.
 - Mention paths or commands in backticks.


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary
- Require issue titles, issue bodies, issue comments, pull request titles, pull request bodies, review comments, and PR replies to be written in English.
- Remove the previous alternate-language allowance from GitHub issue and pull request quality skills.
- Preserve non-English text only when exact quoted source, logs, commit messages, branch names, file contents, or discussion snippets must remain unchanged.

## Verification
- `rg -n "Use another language|English by default|in English by default" .agents/skills` found no remaining matches.
- `git diff --check` passed.
- Empirical prompt-tuning scenarios for Japanese issue and PR reply requests produced English comments with no language-rule ambiguity.