### PR TITLE
ci: publish stable releases to Thunderstore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Enforce CRLF line endings
 * text=auto eol=crlf
+
+# Bash scripts run on Linux CI and must keep LF endings.
+*.sh text eol=lf

--- a/.github/actions/publish-thunderstore/action.yml
+++ b/.github/actions/publish-thunderstore/action.yml
@@ -43,4 +43,4 @@ runs:
         THUNDERSTORE_COMMUNITY: ${{ inputs.community }}
         THUNDERSTORE_COMMUNITY_CATEGORIES: ${{ inputs.community_categories }}
         THUNDERSTORE_REPO: ${{ inputs.repo }}
-      run: bash "${{ github.action_path }}/publish-thunderstore.sh" "${{ inputs.artifact_path }}"
+      run: bash "${GITHUB_ACTION_PATH}/publish-thunderstore.sh" "${{ inputs.artifact_path }}"

--- a/.github/actions/publish-thunderstore/action.yml
+++ b/.github/actions/publish-thunderstore/action.yml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Unlicense
+name: Publish Thunderstore Package
+description: Upload and submit a prebuilt Thunderstore package zip.
+
+inputs:
+  artifact_path:
+    description: Path or shell glob for the package zip to upload.
+    required: true
+  token:
+    description: Thunderstore service account token.
+    required: true
+  namespace:
+    description: Thunderstore team namespace to publish under.
+    required: true
+  community:
+    description: Thunderstore community slug to publish to.
+    required: true
+  community_categories:
+    description: Newline-separated community category slugs.
+    required: true
+  repo:
+    description: Thunderstore repository base URL.
+    required: false
+    default: https://thunderstore.io
+
+outputs:
+  thunderstore_download_url:
+    description: Download URL of the published package version.
+    value: ${{ steps.publish.outputs.thunderstore_download_url }}
+  thunderstore_community_url:
+    description: Community package URL returned by Thunderstore.
+    value: ${{ steps.publish.outputs.thunderstore_community_url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Publish package
+      id: publish
+      shell: bash
+      env:
+        THUNDERSTORE_TOKEN: ${{ inputs.token }}
+        THUNDERSTORE_NAMESPACE: ${{ inputs.namespace }}
+        THUNDERSTORE_COMMUNITY: ${{ inputs.community }}
+        THUNDERSTORE_COMMUNITY_CATEGORIES: ${{ inputs.community_categories }}
+        THUNDERSTORE_REPO: ${{ inputs.repo }}
+      run: bash "${{ github.action_path }}/publish-thunderstore.sh" "${{ inputs.artifact_path }}"

--- a/.github/actions/publish-thunderstore/publish-thunderstore.sh
+++ b/.github/actions/publish-thunderstore/publish-thunderstore.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-artifact_path="${1:?Usage: publish-thunderstore.sh <package.zip>}"
+artifact_pattern="${1:?Usage: publish-thunderstore.sh <package.zip>}"
 
 : "${THUNDERSTORE_TOKEN:?THUNDERSTORE_TOKEN is required}"
 : "${THUNDERSTORE_NAMESPACE:?THUNDERSTORE_NAMESPACE is required}"
@@ -11,6 +11,20 @@ artifact_path="${1:?Usage: publish-thunderstore.sh <package.zip>}"
 : "${THUNDERSTORE_COMMUNITY_CATEGORIES:?THUNDERSTORE_COMMUNITY_CATEGORIES is required}"
 
 thunderstore_repo="${THUNDERSTORE_REPO:-https://thunderstore.io}"
+
+if [ -f "${artifact_pattern}" ]; then
+  artifact_path="${artifact_pattern}"
+else
+  mapfile -t artifact_matches < <(compgen -G "${artifact_pattern}")
+
+  if [ "${#artifact_matches[@]}" -ne 1 ]; then
+    echo "Expected exactly one Thunderstore artifact, found ${#artifact_matches[@]} for: ${artifact_pattern}" >&2
+    exit 1
+  fi
+
+  artifact_path="${artifact_matches[0]}"
+fi
+
 artifact_name=$(basename "${artifact_path}")
 artifact_size=$(wc -c < "${artifact_path}" | tr -d '[:space:]')
 

--- a/.github/scripts/publish-thunderstore.sh
+++ b/.github/scripts/publish-thunderstore.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Unlicense
+
+set -euo pipefail
+
+artifact_path="${1:?Usage: publish-thunderstore.sh <package.zip>}"
+
+: "${THUNDERSTORE_TOKEN:?THUNDERSTORE_TOKEN is required}"
+: "${THUNDERSTORE_NAMESPACE:?THUNDERSTORE_NAMESPACE is required}"
+: "${THUNDERSTORE_COMMUNITY:?THUNDERSTORE_COMMUNITY is required}"
+: "${THUNDERSTORE_COMMUNITY_CATEGORIES:?THUNDERSTORE_COMMUNITY_CATEGORIES is required}"
+
+thunderstore_repo="${THUNDERSTORE_REPO:-https://thunderstore.io}"
+artifact_name=$(basename "${artifact_path}")
+artifact_size=$(wc -c < "${artifact_path}" | tr -d '[:space:]')
+
+api_post() {
+  local url=$1
+  curl --fail-with-body --silent --show-error \
+    --request POST \
+    --header "Accept: application/json" \
+    --header "Authorization: Bearer ${THUNDERSTORE_TOKEN}" \
+    --header "Content-Type: application/json" \
+    --data @- \
+    "${url}"
+}
+
+upload_response=$(
+  jq --null-input --compact-output \
+    --arg filename "${artifact_name}" \
+    --argjson file_size_bytes "${artifact_size}" \
+    '{filename: $filename, file_size_bytes: $file_size_bytes}' \
+    | api_post "${thunderstore_repo}/api/experimental/usermedia/initiate-upload/"
+)
+
+upload_uuid=$(jq --raw-output '.user_media.uuid' <<< "${upload_response}")
+parts_file=$(mktemp)
+trap 'rm -f "${parts_file}"' EXIT
+
+jq --compact-output '.upload_urls[]' <<< "${upload_response}" | while read -r upload_part; do
+  part_number=$(jq --raw-output '.part_number' <<< "${upload_part}")
+  part_offset=$(jq --raw-output '.offset' <<< "${upload_part}")
+  part_length=$(jq --raw-output '.length' <<< "${upload_part}")
+  part_url=$(jq --raw-output '.url' <<< "${upload_part}")
+  headers_file=$(mktemp)
+
+  dd if="${artifact_path}" bs=1 skip="${part_offset}" count="${part_length}" status=none \
+    | curl --fail-with-body --silent --show-error \
+      --request PUT \
+      --dump-header "${headers_file}" \
+      --output /dev/null \
+      --data-binary @- \
+      "${part_url}"
+
+  etag=$(
+    awk 'tolower($1) == "etag:" { value = $2; sub(/\r$/, "", value); print value }' "${headers_file}" \
+      | tail -n 1
+  )
+  rm -f "${headers_file}"
+
+  if [ -z "${etag}" ]; then
+    echo "Thunderstore upload part ${part_number} did not return an ETag header." >&2
+    exit 1
+  fi
+
+  jq --null-input --compact-output \
+    --arg etag "${etag}" \
+    --argjson part_number "${part_number}" \
+    '{"ETag": $etag, "PartNumber": $part_number}' \
+    >> "${parts_file}"
+done
+
+jq --slurp --compact-output '{parts: .}' "${parts_file}" \
+  | api_post "${thunderstore_repo}/api/experimental/usermedia/${upload_uuid}/finish-upload/" \
+  > /dev/null
+
+community_categories=$(
+  printf '%s\n' "${THUNDERSTORE_COMMUNITY_CATEGORIES}" \
+    | tr '[:space:]' '\n' \
+    | sed '/^$/d' \
+    | jq --raw-input . \
+    | jq --slurp --compact-output .
+)
+
+submission_response=$(
+  jq --null-input --compact-output \
+    --arg author_name "${THUNDERSTORE_NAMESPACE}" \
+    --arg community "${THUNDERSTORE_COMMUNITY}" \
+    --arg upload_uuid "${upload_uuid}" \
+    --argjson community_categories "${community_categories}" \
+    '{
+      author_name: $author_name,
+      categories: [],
+      community_categories: {($community): $community_categories},
+      communities: [$community],
+      has_nsfw_content: false,
+      upload_uuid: $upload_uuid
+    }' \
+    | api_post "${thunderstore_repo}/api/experimental/submission/submit/"
+)
+
+download_url=$(jq --raw-output '.package_version.download_url // empty' <<< "${submission_response}")
+community_url=$(jq --raw-output '.available_communities[0].url // empty' <<< "${submission_response}")
+
+{
+  echo "thunderstore_download_url=${download_url}"
+  echo "thunderstore_community_url=${community_url}"
+} >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,6 +158,7 @@ jobs:
           namespace: aoirint
           community: lethal-company
           community_categories: |
+            ai-generated
             mods
             tweaks-and-quality-of-life
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
       - build
     if: needs.build.outputs.release_mode != 'edge'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     permissions:
       contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,14 +151,15 @@ jobs:
       - name: Publish stable release to Thunderstore
         id: publish-thunderstore
         if: needs.build.outputs.release_mode == 'latest'
-        env:
-          THUNDERSTORE_TOKEN: ${{ secrets.THUNDERSTORE_TOKEN }}
-          THUNDERSTORE_NAMESPACE: aoirint
-          THUNDERSTORE_COMMUNITY: lethal-company
-          THUNDERSTORE_COMMUNITY_CATEGORIES: |
+        uses: ./.github/actions/publish-thunderstore
+        with:
+          artifact_path: ./tmp_artifacts/*.zip
+          token: ${{ secrets.THUNDERSTORE_TOKEN }}
+          namespace: aoirint
+          community: lethal-company
+          community_categories: |
             mods
             tweaks-and-quality-of-life
-        run: bash ./.github/scripts/publish-thunderstore.sh ./tmp_artifacts/*.zip
 
       - name: Add Thunderstore summary
         if: steps.publish-thunderstore.outcome == 'success'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,9 +160,9 @@ jobs:
           namespace: aoirint
           community: lethal-company
           community_categories: |
-            ai-generated
             mods
             tweaks-and-quality-of-life
+            ai-generated
 
       - name: Add Thunderstore summary
         if: steps.publish-thunderstore.outcome == 'success'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,8 @@ jobs:
       - build
     if: needs.build.outputs.release_mode != 'edge'
 
+    # Keep this on ubuntu-slim: release publishing only needs standard shell tools
+    # included in that image, and does not require ubuntu-latest's larger toolset.
     runs-on: ubuntu-slim
 
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,12 +120,14 @@ jobs:
       - build
     if: needs.build.outputs.release_mode != 'edge'
 
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
 
     permissions:
       contents: write
 
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
       - name: Download build artifact
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
@@ -145,3 +147,25 @@ jobs:
             ./tmp_artifacts/*.zip
           artifactErrorsFailBuild: true
           artifactContentType: application/zip
+
+      - name: Publish stable release to Thunderstore
+        id: publish-thunderstore
+        if: needs.build.outputs.release_mode == 'latest'
+        env:
+          THUNDERSTORE_TOKEN: ${{ secrets.THUNDERSTORE_TOKEN }}
+          THUNDERSTORE_NAMESPACE: aoirint
+          THUNDERSTORE_COMMUNITY: lethal-company
+          THUNDERSTORE_COMMUNITY_CATEGORIES: |
+            mods
+            tweaks-and-quality-of-life
+        run: bash ./.github/scripts/publish-thunderstore.sh ./tmp_artifacts/*.zip
+
+      - name: Add Thunderstore summary
+        if: steps.publish-thunderstore.outcome == 'success'
+        run: |
+          {
+            echo "| Metric | Value |"
+            echo "| :----- | :---- |"
+            echo "| Thunderstore Package | [Open](${{ steps.publish-thunderstore.outputs.thunderstore_community_url }}) |"
+            echo "| Thunderstore Download | [Download](${{ steps.publish-thunderstore.outputs.thunderstore_download_url }}) |"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Added
+
+- Automated stable-release publishing to Thunderstore from GitHub Actions using
+  the Thunderstore API, reducing the need for manual artifact handling.
+
 ### Changed
 
 - Refactored internal architecture to improve maintainability.
 - Dropped backward compatibility with CruiserJumpPractice v0.1.4 and earlier
   because the internal NetworkBehaviour name changed.
+- Marked automated Thunderstore uploads with the `AI Generated`, `Mods`, and
+  `Tweaks & Quality Of Life` Thunderstore categories.
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Refactored internal architecture to improve maintainability.
 - Dropped backward compatibility with CruiserJumpPractice v0.1.4 and earlier
   because the internal NetworkBehaviour name changed.
-- Marked automated Thunderstore uploads with the `AI Generated`, `Mods`, and
-  `Tweaks & Quality Of Life` Thunderstore categories.
+- Marked automated Thunderstore uploads with the `Mods`,
+  `Tweaks & Quality Of Life`, and `AI Generated` Thunderstore categories.
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Stable releases are published to Thunderstore from CI using the local
 
 The token must belong to a Thunderstore service account that can publish to the
 `aoirint` team. The current workflow publishes to the `lethal-company`
-community with the `AI Generated`, `Mods`, and `Tweaks & Quality Of Life`
+community with the `Mods`, `Tweaks & Quality Of Life`, and `AI Generated`
 categories.
 
 ```powershell

--- a/README.md
+++ b/README.md
@@ -51,8 +51,14 @@ The repository uses GitHub Actions for CI.
 
 The version of the actions are pinned with [pinact](https://github.com/suzuki-shunsuke/pinact).
 
-Stable releases are published to Thunderstore from CI using the `THUNDERSTORE_TOKEN` repository secret.
-The token must belong to a Thunderstore service account that can publish to the `aoirint` team.
+Stable releases are published to Thunderstore from CI using the local
+`.github/actions/publish-thunderstore` composite action and the
+`THUNDERSTORE_TOKEN` repository secret.
+
+The token must belong to a Thunderstore service account that can publish to the
+`aoirint` team. The current workflow publishes to the `lethal-company`
+community with the `AI Generated`, `Mods`, and `Tweaks & Quality Of Life`
+categories.
 
 ```powershell
 # Pin

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ The repository uses GitHub Actions for CI.
 
 The version of the actions are pinned with [pinact](https://github.com/suzuki-shunsuke/pinact).
 
+Stable releases are published to Thunderstore from CI using the `THUNDERSTORE_TOKEN` repository secret.
+The token must belong to a Thunderstore service account that can publish to the `aoirint` team.
+
 ```powershell
 # Pin
 pinact run
@@ -79,8 +82,8 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
    action updates `assets/manifest.json` from the project version.
 5. Commit and push the changes.
 6. CI will create a GitHub Release automatically.
-7. Download the release artifact from the GitHub Release page.
-8. Upload the artifact to Thunderstore. **NOTE: prerelease version is not supported, e.g. `1.2.3-beta.1`.**
+7. For stable releases, CI will upload the release artifact to Thunderstore automatically.
+   **NOTE: prerelease version is not supported, e.g. `1.2.3-beta.1`.**
 
 ### AI Disclosure
 


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Adds a local `.github/actions/publish-thunderstore` composite action that uploads a prebuilt Thunderstore package through the Thunderstore API.
- Updates the build workflow so stable releases publish to Thunderstore automatically after the GitHub Release is created.
- Keeps the release job on `ubuntu-slim`, with an inline workflow comment documenting why the larger `ubuntu-latest` image is unnecessary.
- Marks Thunderstore submissions with `Mods`, `Tweaks & Quality Of Life`, and `AI Generated` categories, with `AI Generated` listed last as a best-effort source-order hint.
- Documents the `THUNDERSTORE_TOKEN` secret requirement and records the release automation in `CHANGELOG.md`.

## Related Issues

- None.

## Notes for reviewers

- The Thunderstore upload path uses the existing release artifact instead of rebuilding or downloading assets manually.
- The workflow only publishes to Thunderstore when `release_mode == 'latest'`; prereleases still create only GitHub prereleases.
- Composite actions cannot access the `secrets` context directly, so the workflow explicitly passes `secrets.THUNDERSTORE_TOKEN` as the action `token` input.
- The token must be configured as the `THUNDERSTORE_TOKEN` repository secret before the first stable release using this workflow.
- Category display order is not guaranteed by Thunderstore; listing `AI Generated` last in the workflow is best-effort and keeps the source intent clear.

### AI disclosure

- Codex helped inspect the existing CI, Thunderstore package/API requirements, GitHub Actions secret handling, `ubuntu-slim` runner capabilities, Thunderstore category ordering behavior, and implement the workflow, composite action, script, and documentation updates.
- The generated changes were reviewed through local diffs and command-based checks listed below.

## Testing

### Automated checks

- `bash -n .github/actions/publish-thunderstore/publish-thunderstore.sh`
- `git diff --check origin/main..HEAD`
- `dotnet build --configuration Release`
- `dotnet format --no-restore --verify-no-changes`

### AI-assisted inspections

- Asked Codex to inspect the release workflow and Thunderstore publish path.
  - AI-assisted result: confirmed the workflow publishes only stable releases, uses the existing artifact, and exposes Thunderstore URLs as action outputs for the job summary.
- Asked Codex to verify composite action secret handling against GitHub Actions documentation.
  - AI-assisted result: confirmed passing `secrets.THUNDERSTORE_TOKEN` explicitly as an input is the documented pattern.
- Asked Codex to investigate whether the release job needs `ubuntu-latest`.
  - AI-assisted result: confirmed the publish action only needs standard shell tooling available on `ubuntu-slim`, so the job can remain on `ubuntu-slim`.
- Asked Codex to investigate whether `AI Generated` can be forced to display last.
  - AI-assisted result: found no Thunderstore ordering contract; the workflow lists it last only as a best-effort source-order hint.

### Manual checks

- Not run.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
