### PR TITLE
docs(skills): clarify CI configuration comment guidance

### DIFF
--- a/.agents/skills/code-quality-check/SKILL.md
+++ b/.agents/skills/code-quality-check/SKILL.md
@@ -92,6 +92,22 @@ When adding a comment:
   rewrite or reject, use a same-line comment or another nearby location that preserves the group.
 - Update nearby tests or verification notes if the comment documents behavior that must stay true.
 
+### CI and Configuration Comments
+
+For configuration-as-code, CI workflows, build files, and tool configuration, intent comments are
+most useful near non-obvious fixed values: pinned tool versions, runtime images, lockfile paths,
+ordering constraints, suppressions, generated-file exclusions, timeout values, matrices, or external
+action references.
+
+When commenting on those values:
+
+- Explain the maintenance signal as well as the initial reason: when maintainers should revisit the
+  value and what compatibility, reproducibility, security, or operational constraint must stay true.
+- Keep broad repeated update policy in one maintained document or shared workflow guidance when
+  repeating it beside every value would drift.
+- Use local comments for site-specific constraints, exceptions, or links to central policy.
+- Avoid comments that merely restate the YAML key, tool option, version literal, or file path.
+
 ## Developer-Facing Language
 
 Treat developer-facing text separately from user-facing text. This includes comments, log messages,


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Update `code-quality-check` with guidance for maintainable comments in CI and configuration files.
- Clarify when comments should explain non-obvious fixed values, update criteria, and operational constraints.
- Keep broad policy guidance centralized instead of repeating version-update policy beside every pinned tool.

## Related Issues

- Split from #39.

## Notes for reviewers

- This is a focused Agent Skill follow-up extracted from the Markdown lint and quality-check PR.
- The guidance is intentionally about maintainer-facing rationale, not about restating YAML keys, action names, or
  literal option values.

### AI disclosure

- Codex used `empirical-prompt-tuning` from `mizchi/skills@2036fb480a8b442c7b6298595b38c9a7a25b97af` to evaluate the
  proposed skill change, then iterated once based on scenario feedback.

## Testing

### Automated checks

- `git diff --check origin/main...HEAD`

### AI-assisted inspections

- Request: evaluate configuration-comment guidance individually with empirical prompt tuning.
  - AI-assisted result: the baseline missed update/revisit criteria and risked duplicated policy; the revised guidance
    passed the targeted scenario without new unclear points.

### Manual checks

- Not applicable.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
