### PR TITLE
docs(ci): document build workflow intent

### DIFF
--- a/.github/actions/generate-version/action.yml
+++ b/.github/actions/generate-version/action.yml
@@ -3,6 +3,8 @@ description: "Generate application and git version based on csproj version and g
 
 inputs:
   csproj_file:
+    # This file must contain APP_VERSION_MARKER immediately before <Version>;
+    # the marker avoids broad XML edits while keeping the action shell-only.
     description: 'csproj file path'
     required: true
 
@@ -25,8 +27,8 @@ runs:
       id: csproj-version
       shell: bash
       run: |
-        # Read the version from the next line after APP_VERSION_MARKER in the csproj file
-        # tr and xargs for trimming whitespace, line endings
+        # Read only the marker-adjacent Version element so unrelated XML
+        # metadata does not affect release classification.
         CSPROJ_VERSION=$(sed -n '/APP_VERSION_MARKER/{n; s|<Version>\(.*\)</Version>|\1|; p;}' "${{ inputs.csproj_file }}" | tr -d '\r' | xargs)
         echo "version=${CSPROJ_VERSION}" >> "${GITHUB_OUTPUT}"
 
@@ -34,16 +36,15 @@ runs:
       id: release-mode
       shell: bash
       run: |
-        # New version: Latest mode
-        # Known version: Edge mode
-
         CSPROJ_VERSION="${{ steps.csproj-version.outputs.version }}"
 
+        # Tags are fetched here, not by checkout, because release mode depends
+        # on the remote tag set at the moment the build runs.
         git fetch --tags
         if git rev-parse "refs/tags/v${CSPROJ_VERSION}" >/dev/null 2>&1; then
           echo "mode=edge" >> "${GITHUB_OUTPUT}"
         elif [[ "${CSPROJ_VERSION}" == "0.0.0" ]]; then
-          # Early development version
+          # Keep the placeholder development version from publishing releases.
           echo "mode=edge" >> "${GITHUB_OUTPUT}"
         elif [[ "${CSPROJ_VERSION}" == *"-"* ]]; then
           echo "mode=prerelease" >> "${GITHUB_OUTPUT}"
@@ -55,13 +56,12 @@ runs:
       id: app-version
       shell: bash
       run: |
-        # Edge mode: {csproj_version}-edge.{date}.{short_sha}
-        # Prerelease mode: {csproj_version}-{prerelease}
-        # Latest mode: {csproj_version}
         CSPROJ_VERSION="${{ steps.csproj-version.outputs.version }}"
         RELEASE_MODE="${{ steps.release-mode.outputs.mode }}"
 
         if [ "${RELEASE_MODE}" = "edge" ]; then
+          # Edge artifacts need globally unique SemVer-compatible versions so
+          # repeated main-branch builds do not collide with published packages.
           DATE_STRING=$(date -u "+%Y-%m-%dT%H-%M-%SZ")
           SHA_SHORT="${GITHUB_SHA:0:7}"
           APP_VERSION="${CSPROJ_VERSION}-edge.${DATE_STRING}.${SHA_SHORT}"
@@ -81,12 +81,16 @@ runs:
     - name: Replace version in csproj
       shell: bash
       run: |
+        # The generated version is written back before build so the compiled
+        # assembly and package metadata describe the same artifact.
         APP_VERSION="${{ steps.app-version.outputs.version }}"
         sed -i "/APP_VERSION_MARKER/{n; s|<Version>.*</Version>|<Version>${APP_VERSION}</Version>|;}" "${{ inputs.csproj_file }}"
 
     - name: Replace version in manifest.json
       shell: bash
       run: |
+        # Thunderstore reads version_number from the manifest inside the zip,
+        # so keep it synchronized with the build-time package version.
         APP_VERSION="${{ steps.app-version.outputs.version }}"
         jq --arg ver "${APP_VERSION}" '.version_number = $ver' assets/manifest.json > assets/manifest.tmp.json
         mv assets/manifest.tmp.json assets/manifest.json

--- a/.github/actions/publish-thunderstore/action.yml
+++ b/.github/actions/publish-thunderstore/action.yml
@@ -4,6 +4,8 @@ description: Upload and submit a prebuilt Thunderstore package zip.
 
 inputs:
   artifact_path:
+    # Accept a glob from the workflow so the action stays independent of the
+    # generated package version while the script still enforces one match.
     description: Path or shell glob for the package zip to upload.
     required: true
   token:
@@ -16,9 +18,13 @@ inputs:
     description: Thunderstore community slug to publish to.
     required: true
   community_categories:
+    # Keep categories newline-separated in workflow YAML; the script normalizes
+    # this to the JSON array expected by Thunderstore's submission API.
     description: Newline-separated community category slugs.
     required: true
   repo:
+    # This exists for tests or API migrations; production should use the
+    # default Thunderstore host unless the service endpoint changes.
     description: Thunderstore repository base URL.
     required: false
     default: https://thunderstore.io
@@ -38,6 +44,8 @@ runs:
       id: publish
       shell: bash
       env:
+        # Pass inputs through env vars so the script can fail early on missing
+        # secrets and avoid printing sensitive token values in shell arguments.
         THUNDERSTORE_TOKEN: ${{ inputs.token }}
         THUNDERSTORE_NAMESPACE: ${{ inputs.namespace }}
         THUNDERSTORE_COMMUNITY: ${{ inputs.community }}

--- a/.github/actions/publish-thunderstore/publish-thunderstore.sh
+++ b/.github/actions/publish-thunderstore/publish-thunderstore.sh
@@ -15,6 +15,8 @@ thunderstore_repo="${THUNDERSTORE_REPO:-https://thunderstore.io}"
 if [ -f "${artifact_pattern}" ]; then
   artifact_path="${artifact_pattern}"
 else
