### PR TITLE
docs: put changelog notes after change sections

### DIFF
--- a/.agents/skills/changelog-workflow/SKILL.md
+++ b/.agents/skills/changelog-workflow/SKILL.md
@@ -48,6 +48,7 @@ Reference:
    - Put supplemental release metadata that is not itself a change type, such as
      compatibility notes and test environments, under `Notes` instead of making
      separate top-level change-category headings.
+   - Put `Notes` after all change-category sections within each release entry.
 5. Keep versioned sections newest first, with headings such as
    `## v1.2.3 - 2026-05-03 UTC`.
 6. Record developer-facing details that help future maintainers, including:

--- a/.agents/skills/release-note-workflow/SKILL.md
+++ b/.agents/skills/release-note-workflow/SKILL.md
@@ -108,6 +108,8 @@ description: Create, update, or review user-facing release notes. Use when deriv
      labeled bullets such as `Compatibility:` or `Known limitations:`, instead
      of creating standalone headings for metadata that is not a Keep a
      Changelog change category.
+   - Put `Notes` after all change-category sections within each release entry
+     unless the publication channel explicitly requires another order.
 10. Before publication, verify:
    - The user-facing release-note file has a stable version heading at
      the top, not `Unreleased`, and does not contain placeholder release
@@ -174,6 +176,8 @@ Classify review items as:
   bullets. Do not use standalone `Compatibility`, `Test Environment`, or
   similar metadata headings unless the publication channel explicitly requires
   them.
+- `Notes` appears after all change-category sections within each release entry
+  unless the publication channel explicitly requires another order.
 - Each user-visible change includes one concise reason or background sentence,
   sourced from the canonical changelog or maintainer input.
   This applies to the target release; untouched historical entries in a

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -6,6 +6,10 @@ This is a maintenance release reflecting internal improvements.
 
 No gameplay changes are introduced.
 
+### Changed
+
+- This release is not backward-compatible with CruiserJumpPractice v0.1.4 and earlier.
+
 ### Notes
 
 - Compatibility:
@@ -14,31 +18,22 @@ No gameplay changes are introduced.
     - Lethal Company v73: It still seems to work.
     - Lethal Company v56: Major features work as expected, but there is a minor known issue: https://github.com/aoirint/CruiserJumpPractice/issues/5
 
+## v0.1.4 - 2025-11-30 UTC
+
 ### Changed
 
-- This release is not backward-compatible with CruiserJumpPractice v0.1.4 and earlier.
-
-## v0.1.4 - 2025-11-30 UTC
+- Enables keybind actions while the player is dead, same as Imperium.
 
 ### Notes
 
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
-
-### Changed
-
-- Enables keybind actions while the player is dead, same as Imperium.
 
 ## v0.1.3 - 2025-11-30 UTC [YANKED]
 
 Yanked release due to a build issue.
 
 ## v0.1.2 - 2025-11-29 UTC
-
-### Notes
-
-- Compatibility:
-    - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
 
 ### Changed
 
@@ -48,24 +43,29 @@ Yanked release due to a build issue.
 
 - Fixed an issue where the magnet lever on the ship wall did not reflect the magnet status when toggled via keybind.
 
-## v0.1.1 - 2025-11-29 UTC
-
 ### Notes
 
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
+
+## v0.1.1 - 2025-11-29 UTC
 
 ### Changed
 
 - Updated documentation.
 
-## v0.1.0 - 2025-11-29 UTC
-
 ### Notes
 
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).
 
+## v0.1.0 - 2025-11-29 UTC
+
 ### Added
 
 - Initial release on Thunderstore.
+
+### Notes
+
+- Compatibility:
+    - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID: `1749099131234587692`).


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Move `Notes` sections in `assets/CHANGELOG.md` below change-category sections for each release entry.
- Document the same ordering rule in both changelog and release-note workflow skills.

## Related Issues

- None.

## Notes for reviewers

- This is a documentation/release-note formatting change only.

### AI disclosure

- Codex helped reorder the user-facing changelog sections and update the local Agent Skill guidance.
- The resulting diff was checked for Markdown whitespace issues and for `Notes` ordering across release entries.

## Testing

### Automated checks

- `git diff --check -- .agents/skills/changelog-workflow/SKILL.md .agents/skills/release-note-workflow/SKILL.md assets/CHANGELOG.md`

### AI-assisted inspections

- Human request: move user-facing changelog `Notes` sections to the bottom and align the relevant skills.
  - AI-assisted result: confirmed `assets/CHANGELOG.md` has `Notes` after change-category sections in all release entries.

### Manual checks

- Not run - documentation-only change.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
