### PR TITLE
docs: define .NET tooling update policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
           csproj_file: "CruiserJumpPractice/CruiserJumpPractice.csproj"
 
       - name: Setup .NET
+        # Keep dotnet-version aligned with lint.yml per the README .NET and
+        # C# tooling update policy.
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: '10.x'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,11 +26,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET
-        # Keep dotnet-version aligned with build.yml so formatter and analyzer
-        # behavior matches compilation. If the project target SDK changes,
-        # update both workflows together. The cache path is intentionally the
-        # project lock file; update it only if the lock file moves or additional
-        # projects are added.
+        # Keep dotnet-version aligned with build.yml per the README .NET and
+        # C# tooling update policy. The cache path is intentionally the project
+        # lock file; update it only if the lock file moves or projects are
+        # added.
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: '10.x'

--- a/README.md
+++ b/README.md
@@ -60,15 +60,18 @@ framework that controls runtime compatibility.
 - Keep `TargetFramework` on `netstandard2.1` unless the supported Lethal
   Company, BepInEx, Unity, and dependency versions justify a compatibility
   change.
-- Prefer the latest supported .NET SDK major that works in GitHub Actions and
-  Visual Studio 2022. .NET even-numbered releases are LTS and odd-numbered
-  releases are STS; do not move CI or contributor setup to an unsupported SDK.
-- Update `actions/setup-dotnet` `dotnet-version` values in build and lint
-  workflows together so compilation, analyzer, and formatter behavior stay
-  aligned.
+- Prefer a supported LTS .NET SDK for routine maintenance. Adopt an STS or
+  newer SDK major only when a specific compiler, formatter, analyzer, CI, or
+  Visual Studio compatibility reason justifies the shorter support window.
+  .NET even-numbered releases are LTS and odd-numbered releases are STS; do
+  not move CI or contributor setup to an unsupported SDK.
+- Update the README SDK requirement and `actions/setup-dotnet` `dotnet-version`
+  values in build and lint workflows together so compilation, analyzer, and
+  formatter behavior stay aligned.
 - Keep `LangVersion` explicit when the project intentionally uses a specific
   C# version. Review Visual Studio support, CI SDK support, and mod dependency
-  compatibility before increasing it.
+  compatibility before increasing it, and keep the C# format summary above in
+  sync with the project file.
 - Treat analyzer package, formatter, SDK, and workflow action updates as
   tooling changes. Preserve `dotnet restore --locked-mode`,
   `dotnet format --no-restore --verify-no-changes`, and

--- a/README.md
+++ b/README.md
@@ -57,49 +57,21 @@ including diagnostics that cannot be automatically fixed.
 This project separates the SDK used to build and format the mod from the target
 framework that controls runtime compatibility.
 
-- Keep `TargetFramework` on `netstandard2.1` unless the supported Lethal
-  Company, BepInEx, Unity, and dependency versions justify a compatibility
-  change.
-- Prefer a supported LTS .NET SDK for routine maintenance. Adopt an STS or
-  newer SDK major only when a specific compiler, formatter, analyzer, CI, or
-  Visual Studio compatibility reason justifies the shorter support window.
-  .NET even-numbered releases are LTS and odd-numbered releases are STS; do
-  not move CI or contributor setup to an unsupported SDK.
-- Update the README SDK requirement and `actions/setup-dotnet` `dotnet-version`
-  values in build and lint workflows together so compilation, analyzer, and
-  formatter behavior stay aligned.
-- Keep `LangVersion` explicit when the project intentionally uses a specific
-  C# version. Review Visual Studio support, CI SDK support, and mod dependency
-  compatibility before increasing it, and keep the C# format summary above in
-  sync with the project file.
-- Treat analyzer package, formatter, SDK, and workflow action updates as
-  tooling changes. Preserve `dotnet restore --locked-mode`,
-  `dotnet format --no-restore --verify-no-changes`, and
-  `dotnet build --no-restore --configuration Release` behavior unless the
-  pull request explicitly documents why a behavior change is needed.
-- When updating analyzer packages, update `packages.lock.json` with
-  `dotnet restore --use-lock-file`, review new diagnostics, and document
-  intentional rule or severity changes in the pull request.
-
-Use this operating model for tooling maintenance:
-
-- Handle routine SDK, formatter, analyzer, and workflow action updates in
-  maintenance-only pull requests, separate from gameplay or mod behavior
-  changes.
-- Before proposing an SDK or `LangVersion` change, confirm the new combination
-  is supported by GitHub Actions, Visual Studio 2022, and the current
-  `netstandard2.1` target. Record that compatibility check in the pull request.
-- If `dotnet format` or analyzers report new diagnostics after a tooling
-  update, split mechanical formatting fixes from intentional rule or code
-  changes when practical. Call out any new diagnostic category that reviewers
-  should inspect.
-- Keep build and lint behavior stable by default. A tooling update PR should
-  run and report `dotnet restore --locked-mode`,
-  `dotnet format --no-restore --verify-no-changes`,
-  `dotnet build --no-restore --configuration Release`, and Markdown lint.
-- Defer a tooling update instead of merging around it when CI image support,
-  Visual Studio support, dependency compatibility, or analyzer impact is
-  unclear.
+- Keep `TargetFramework` on `netstandard2.1` unless Lethal Company, BepInEx,
+  Unity, or compile-only dependencies require a compatibility change.
+- Prefer supported LTS SDKs for routine maintenance. Use an STS or newer SDK
+  major only when it solves a specific compiler, formatter, analyzer, CI, or
+  Visual Studio problem.
+- Keep SDK updates in maintenance-only pull requests. Update the README SDK
+  requirement and both workflow `dotnet-version` values together.
+- Keep `LangVersion` explicit. Before increasing it, confirm SDK, Visual Studio
+  2022, and dependency compatibility, then update the C# format summary above.
+- For analyzer updates, update `packages.lock.json`, review new diagnostics,
+  and separate mechanical formatting from intentional rule or code changes when
+  practical.
+- Preserve existing restore, format, build, and Markdown lint behavior by
+  default. Record compatibility checks and verification commands in the pull
+  request, and defer the update when the impact is unclear.
 
 Maintenance references:
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,39 @@ dotnet format --no-restore --verify-no-changes
 style, and fixable analyzer diagnostics. Roslyn analyzers also run during build,
 including diagnostics that cannot be automatically fixed.
 
