### PR TITLE
docs(skills): codify PR follow-up workflow lessons

### DIFF
--- a/.agents/skills/git-worktree-workflow/SKILL.md
+++ b/.agents/skills/git-worktree-workflow/SKILL.md
@@ -53,6 +53,9 @@ If network access or Git metadata writes require approval, request it and contin
 - After creating the task worktree, make implementation changes there.
 - Do not remove another worktree unless the user explicitly asks.
 - If the branch or worktree path already exists, inspect it before reuse or choose a new descriptive name.
+- Once a branch has been pushed or attached to a pull request, do not amend, rebase, squash,
+  force-push, or otherwise rewrite its history unless the user explicitly asks for history
+  rewriting.
 
 ## Quality Check
 
@@ -68,4 +71,6 @@ The final quality check also includes reviewing the complete diff and recent com
 ## Pull Request Notes
 
 - Keep pull request titles and bodies consistent with `pull-request-quality-check`.
+- For later corrections on an already-pushed pull request branch, add follow-up commits on top of
+  the branch so review history remains visible.
 - Remove temporary PR body files from the worktree after creating or editing the pull request.

--- a/.agents/skills/issue-quality-check/SKILL.md
+++ b/.agents/skills/issue-quality-check/SKILL.md
@@ -57,6 +57,11 @@ Recommend sections only when they carry useful information:
 - `Verification`: commands, manual checks, or observations already performed.
 - `Notes`: limitations, related work, dependencies, or reviewer attention points.
 
+For follow-up issues, include durable origin context when useful, such as the pull request,
+review thread, issue, discussion, or investigation that caused the follow-up. When multiple related
+follow-up issues come from the same source, cross-link them in the issue bodies so future readers
+can trace the relationship without relying on transient comments elsewhere.
+
 ## Style
 
 - Write issue titles, issue bodies, and issue comments in English.

--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -149,6 +149,10 @@ Use `Update Note` or `Discussion Note` sections only when a human explicitly ask
 
 - Use `Update Note` for a concrete change that was just made to the pull request.
 - Use `Discussion Note` for a decision, tradeoff, or rationale that should remain visible in the PR thread.
+- If a human asks for "history so far", "notes so far", or similar retrospective PR-thread notes,
+  do not dump raw commit history. Create separate concise notes grouped by meaningful decision or
+  change theme, using `Update Note` for concrete PR changes and `Discussion Note` for decisions,
+  tradeoffs, or rationale.
 - Immediately after the required LLM alert and before the note heading, state which human prompt or user request the
   note answers. Use a short `Human request addressed: ...` line so the note naturally identifies the prompt source as
   human and can be reused as source material for `### AI-assisted inspections` in the pull request body. Do not classify


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Update `git-worktree-workflow` to prefer follow-up commits over history rewriting after a branch is pushed or attached
  to a pull request.
- Update `issue-quality-check` so follow-up issues preserve their origin context and cross-link related follow-ups.
- Update `pull-request-quality-check` so requested PR notes are grouped by meaningful decision or change theme instead
  of dumping raw commit history.

## Related Issues

- Split from #39.

## Notes for reviewers

- This is a focused Agent Skill follow-up extracted from the Markdown lint and quality-check PR.
- The guidance captures workflow decisions that became stable while preparing and revising #39.

### AI disclosure

- Codex used `empirical-prompt-tuning` from `mizchi/skills@2036fb480a8b442c7b6298595b38c9a7a25b97af` and evaluated the
  three skill areas separately rather than as one batch.

## Testing

### Automated checks

- `git diff --check origin/main...HEAD`

### AI-assisted inspections

- Request: evaluate each workflow lesson individually with empirical prompt tuning.
  - AI-assisted result: separate evaluations found and verified updates for pushed-PR history handling, follow-up issue
    traceability, and PR-thread notes.

### Manual checks

- Not applicable.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