+  # Release publishing must fail if packaging ever creates zero or multiple
+  # zips; Thunderstore submissions should map to exactly one package version.
   mapfile -t artifact_matches < <(compgen -G "${artifact_pattern}")
 
   if [ "${#artifact_matches[@]}" -ne 1 ]; then
@@ -51,6 +53,8 @@ upload_uuid=$(jq --raw-output '.user_media.uuid' <<< "${upload_response}")
 parts_file=$(mktemp)
 trap 'rm -f "${parts_file}"' EXIT
 
+# Thunderstore returns presigned upload parts for larger files; upload each
+# byte range exactly as requested and collect the ETags required to finalize.
 jq --compact-output '.upload_urls[]' <<< "${upload_response}" | while read -r upload_part; do
   part_number=$(jq --raw-output '.part_number' <<< "${upload_part}")
   part_offset=$(jq --raw-output '.offset' <<< "${upload_part}")
@@ -89,6 +93,8 @@ jq --slurp --compact-output '{parts: .}' "${parts_file}" \
   > /dev/null
 
 community_categories=$(
+  # Workflow YAML keeps categories readable as lines; Thunderstore requires a
+  # compact JSON array under the community-specific category map.
   printf '%s\n' "${THUNDERSTORE_COMMUNITY_CATEGORIES}" \
     | tr '[:space:]' '\n' \
     | sed '/^$/d' \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,8 @@ defaults:
 
 jobs:
   build:
-    # Build keeps ubuntu-latest because the artifact step depends on the
-    # image-provided .NET, jq, and 7z toolchain used by the release package.
+    # Build keeps ubuntu-latest because packaging currently relies on
+    # runner-provided shell tools such as jq and 7z.
     runs-on: ubuntu-latest
 
     outputs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ defaults:
 
 jobs:
   build:
+    # Build keeps ubuntu-latest because the artifact step depends on the
+    # image-provided .NET, jq, and 7z toolchain used by the release package.
     runs-on: ubuntu-latest
 
     outputs:
@@ -19,6 +21,8 @@ jobs:
       git_version: ${{ steps.generate-version.outputs.git_version }}
 
     steps:
+      # Checkout is required before generating versions because the local
+      # composite action reads project files and fetches tags from this clone.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Generate version
@@ -37,6 +41,8 @@ jobs:
           cache-dependency-path: CruiserJumpPractice/packages.lock.json
 
       - name: Restore NuGet packages
+        # Restore once in locked mode so build uses the committed dependency
+        # graph and does not rewrite package resolution in CI.
         run: dotnet restore --locked-mode
 
       - name: Record start time
@@ -58,7 +64,8 @@ jobs:
 
           mkdir -p "${TMP_ARTIFACT_DIR}/${ARTIFACT_STEM}"
 
-          # Package format
+          # Keep this layout as the Thunderstore package root; consumers expect
+          # the DLL, manifest, icon, docs, changelog, and license at zip root.
           # https://thunderstore.io/c/lethal-company/create/docs/
 
           mv ./CruiserJumpPractice/bin/Release/netstandard2.1/com.aoirint.CruiserJumpPractice.dll  "${TMP_ARTIFACT_DIR}/${ARTIFACT_STEM}/"
@@ -78,6 +85,8 @@ jobs:
  
       - name: Upload artifact
         id: upload-artifact
+        # The package is already a zip file, so upload it without recompressing
+        # to keep the digest and download size tied to the release payload.
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact
@@ -120,6 +129,8 @@ jobs:
   release:
     needs:
       - build
+    # Edge builds are validation artifacts only; GitHub releases are created
+    # only for new project versions that should receive a tag.
     if: needs.build.outputs.release_mode != 'edge'
 
     # Keep this on ubuntu-slim: release publishing only needs standard shell tools
@@ -130,6 +141,8 @@ jobs:
       contents: write
 
     steps:
+      # Checkout is needed even though the package is downloaded, because the
+      # Thunderstore publisher is a repository-local composite action.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download build artifact
@@ -139,6 +152,8 @@ jobs:
           path: ./tmp_artifacts
 
       - name: Publish release
+        # Create immutable releases so an already-published version cannot be
+        # silently replaced by a later workflow run for the same tag.
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ needs.build.outputs.git_version }}
@@ -154,6 +169,8 @@ jobs:
 
       - name: Publish stable release to Thunderstore
         id: publish-thunderstore
+        # Thunderstore does not accept the prerelease versions generated here,
+        # so only stable latest releases are published to the community.
         if: needs.build.outputs.release_mode == 'latest'
         uses: ./.github/actions/publish-thunderstore
         with:


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Add concise intent comments to the build workflow for runner selection, restore behavior, artifact packaging, release creation, and Thunderstore publishing conditions.
- Document non-obvious constraints in local composite actions for version generation and Thunderstore publishing.
- Preserve existing CI behavior; this is documentation/comment-only.

## Related Issues

- Closes #40

## Notes for reviewers

- `actionlint` was not available in the local environment, so workflow validation was limited to diff whitespace checks and shell syntax for the changed script.

### AI disclosure

- Codex helped inspect the workflow/action files, draft the intent comments, run local checks, and prepare this pull request. The resulting diff was reviewed before commit.

## Testing

### Automated checks

- `bash -n .github/actions/publish-thunderstore/publish-thunderstore.sh`
- `git diff --check`
- `git diff --check origin/main...HEAD`

### Manual checks

- Reviewed the final diff to confirm changes are comments only and do not modify workflow keys, action inputs, or script behavior.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
