### PR TITLE
ci: update pinned GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       git_version: ${{ steps.generate-version.outputs.git_version }}
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Generate version
         id: generate-version
@@ -28,7 +28,7 @@ jobs:
           csproj_file: "CruiserJumpPractice/CruiserJumpPractice.csproj"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: '10.x'
           cache: true
@@ -76,7 +76,7 @@ jobs:
  
       - name: Upload artifact
         id: upload-artifact
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact
           path: ./tmp_artifacts/*.zip
@@ -128,16 +128,16 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download build artifact
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: artifact
           path: ./tmp_artifacts
 
       - name: Publish release
-        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1.20.0
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ needs.build.outputs.git_version }}
           commit: ${{ github.sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-slim
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: '10.x'
           cache: true

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
    community with the `Mods`, `Tweaks & Quality Of Life`, and `AI Generated` categories.
    The `THUNDERSTORE_TOKEN` secret must belong to a Thunderstore service account that can publish to that team.
 
-   **NOTE: prerelease version is not supported, e.g. `1.2.3-beta.1`.**
+   **NOTE: prerelease version is not supported by Thunderstore, e.g. `1.2.3-beta.1`.**
 
 ### AI Disclosure
 

--- a/README.md
+++ b/README.md
@@ -75,11 +75,7 @@ This repository currently does not use GitHub Actions variables.
 
 | Name | Used by | Description |
 | :--- | :------ | :---------- |
-| `THUNDERSTORE_TOKEN` | `.github/workflows/build.yml` | Thunderstore service account token used by `.github/actions/publish-thunderstore` to publish stable releases to the `aoirint` team. |
-
-The current workflow publishes stable releases to the `lethal-company`
-community with the `Mods`, `Tweaks & Quality Of Life`, and `AI Generated`
-categories.
+| `THUNDERSTORE_TOKEN` | `.github/workflows/build.yml` | Thunderstore service account token used by `.github/actions/publish-thunderstore`. |
 
 ## Build
 
@@ -102,6 +98,9 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
 5. Commit and push the changes.
 6. CI will create a GitHub Release automatically.
 7. For stable releases, CI will upload the release artifact to Thunderstore automatically.
+   The token must belong to a Thunderstore service account that can publish to the `aoirint` team.
+   The current workflow publishes to the `lethal-company` community with the `Mods`, `Tweaks & Quality Of Life`,
+   and `AI Generated` categories.
    **NOTE: prerelease version is not supported, e.g. `1.2.3-beta.1`.**
 
 ### AI Disclosure

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ categories.
 pinact run
 
 # Update
-pinact run --update
+pinact run --update --min-age 7
 ```
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To update the lock file after modifying your package references, run:
 dotnet restore --use-lock-file
 ```
 
-## GitHub Actions management
+## GitHub Actions
 
 The repository uses GitHub Actions for CI.
 
@@ -61,14 +61,23 @@ pinact run --min-age 7
 pinact run --update --min-age 7
 ```
 
-### Thunderstore publishing secret
+### GitHub Actions configuration
 
-Stable releases are published to Thunderstore from CI using the local
-`.github/actions/publish-thunderstore` composite action and the
-`THUNDERSTORE_TOKEN` repository secret.
+#### GitHub Variables
 
-The token must belong to a Thunderstore service account that can publish to the
-`aoirint` team. The current workflow publishes to the `lethal-company`
+This repository currently does not use GitHub Actions variables.
+
+| Name | Used by | Description |
+| :--- | :------ | :---------- |
+| None | Not applicable | No repository variables are currently used. |
+
+#### GitHub Secrets
+
+| Name | Used by | Description |
+| :--- | :------ | :---------- |
+| `THUNDERSTORE_TOKEN` | `.github/workflows/build.yml` | Thunderstore service account token used by `.github/actions/publish-thunderstore` to publish stable releases to the `aoirint` team. |
+
+The current workflow publishes stable releases to the `lethal-company`
 community with the `Mods`, `Tweaks & Quality Of Life`, and `AI Generated`
 categories.
 

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
 6. CI will create a GitHub Release automatically.
 7. For stable releases, CI will upload the release artifact to Thunderstore automatically.
 
-   The `THUNDERSTORE_TOKEN` secret must belong to a Thunderstore service account that can publish to the
-   `aoirint` team. The current workflow publishes to the `lethal-company` community with the `Mods`,
-   `Tweaks & Quality Of Life`, and `AI Generated` categories.
+   The current workflow deploys to the Thunderstore `aoirint` team and publishes to the `lethal-company`
+   community with the `Mods`, `Tweaks & Quality Of Life`, and `AI Generated` categories.
+   The `THUNDERSTORE_TOKEN` secret must belong to a Thunderstore service account that can publish to that team.
 
    **NOTE: prerelease version is not supported, e.g. `1.2.3-beta.1`.**
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ categories.
 
 ```powershell
 # Pin
-pinact run
+pinact run --min-age 7
 
 # Update
 pinact run --update --min-age 7

--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
 5. Commit and push the changes.
 6. CI will create a GitHub Release automatically.
 7. For stable releases, CI will upload the release artifact to Thunderstore automatically.
-   The token must belong to a Thunderstore service account that can publish to the `aoirint` team.
-   The current workflow publishes to the `lethal-company` community with the `Mods`, `Tweaks & Quality Of Life`,
-   and `AI Generated` categories.
+
+   The `THUNDERSTORE_TOKEN` secret must belong to a Thunderstore service account that can publish to the
+   `aoirint` team. The current workflow publishes to the `lethal-company` community with the `Mods`,
+   `Tweaks & Quality Of Life`, and `AI Generated` categories.
+
    **NOTE: prerelease version is not supported, e.g. `1.2.3-beta.1`.**
 
 ### AI Disclosure

--- a/README.md
+++ b/README.md
@@ -49,7 +49,19 @@ dotnet restore --use-lock-file
 
 The repository uses GitHub Actions for CI.
 
+### Action pinning
+
 The version of the actions are pinned with [pinact](https://github.com/suzuki-shunsuke/pinact).
+
+```powershell
+# Pin
+pinact run --min-age 7
+
+# Update
+pinact run --update --min-age 7
+```
+
+### Thunderstore publishing secret
 
 Stable releases are published to Thunderstore from CI using the local
 `.github/actions/publish-thunderstore` composite action and the
@@ -59,14 +71,6 @@ The token must belong to a Thunderstore service account that can publish to the
 `aoirint` team. The current workflow publishes to the `lethal-company`
 community with the `Mods`, `Tweaks & Quality Of Life`, and `AI Generated`
 categories.
-
-```powershell
-# Pin
-pinact run --min-age 7
-
-# Update
-pinact run --update --min-age 7
-```
 
 ## Build
 


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Update pinned GitHub Actions using `pinact run --update --min-age 7`.
- Reorganize the README GitHub Actions documentation into `Action pinning` and `GitHub Actions configuration`.
- Document that GitHub Actions variables are currently unused and list the `THUNDERSTORE_TOKEN` secret.
- Move Thunderstore target details into the Release instructions, where stable-release publishing is described.

## Related Issues

- None.

## Notes for reviewers

- `pinact` v3.9.0 was used because the latest v3.9.2 release was published on 2026-04-29, which is less than 7 days old as of 2026-05-03.
- Updated action versions were selected through pinact's `--min-age 7` option.
- PR conversation comments now include per-request `Update Note` / `Discussion Note` summaries for the follow-up changes.

### AI disclosure

- Codex prepared the branch, ran the pinact update, revised the README structure across follow-up requests, fixed the PR body formatting, and added PR conversation notes.

## Testing

### Automated checks

- `pinact run --update --min-age 7`
- `pinact run --verify`
- `git diff --check`

### AI-assisted inspections

- Human request: update README and current GitHub Actions using pinact with `--min-age 7`, then revise the README organization and PR reporting.
  - AI-assisted result: confirmed the diff updates README guidance, pinned workflow action references, GitHub Actions configuration documentation, Release notes, and PR metadata.

### Manual checks

- Not applicable.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
