### PR TITLE
docs: make process notes opt-in

### DIFF
--- a/.agents/skills/issue-quality-check/SKILL.md
+++ b/.agents/skills/issue-quality-check/SKILL.md
@@ -121,6 +121,19 @@ For issue replies:
 - Avoid large diffs, large logs, and unrelated implementation plans.
 - Do not promise timelines unless they are already agreed.
 
+Use `Update Note` or `Discussion Note` sections only when the user or maintainer explicitly asks for process notes,
+decision logs, or granular issue-thread updates. Do not add them by default: frequent process notes can clutter the
+thread and may expose unnecessary implementation context. When enabled:
+
+- Use `Update Note` for a concrete issue, documentation, or implementation update that was just made.
+- Use `Discussion Note` for a decision, tradeoff, or rationale that should remain visible in the issue thread.
+- Keep each note concise and limited to information that is safe and useful for future readers.
+- Base notes on confirmed issue context. If a note includes an inference or assumption, label it as such.
+- Do not include secrets, private discussion, local-only paths, hidden chain-of-thought, or unrelated implementation
+  details.
+- Prefer a normal short reply when the comment only needs to answer a question, report investigation results, or
+  acknowledge completion.
+
 When creating or editing issue replies with a shell command:
 
 - Prefer writing the reply to a temporary Markdown file and passing it with `gh issue comment --body-file <file>`.

--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -80,6 +80,19 @@ When a pull request reply or review was prepared with LLM assistance, check that
 
 The alert should appear before every other paragraph, heading, checklist, quote, finding, or metadata block.
 
+Use `Update Note` or `Discussion Note` sections only when the user or maintainer explicitly asks for process notes,
+decision logs, or granular PR-thread updates. Do not add them by default: frequent process notes can clutter the PR
+conversation and may expose unnecessary implementation context. When enabled:
+
+- Use `Update Note` for a concrete change that was just made to the pull request.
+- Use `Discussion Note` for a decision, tradeoff, or rationale that should remain visible in the PR thread.
+- Keep each note concise and limited to information that is safe and useful for future reviewers.
+- Base notes on confirmed PR context. If a note includes an inference or assumption, label it as such.
+- Do not include secrets, private discussion, local-only paths, hidden chain-of-thought, or unrelated implementation
+  details.
+- Prefer a normal short reply when the comment only needs to answer a question, report review results, or acknowledge
+  completion.
+
 ## CLI Safety
 
 When creating or editing PR bodies with a shell command, avoid passing Markdown directly through command arguments if it contains backticks, quotes, dollar signs, backslashes, or multiple lines. Shells such as PowerShell and bash can interpret those characters and silently corrupt the body.


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary
- Document that `Update Note` and `Discussion Note` sections are opt-in for PR and issue replies.
- Add guidance for when each note type is appropriate, what to avoid, and how to keep notes based on confirmed context.

## Verification
- `git diff --check HEAD~1..HEAD`
- Empirical prompt tuning with two rounds of fresh executor scenarios:
  - Round 1: no explicit note request skips process-note sections; explicit decision-log request uses `Discussion Note`.
  - Round 2: explicit `Discussion Note` stays limited to confirmed context; ordinary completion replies still skip process-note sections.

## Notes
- Retrieved and applied `empirical-prompt-tuning` from `mizchi/skills` at commit `2036fb480a8b442c7b6298595b38c9a7a25b97af`.