+### .NET and C# tooling updates
+
+This project separates the SDK used to build and format the mod from the target
+framework that controls runtime compatibility.
+
+- Keep `TargetFramework` on `netstandard2.1` unless the supported Lethal
+  Company, BepInEx, Unity, and dependency versions justify a compatibility
+  change.
+- Prefer the latest supported .NET SDK major that works in GitHub Actions and
+  Visual Studio 2022. .NET even-numbered releases are LTS and odd-numbered
+  releases are STS; do not move CI or contributor setup to an unsupported SDK.
+- Update `actions/setup-dotnet` `dotnet-version` values in build and lint
+  workflows together so compilation, analyzer, and formatter behavior stay
+  aligned.
+- Keep `LangVersion` explicit when the project intentionally uses a specific
+  C# version. Review Visual Studio support, CI SDK support, and mod dependency
+  compatibility before increasing it.
+- Treat analyzer package, formatter, SDK, and workflow action updates as
+  tooling changes. Preserve `dotnet restore --locked-mode`,
+  `dotnet format --no-restore --verify-no-changes`, and
+  `dotnet build --no-restore --configuration Release` behavior unless the
+  pull request explicitly documents why a behavior change is needed.
+- When updating analyzer packages, update `packages.lock.json` with
+  `dotnet restore --use-lock-file`, review new diagnostics, and document
+  intentional rule or severity changes in the pull request.
+
+Maintenance references:
+
+- [.NET releases and support](https://learn.microsoft.com/en-us/dotnet/core/releases-and-support)
+- [.NET SDK, MSBuild, and Visual Studio versioning](https://learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs)
+- [Configure C# language version](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version)
+- [`dotnet format`](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-format)
+
 ### Markdown lint
 
 Markdown is checked with `markdownlint-cli2`. The project uses the pinned Docker

--- a/README.md
+++ b/README.md
@@ -81,6 +81,26 @@ framework that controls runtime compatibility.
   `dotnet restore --use-lock-file`, review new diagnostics, and document
   intentional rule or severity changes in the pull request.
 
+Use this operating model for tooling maintenance:
+
+- Handle routine SDK, formatter, analyzer, and workflow action updates in
+  maintenance-only pull requests, separate from gameplay or mod behavior
+  changes.
+- Before proposing an SDK or `LangVersion` change, confirm the new combination
+  is supported by GitHub Actions, Visual Studio 2022, and the current
+  `netstandard2.1` target. Record that compatibility check in the pull request.
+- If `dotnet format` or analyzers report new diagnostics after a tooling
+  update, split mechanical formatting fixes from intentional rule or code
+  changes when practical. Call out any new diagnostic category that reviewers
+  should inspect.
+- Keep build and lint behavior stable by default. A tooling update PR should
+  run and report `dotnet restore --locked-mode`,
+  `dotnet format --no-restore --verify-no-changes`,
+  `dotnet build --no-restore --configuration Release`, and Markdown lint.
+- Defer a tooling update instead of merging around it when CI image support,
+  Visual Studio support, dependency compatibility, or analyzer impact is
+  unclear.
+
 Maintenance references:
 
 - [.NET releases and support](https://learn.microsoft.com/en-us/dotnet/core/releases-and-support)


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Adds README guidance for updating the .NET SDK, C# language version, analyzers, and formatter-related tooling.
- Documents current maintenance references for .NET support, SDK/Visual Studio compatibility, C# language versioning, and `dotnet format`.
- Points CI comments at the README policy instead of duplicating SDK update rules in workflow comments.

## Related Issues

- Closes #42

## Notes for reviewers

- No SDK, language version, analyzer package, formatter, or CI behavior change is intended.
- The policy is based on current Microsoft Learn guidance for .NET releases/support, SDK/MSBuild/Visual Studio versioning, C# language version configuration, and `dotnet format`.

### AI disclosure

- Codex researched the current official .NET/C# tooling guidance, drafted the README policy, updated CI comments, and reviewed the diff.

## Testing

### Automated checks

- `docker run --rm --network none -v "${PWD}:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5`
- `git diff --check`

### AI-assisted inspections

- None.

### Manual checks

- Reviewed the README policy against official Microsoft Learn guidance.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.