### PR TITLE
docs(changelog): add alpha release history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,8 +167,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
-        - Backfilled as reference compatibility information in
-          v0.2.0-alpha.1.
+        - Backfilled as reference compatibility information when preparing
+          the v0.2.0-alpha.1 release.
 - Test environment:
     - Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`)
@@ -202,8 +202,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
-        - Backfilled as reference compatibility information in
-          v0.2.0-alpha.1.
+        - Backfilled as reference compatibility information when preparing
+          the v0.2.0-alpha.1 release.
 
 ## v0.1.1 - 2025-11-29 UTC
 
@@ -216,8 +216,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
-        - Backfilled as reference compatibility information in
-          v0.2.0-alpha.1.
+        - Backfilled as reference compatibility information when preparing
+          the v0.2.0-alpha.1 release.
 
 ## v0.1.0 - 2025-11-29 UTC
 
@@ -230,5 +230,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
-        - Backfilled as reference compatibility information in
-          v0.2.0-alpha.1.
+        - Backfilled as reference compatibility information when preparing
+          the v0.2.0-alpha.1 release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added repository-local Agent Skills and `AGENTS.md` guidance for commit
   message checks, pull request quality checks, and agent workflow conventions.
 - Added AI disclosure documentation to the repository README and Thunderstore
-  package README to satisfy Thunderstore policy expectations.
+  package README for Thunderstore policy compliance.
 
 ### Changed
 
@@ -62,13 +62,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   UnityEngine.Modules 2022.3.62.
 - Replaced `RestoreAdditionalProjectSources` with an explicit `nuget.config`
   and package source mapping to make dependency restores more deterministic.
-- Renamed interop adapters from `V73` to `Current` and removed game-version
-  suffixes from reference aliases after confirming NuGet cannot support the
-  intended static multi-version validation model without manual DLL management.
+- Renamed interop adapters from `V73` to `Current`, then removed game-version
+  suffixes from reference aliases after confirming static multi-version
+  validation is not practical with NuGet-managed package references.
 - Simplified redundant network role guards in RPC surrogate and frame-handling
   paths.
 - Updated Thunderstore README compatibility language to focus on the latest
-  stable Lethal Company version, with older versions treated as best-effort.
+  stable Lethal Company version.
 - Documented safer GitHub CLI pull request body handling so Markdown is passed
   through body files and verified after creation.
 
@@ -87,26 +87,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
       `6423525044216269478`).
-    - Lethal Company v73 and v56 compatibility became best-effort rather than
-      something validated statically through parallel NuGet references.
+    - Lethal Company v73 and v56 compatibility became best-effort after the
+      project stopped pursuing static multi-version validation through NuGet
+      references.
 
 ## v0.2.0-alpha.1 - 2026-04-25 UTC
 
 ### Changed
 
-- Refactored the runtime from a manager-centered structure into a layered
+- Refactored the runtime from a manager-centered structure into layered
   application architecture with a composition root, domain models, explicit use
-  case result types, client/server services, and frame/startup runtime
-  handlers.
-- Replaced direct base-game utility access with an `IGameInterop` abstraction
+  case result types, client/server services, and frame/startup handlers.
+- Replaced direct base game utility access with an `IGameInterop` abstraction
   and adapter layer so future game-version work can be isolated behind interop
   boundaries.
 - Centralized in-game notifications through a notification use case for more
   consistent save, load, and magnet-toggle result handling.
 - Split cruiser state and magnet behavior into explicit save/load/toggle use
   cases while preserving the existing user-facing gameplay flow.
-- Changed the internal network behaviour and interop layout, making this alpha
-  line not backward-compatible with CruiserJumpPractice v0.1.4 and earlier.
+- Changed the internal `NetworkBehaviour` and interop layout, making this
+  alpha release not backward-compatible with CruiserJumpPractice v0.1.4 and
+  earlier.
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,9 +110,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
       `6423525044216269478`).
-    - Lethal Company v73 and v56 compatibility became best-effort after the
-      project stopped pursuing static multi-version validation through NuGet
-      references.
+    - Older base-game compatibility became best-effort after the project
+      stopped pursuing static multi-version validation through NuGet
+      references:
+        - Lethal Company v73 still appeared to work.
+        - Lethal Company v56 had lower-confidence compatibility, with a known
+          minor issue found early.
 
 ## v0.2.0-alpha.1 - 2026-04-25 UTC
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Refactored internal architecture to improve maintainability.
 - Dropped backward compatibility with older CruiserJumpPractice versions:
     - Affects CruiserJumpPractice v0.1.4 and earlier.
-    - Caused by this mod's internal `NetworkBehaviour` name change.
+    - Caused by a mod-internal `NetworkBehaviour` name change in
+      CruiserJumpPractice.
 - Marked automated Thunderstore uploads with an additional Thunderstore
   category:
     - `AI Generated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
       `6423525044216269478`).
     - Lethal Company v73 still appears to work.
-    - Lethal Company v56 mostly works, with a known minor issue tracked in
-      <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
+    - Lethal Company v56 has lower-confidence compatibility:
+        - Core features appear to work in limited checks.
+        - A known minor issue was found early and is tracked in
+          <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
     - Imperium v1.3.0 appears to have some cruiser-related issues:
         - See
           <https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735>
@@ -145,8 +147,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
         - Later withdrawn as explicit support wording in v0.2.0-alpha.2.
-    - Lethal Company v56 mostly works, with a known minor issue tracked in
-      <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
+    - Lethal Company v56 has lower-confidence compatibility:
+        - Core features appeared to work in limited checks.
+        - A known minor issue was found early and is tracked in
+          <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
 - Test environment:
     - Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Refactored internal architecture to improve maintainability.
 - Dropped backward compatibility with older CruiserJumpPractice versions:
     - Affects CruiserJumpPractice v0.1.4 and earlier.
-    - Caused by a mod-internal `NetworkBehaviour` name change in
-      CruiserJumpPractice.
+    - Caused by a mod-internal `NetworkBehaviour` name change.
 - Marked automated Thunderstore uploads with an additional Thunderstore
   category:
     - `AI Generated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Notes
 
 - Compatibility:
+    - Compatibility notes were first added in v0.2.0-alpha.1:
+        - Earlier releases did not include compatibility information in this
+          changelog.
+        - Compatibility information for older releases was backfilled as
+          reference material at the same time.
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
         - Later withdrawn as explicit support wording in v0.2.0-alpha.2.
@@ -162,6 +167,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
+        - Backfilled as reference compatibility information in
+          v0.2.0-alpha.1.
 - Test environment:
     - Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`)
@@ -194,6 +201,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
+        - Backfilled as reference compatibility information in
+          v0.2.0-alpha.1.
 
 ## v0.1.1 - 2025-11-29 UTC
 
@@ -206,6 +215,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
+        - Backfilled as reference compatibility information in
+          v0.2.0-alpha.1.
 
 ## v0.1.0 - 2025-11-29 UTC
 
@@ -218,3 +229,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
+        - Backfilled as reference compatibility information in
+          v0.2.0-alpha.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Refactored internal architecture to improve maintainability.
 - Dropped backward compatibility with CruiserJumpPractice v0.1.4 and earlier
   because the internal NetworkBehaviour name changed.
-- Marked automated Thunderstore uploads with Thunderstore categories:
-    - `Mods`
-    - `Tweaks & Quality Of Life`
-    - `AI Generated`
+- Marked automated Thunderstore uploads with the `AI Generated` Thunderstore
+  category.
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - Added domain models and explicit use case result types.
     - Split client/server services and frame/startup handlers.
     - Later superseded by the stable-release roll-up and the follow-up
-      alpha.2 refactors.
+      v0.2.0-alpha.2 refactors.
 - Replaced direct base game utility access with an `IGameInterop` abstraction
   and adapter layer so future game-version work can be isolated behind interop
   boundaries.
@@ -130,9 +130,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   consistent save, load, and magnet-toggle result handling.
 - Split cruiser state and magnet behavior into explicit save/load/toggle use
   cases while preserving the existing user-facing gameplay flow.
-- Changed the internal `NetworkBehaviour` and interop layout, making this
-  alpha release not backward-compatible with CruiserJumpPractice v0.1.4 and
-  earlier.
+- Changed the internal `NetworkBehaviour` and interop layout, making the
+  v0.2.0-alpha.1 release not backward-compatible with CruiserJumpPractice
+  v0.1.4 and earlier.
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Refactored internal architecture to improve maintainability.
 - Dropped backward compatibility with older CruiserJumpPractice versions:
     - Affects CruiserJumpPractice v0.1.4 and earlier.
-    - Caused by the internal `NetworkBehaviour` name change.
+    - Caused by this mod's internal `NetworkBehaviour` name change.
 - Marked automated Thunderstore uploads with an additional Thunderstore
   category:
     - `AI Generated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,7 +167,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
-        - Backfilled as reference compatibility information when preparing
+        - Backfilled as reference compatibility information while preparing
           the v0.2.0-alpha.1 release.
 - Test environment:
     - Lethal Company v73 (2025-10-04 UTC, Manifest ID:
@@ -183,7 +183,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Notes
 
 - Yanked release due to a build issue.
-- No compatibility information was backfilled when preparing the
+- No compatibility information was backfilled while preparing the
   v0.2.0-alpha.1 release because this release was yanked.
 
 ## v0.1.2 - 2025-11-29 UTC
@@ -203,7 +203,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
-        - Backfilled as reference compatibility information when preparing
+        - Backfilled as reference compatibility information while preparing
           the v0.2.0-alpha.1 release.
 
 ## v0.1.1 - 2025-11-29 UTC
@@ -217,7 +217,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
-        - Backfilled as reference compatibility information when preparing
+        - Backfilled as reference compatibility information while preparing
           the v0.2.0-alpha.1 release.
 
 ## v0.1.0 - 2025-11-29 UTC
@@ -231,5 +231,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
-        - Backfilled as reference compatibility information when preparing
+        - Backfilled as reference compatibility information while preparing
           the v0.2.0-alpha.1 release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Refactored internal architecture to improve maintainability.
-- Dropped backward compatibility with CruiserJumpPractice v0.1.4 and earlier
-  because the internal NetworkBehaviour name changed.
+- Dropped backward compatibility with older CruiserJumpPractice versions:
+    - Affects CruiserJumpPractice v0.1.4 and earlier.
+    - Caused by the internal `NetworkBehaviour` name change.
 - Marked automated Thunderstore uploads with an additional Thunderstore
   category:
     - `AI Generated`
@@ -35,9 +36,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - Lethal Company v73 still appears to work.
     - Lethal Company v56 mostly works, with a known minor issue tracked in
       <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
-    - Imperium v1.3.0 appears to have some cruiser-related issues; see
-      <https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735>
-      for a workaround.
+    - Imperium v1.3.0 appears to have some cruiser-related issues:
+        - See
+          <https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735>
+          for a workaround.
 - Test environment:
     - Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
       `6423525044216269478`)
@@ -66,26 +68,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - LethalCompany_InputUtils v0.7.13.
     - BepInEx.PluginInfoProps v2.1.0.
     - UnityEngine.Modules 2022.3.62.
-- Replaced `RestoreAdditionalProjectSources` with an explicit `nuget.config`
-  and package source mapping to make dependency restores more deterministic.
+- Replaced implicit restore package sources with explicit package source
+  mapping:
+    - Removed `RestoreAdditionalProjectSources`.
+    - Added `nuget.config`.
+    - Made dependency restores more deterministic.
 - Clarified current-version interop naming:
     - Renamed interop adapters from `V73` to `Current`.
     - Removed game-version suffixes from reference aliases after confirming
       static multi-version validation is not practical with NuGet-managed
       package references.
-- Simplified redundant network role guards in RPC surrogate and frame-handling
-  paths.
-- Updated Thunderstore README compatibility language to focus on the latest
-  stable Lethal Company version.
-- Revised earlier alpha changelog wording that was later withdrawn or
-  superseded:
-    - Lethal Company v73 and v56 are documented as best-effort compatibility
-      notes instead of explicit Lethal Company v73 support.
-    - The broad internal architecture refactor note is superseded by the
-      current stable-release roll-up and the follow-up alpha.2 refactors
-      listed above.
-- Documented safer GitHub CLI pull request body handling so Markdown is passed
-  through body files and verified after creation.
+- Simplified redundant network role guards:
+    - RPC surrogate paths.
+    - Frame-handling paths.
+- Updated Thunderstore README compatibility language:
+    - Focused the README on the latest stable Lethal Company version.
+    - Withdrew the earlier alpha changelog wording that explicitly declared
+      Lethal Company v73 support.
+    - Kept Lethal Company v73 and v56 as best-effort compatibility notes in
+      changelog context.
+- Documented safer GitHub CLI pull request body handling:
+    - Pass Markdown through body files.
+    - Verify stored pull request bodies after creation.
 
 ### Fixed
 
@@ -94,8 +98,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
-- Removed unmaintained `Debug.ps1` and `InitProfiles.ps1` scripts together
-  with stale setup, debug, and Visual Studio launch-profile references.
+- Removed unmaintained PowerShell scripts and stale references:
+    - `Debug.ps1`
+    - `InitProfiles.ps1`
+    - Setup, debug, and Visual Studio launch-profile references.
 
 ### Notes
 
@@ -115,6 +121,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - Added a composition root.
     - Added domain models and explicit use case result types.
     - Split client/server services and frame/startup handlers.
+    - Later superseded by the stable-release roll-up and the follow-up
+      alpha.2 refactors.
 - Replaced direct base game utility access with an `IGameInterop` abstraction
   and adapter layer so future game-version work can be isolated behind interop
   boundaries.
@@ -131,6 +139,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
+        - Later withdrawn as explicit support wording in v0.2.0-alpha.2.
     - Lethal Company v56 mostly works, with a known minor issue tracked in
       <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
 - Test environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,15 +33,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
       `6423525044216269478`).
+        - Normally used together with Imperium; the v81.5 test environment
+          used Imperium v1.3.0.
+        - Imperium v1.3.0 appears to have some cruiser-related issues:
+            - See
+              <https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735>
+              for a workaround.
     - Lethal Company v73 still appears to work.
     - Lethal Company v56 has lower-confidence compatibility:
         - Core features appear to work in limited checks.
         - A known minor issue was found early and is tracked in
           <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
-    - Imperium v1.3.0 appears to have some cruiser-related issues:
-        - See
-          <https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735>
-          for a workaround.
 - Test environment:
     - Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
       `6423525044216269478`)
@@ -110,6 +112,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Compatibility:
     - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
       `6423525044216269478`).
+        - Normally used together with Imperium; the v81.5 test environment
+          used Imperium v1.3.0.
     - Older base-game compatibility became best-effort after the project
       stopped pursuing static multi-version validation through NuGet
       references:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   paths.
 - Updated Thunderstore README compatibility language to focus on the latest
   stable Lethal Company version.
+- Revised earlier alpha changelog wording that was later withdrawn or
+  superseded:
+    - Lethal Company v73 and v56 are documented as best-effort compatibility
+      notes instead of explicit Lethal Company v73 support.
+    - The broad internal architecture refactor note is superseded by the
+      current stable-release roll-up and the follow-up alpha.2 refactors
+      listed above.
 - Documented safer GitHub CLI pull request body handling so Markdown is passed
   through body files and verified after creation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,7 +183,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Notes
 
 - Yanked release due to a build issue.
-- No compatibility information was backfilled because this release was yanked.
+- No compatibility information was backfilled when preparing the
+  v0.2.0-alpha.1 release because this release was yanked.
 
 ## v0.1.2 - 2025-11-29 UTC
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,84 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - OdinSerializer v2024.2.2700 (2025-05-18 UTC)
     - BepInEx_MonoMod_Debug_Patcher v1.1.1 (2025-04-03 UTC)
 
+## v0.2.0-alpha.2 - 2026-04-26 UTC
+
+### Added
+
+- Added repository-local Agent Skills and `AGENTS.md` guidance for commit
+  message checks, pull request quality checks, and agent workflow conventions.
+- Added AI disclosure documentation to the repository README and Thunderstore
+  package README to satisfy Thunderstore policy expectations.
+
+### Changed
+
+- Updated compile-time dependencies from Lethal Company v73 to v81.5,
+  LethalCompany_InputUtils v0.7.13, BepInEx.PluginInfoProps v2.1.0, and
+  UnityEngine.Modules 2022.3.62.
+- Replaced `RestoreAdditionalProjectSources` with an explicit `nuget.config`
+  and package source mapping to make dependency restores more deterministic.
+- Renamed interop adapters from `V73` to `Current` and removed game-version
+  suffixes from reference aliases after confirming NuGet cannot support the
+  intended static multi-version validation model without manual DLL management.
+- Simplified redundant network role guards in RPC surrogate and frame-handling
+  paths.
+- Updated Thunderstore README compatibility language to focus on the latest
+  stable Lethal Company version, with older versions treated as best-effort.
+- Documented safer GitHub CLI pull request body handling so Markdown is passed
+  through body files and verified after creation.
+
+### Fixed
+
+- Fixed package source mapping for indirect dependencies after clean restore
+  checks exposed missing mappings.
+
+### Removed
+
+- Removed unmaintained `Debug.ps1` and `InitProfiles.ps1` scripts together
+  with stale setup, debug, and Visual Studio launch-profile references.
+
+### Notes
+
+- Compatibility:
+    - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
+      `6423525044216269478`).
+    - Lethal Company v73 and v56 compatibility became best-effort rather than
+      something validated statically through parallel NuGet references.
+
+## v0.2.0-alpha.1 - 2026-04-25 UTC
+
+### Changed
+
+- Refactored the runtime from a manager-centered structure into a layered
+  application architecture with a composition root, domain models, explicit use
+  case result types, client/server services, and frame/startup runtime
+  handlers.
+- Replaced direct base-game utility access with an `IGameInterop` abstraction
+  and adapter layer so future game-version work can be isolated behind interop
+  boundaries.
+- Centralized in-game notifications through a notification use case for more
+  consistent save, load, and magnet-toggle result handling.
+- Split cruiser state and magnet behavior into explicit save/load/toggle use
+  cases while preserving the existing user-facing gameplay flow.
+- Changed the internal network behaviour and interop layout, making this alpha
+  line not backward-compatible with CruiserJumpPractice v0.1.4 and earlier.
+
+### Notes
+
+- Compatibility:
+    - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
+      `1749099131234587692`).
+    - Lethal Company v56 mostly works, with a known minor issue tracked in
+      <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
+- Test environment:
+    - Lethal Company v73 (2025-10-04 UTC, Manifest ID:
+      `1749099131234587692`)
+    - BepInExPack v5.4.2304 (2025-11-05 UTC)
+    - Imperium v1.1.1 (2025-10-27 UTC)
+    - LethalCompany_InputUtils v0.7.12 (2025-10-24 UTC)
+    - LethalNetworkAPI v3.3.2 (2024-12-29 UTC)
+    - OdinSerializer v2024.2.2700 (2025-05-18 UTC)
+
 ## v0.1.4 - 2025-11-30 UTC
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,7 +147,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## v0.1.3 - 2025-11-30 UTC [YANKED]
 
-### Removed
+### Notes
 
 - Yanked release due to a build issue.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- Automated stable-release publishing to Thunderstore from GitHub Actions using
-  the Thunderstore API, reducing the need for manual artifact handling.
+- Automated stable-release publishing to Thunderstore from GitHub Actions:
+    - Uses the Thunderstore API.
+    - Reduces the need for manual artifact handling.
 
 ### Changed
 
 - Refactored internal architecture to improve maintainability.
 - Dropped backward compatibility with CruiserJumpPractice v0.1.4 and earlier
   because the internal NetworkBehaviour name changed.
-- Marked automated Thunderstore uploads with the `Mods`,
-  `Tweaks & Quality Of Life`, and `AI Generated` Thunderstore categories.
+- Marked automated Thunderstore uploads with Thunderstore categories:
+    - `Mods`
+    - `Tweaks & Quality Of Life`
+    - `AI Generated`
 
 ### Notes
 
@@ -50,21 +53,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- Added repository-local Agent Skills and `AGENTS.md` guidance for commit
-  message checks, pull request quality checks, and agent workflow conventions.
+- Added repository-local Agent Skills and `AGENTS.md` guidance:
+    - Commit message checks.
+    - Pull request quality checks.
+    - Agent workflow conventions.
 - Added AI disclosure documentation to the repository README and Thunderstore
   package README for Thunderstore policy compliance.
 
 ### Changed
 
-- Updated compile-time dependencies from Lethal Company v73 to v81.5,
-  LethalCompany_InputUtils v0.7.13, BepInEx.PluginInfoProps v2.1.0, and
-  UnityEngine.Modules 2022.3.62.
+- Updated compile-time dependencies:
+    - Lethal Company v73 to v81.5.
+    - LethalCompany_InputUtils v0.7.13.
+    - BepInEx.PluginInfoProps v2.1.0.
+    - UnityEngine.Modules 2022.3.62.
 - Replaced `RestoreAdditionalProjectSources` with an explicit `nuget.config`
   and package source mapping to make dependency restores more deterministic.
-- Renamed interop adapters from `V73` to `Current`, then removed game-version
-  suffixes from reference aliases after confirming static multi-version
-  validation is not practical with NuGet-managed package references.
+- Clarified current-version interop naming:
+    - Renamed interop adapters from `V73` to `Current`.
+    - Removed game-version suffixes from reference aliases after confirming
+      static multi-version validation is not practical with NuGet-managed
+      package references.
 - Simplified redundant network role guards in RPC surrogate and frame-handling
   paths.
 - Updated Thunderstore README compatibility language to focus on the latest
@@ -96,8 +105,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Refactored the runtime from a manager-centered structure into layered
-  application architecture with a composition root, domain models, explicit use
-  case result types, client/server services, and frame/startup handlers.
+  application architecture:
+    - Added a composition root.
+    - Added domain models and explicit use case result types.
+    - Split client/server services and frame/startup handlers.
 - Replaced direct base game utility access with an `IGameInterop` abstraction
   and adapter layer so future game-version work can be isolated behind interop
   boundaries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Refactored internal architecture to improve maintainability.
 - Dropped backward compatibility with CruiserJumpPractice v0.1.4 and earlier
   because the internal NetworkBehaviour name changed.
-- Marked automated Thunderstore uploads with the `AI Generated` Thunderstore
-  category.
+- Marked automated Thunderstore uploads with an additional Thunderstore
+  category:
+    - `AI Generated`
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Notes
 
 - Yanked release due to a build issue.
+- No compatibility information was backfilled because this release was yanked.
 
 ## v0.1.2 - 2025-11-29 UTC
 

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -22,14 +22,16 @@ No gameplay changes are introduced.
 - Compatibility:
     - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
       `6423525044216269478`).
+        - Normally used together with Imperium; the v81.5 test environment
+          used Imperium v1.3.0.
+        - Imperium v1.3.0 appears to have some cruiser-related issues:
+            - See the [Imperium issue comment][imperium-cruiser-workaround]
+              for a workaround.
     - Lethal Company v73 still appears to work.
     - Lethal Company v56 has lower-confidence compatibility:
         - Core features appear to work in limited checks.
         - A known minor issue was found early and is tracked in
           <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
-    - Imperium v1.3.0 appears to have some cruiser-related issues:
-        - See the [Imperium issue comment][imperium-cruiser-workaround] for a
-          workaround.
 
 ## v0.1.4 - 2025-11-30 UTC
 

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -1,5 +1,10 @@
 <!-- SPDX-License-Identifier: Unlicense -->
 
+This changelog is the user-facing release notes for Thunderstore.
+
+For internal implementation details and developer-facing release history, see
+the [GitHub changelog][github-changelog].
+
 ## Unreleased
 
 This is a maintenance release reflecting internal improvements.
@@ -94,3 +99,4 @@ No gameplay changes are introduced.
           release timing.
 
 [imperium-cruiser-workaround]: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735
+[github-changelog]: https://github.com/aoirint/CruiserJumpPractice/blob/main/CHANGELOG.md

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -26,8 +26,10 @@ No gameplay changes are introduced.
         - See the [Imperium issue comment][imperium-cruiser-workaround] for a
           workaround.
     - Lethal Company v73: It still appears to work.
-    - Lethal Company v56: It mostly works, with a minor known issue tracked in
-      <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
+    - Lethal Company v56 has lower-confidence compatibility:
+        - Core features appear to work in limited checks.
+        - A known minor issue was found early and is tracked in
+          <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
 
 ## v0.1.4 - 2025-11-30 UTC
 

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -22,14 +22,14 @@ No gameplay changes are introduced.
 - Compatibility:
     - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
       `6423525044216269478`).
-    - Imperium v1.3.0 appears to have some cruiser-related issues:
-        - See the [Imperium issue comment][imperium-cruiser-workaround] for a
-          workaround.
-    - Lethal Company v73: It still appears to work.
+    - Lethal Company v73 still appears to work.
     - Lethal Company v56 has lower-confidence compatibility:
         - Core features appear to work in limited checks.
         - A known minor issue was found early and is tracked in
           <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
+    - Imperium v1.3.0 appears to have some cruiser-related issues:
+        - See the [Imperium issue comment][imperium-cruiser-workaround] for a
+          workaround.
 
 ## v0.1.4 - 2025-11-30 UTC
 

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -8,16 +8,18 @@ No gameplay changes are introduced.
 
 ### Changed
 
-- Dropped backward compatibility with CruiserJumpPractice v0.1.4 and earlier
-  due to an internal change.
+- Dropped backward compatibility with older CruiserJumpPractice versions:
+    - Affects CruiserJumpPractice v0.1.4 and earlier.
+    - Caused by an internal change.
 
 ### Notes
 
 - Compatibility:
     - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
       `6423525044216269478`).
-    - Imperium v1.3.0 appears to have some cruiser-related issues. See
-      [this issue comment][imperium-cruiser-workaround] for a workaround.
+    - Imperium v1.3.0 appears to have some cruiser-related issues:
+        - See [this issue comment][imperium-cruiser-workaround] for a
+          workaround.
     - Lethal Company v73: It still seems to work.
     - Lethal Company v56: Major features work as expected, but there is a minor
       known issue: <https://github.com/aoirint/CruiserJumpPractice/issues/5>.

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -8,7 +8,8 @@ No gameplay changes are introduced.
 
 ### Changed
 
-- This release is not backward-compatible with CruiserJumpPractice v0.1.4 and earlier.
+- Dropped backward compatibility with CruiserJumpPractice v0.1.4 and earlier
+  due to an internal change.
 
 ### Notes
 
@@ -35,7 +36,9 @@ No gameplay changes are introduced.
 
 ## v0.1.3 - 2025-11-30 UTC [YANKED]
 
-Yanked release due to a build issue.
+### Notes
+
+- Yanked release due to a build issue.
 
 ## v0.1.2 - 2025-11-29 UTC
 

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -35,6 +35,8 @@ No gameplay changes are introduced.
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
+        - Backfilled as reference compatibility information in
+          v0.2.0-alpha.1.
 
 ## v0.1.3 - 2025-11-30 UTC [YANKED]
 
@@ -59,6 +61,8 @@ No gameplay changes are introduced.
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
+        - Backfilled as reference compatibility information in
+          v0.2.0-alpha.1.
 
 ## v0.1.1 - 2025-11-29 UTC
 
@@ -71,6 +75,8 @@ No gameplay changes are introduced.
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
+        - Backfilled as reference compatibility information in
+          v0.2.0-alpha.1.
 
 ## v0.1.0 - 2025-11-29 UTC
 
@@ -83,5 +89,7 @@ No gameplay changes are introduced.
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
+        - Backfilled as reference compatibility information in
+          v0.2.0-alpha.1.
 
 [imperium-cruiser-workaround]: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -23,8 +23,8 @@ No gameplay changes are introduced.
     - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
       `6423525044216269478`).
     - Imperium v1.3.0 appears to have some cruiser-related issues:
-        - See [this issue comment][imperium-cruiser-workaround] for a
-          workaround.
+        - See the [linked Imperium issue comment][imperium-cruiser-workaround]
+          for a workaround.
     - Lethal Company v73: It still seems to work.
     - Lethal Company v56: Major features work as expected, but there is a minor
       known issue: <https://github.com/aoirint/CruiserJumpPractice/issues/5>.

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -48,7 +48,8 @@ No gameplay changes are introduced.
 ### Notes
 
 - Yanked release due to a build issue.
-- No compatibility information was backfilled because this release was yanked.
+- No compatibility information was backfilled for the v0.2.0 release timing
+  because this release was yanked.
 
 ## v0.1.2 - 2025-11-29 UTC
 

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -35,8 +35,8 @@ No gameplay changes are introduced.
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
-        - Backfilled as reference compatibility information in
-          v0.2.0-alpha.1.
+        - Backfilled as reference compatibility information for the v0.2.0
+          release timing.
 
 ## v0.1.3 - 2025-11-30 UTC [YANKED]
 
@@ -62,8 +62,8 @@ No gameplay changes are introduced.
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
-        - Backfilled as reference compatibility information in
-          v0.2.0-alpha.1.
+        - Backfilled as reference compatibility information for the v0.2.0
+          release timing.
 
 ## v0.1.1 - 2025-11-29 UTC
 
@@ -76,8 +76,8 @@ No gameplay changes are introduced.
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
-        - Backfilled as reference compatibility information in
-          v0.2.0-alpha.1.
+        - Backfilled as reference compatibility information for the v0.2.0
+          release timing.
 
 ## v0.1.0 - 2025-11-29 UTC
 
@@ -90,7 +90,7 @@ No gameplay changes are introduced.
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
-        - Backfilled as reference compatibility information in
-          v0.2.0-alpha.1.
+        - Backfilled as reference compatibility information for the v0.2.0
+          release timing.
 
 [imperium-cruiser-workaround]: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -43,6 +43,7 @@ No gameplay changes are introduced.
 ### Notes
 
 - Yanked release due to a build issue.
+- No compatibility information was backfilled because this release was yanked.
 
 ## v0.1.2 - 2025-11-29 UTC
 

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -15,7 +15,7 @@ No gameplay changes are introduced.
 
 - Dropped backward compatibility with older CruiserJumpPractice versions:
     - Affects CruiserJumpPractice v0.1.4 and earlier.
-    - Caused by a mod-internal CruiserJumpPractice change.
+    - Caused by a mod-internal change.
 
 ### Notes
 

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -15,7 +15,7 @@ No gameplay changes are introduced.
 
 - Dropped backward compatibility with older CruiserJumpPractice versions:
     - Affects CruiserJumpPractice v0.1.4 and earlier.
-    - Caused by an internal change.
+    - Caused by an internal change in this mod.
 
 ### Notes
 

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -23,8 +23,8 @@ No gameplay changes are introduced.
     - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
       `6423525044216269478`).
     - Imperium v1.3.0 appears to have some cruiser-related issues:
-        - See the [linked Imperium issue comment][imperium-cruiser-workaround]
-          for a workaround.
+        - See the [Imperium issue comment][imperium-cruiser-workaround] for a
+          workaround.
     - Lethal Company v73: It still seems to work.
     - Lethal Company v56: Major features work as expected, but there is a minor
       known issue: <https://github.com/aoirint/CruiserJumpPractice/issues/5>.

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -25,9 +25,9 @@ No gameplay changes are introduced.
     - Imperium v1.3.0 appears to have some cruiser-related issues:
         - See the [Imperium issue comment][imperium-cruiser-workaround] for a
           workaround.
-    - Lethal Company v73: It still seems to work.
-    - Lethal Company v56: Major features work as expected, but there is a minor
-      known issue: <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
+    - Lethal Company v73: It still appears to work.
+    - Lethal Company v56: It mostly works, with a minor known issue tracked in
+      <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
 
 ## v0.1.4 - 2025-11-30 UTC
 
@@ -40,16 +40,16 @@ No gameplay changes are introduced.
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
-        - Backfilled as reference compatibility information for the v0.2.0
-          release timing.
+        - Backfilled as reference compatibility information while preparing
+          the v0.2.0 release.
 
 ## v0.1.3 - 2025-11-30 UTC [YANKED]
 
 ### Notes
 
 - Yanked release due to a build issue.
-- No compatibility information was backfilled for the v0.2.0 release timing
-  because this release was yanked.
+- No compatibility information was backfilled while preparing the v0.2.0
+  release because this release was yanked.
 
 ## v0.1.2 - 2025-11-29 UTC
 
@@ -68,8 +68,8 @@ No gameplay changes are introduced.
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
-        - Backfilled as reference compatibility information for the v0.2.0
-          release timing.
+        - Backfilled as reference compatibility information while preparing
+          the v0.2.0 release.
 
 ## v0.1.1 - 2025-11-29 UTC
 
@@ -82,8 +82,8 @@ No gameplay changes are introduced.
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
-        - Backfilled as reference compatibility information for the v0.2.0
-          release timing.
+        - Backfilled as reference compatibility information while preparing
+          the v0.2.0 release.
 
 ## v0.1.0 - 2025-11-29 UTC
 
@@ -96,8 +96,8 @@ No gameplay changes are introduced.
 - Compatibility:
     - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`).
-        - Backfilled as reference compatibility information for the v0.2.0
-          release timing.
+        - Backfilled as reference compatibility information while preparing
+          the v0.2.0 release.
 
 [imperium-cruiser-workaround]: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735
 [github-changelog]: https://github.com/aoirint/CruiserJumpPractice/blob/main/CHANGELOG.md

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -15,7 +15,7 @@ No gameplay changes are introduced.
 
 - Dropped backward compatibility with older CruiserJumpPractice versions:
     - Affects CruiserJumpPractice v0.1.4 and earlier.
-    - Caused by an internal change in this mod.
+    - Caused by a mod-internal CruiserJumpPractice change.
 
 ### Notes
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -18,7 +18,8 @@ reset the cruiser every attempt.
         - OdinSerializer v2024.2.2700 (2025-05-18 UTC)
         - BepInEx_MonoMod_Debug_Patcher v1.1.1 (2025-04-03 UTC)
     - NOTE: Imperium v1.3.0 appears to have some cruiser-related issues. See
-      [this issue comment][imperium-cruiser-workaround] for a workaround.
+      the [linked Imperium issue comment][imperium-cruiser-workaround] for a
+      workaround.
 
 ## What it does
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -18,7 +18,7 @@ reset the cruiser every attempt.
         - OdinSerializer v2024.2.2700 (2025-05-18 UTC)
         - BepInEx_MonoMod_Debug_Patcher v1.1.1 (2025-04-03 UTC)
     - NOTE: Imperium v1.3.0 appears to have some cruiser-related issues. See
-      the [linked Imperium issue comment][imperium-cruiser-workaround] for a
+      the [Imperium issue comment][imperium-cruiser-workaround] for a
       workaround.
 
 ## What it does


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Add canonical root `CHANGELOG.md` entries for `v0.2.0-alpha.2` and
  `v0.2.0-alpha.1`, sourced from release notes, merged PRs, and commit
  history.
- Preserve `Unreleased` as the stable `v0.2.0` roll-up while recording
  prerelease-only history, superseded wording, and compatibility-backfill
  context.
- Keep root changelog entries readable with indented subitems for long
  dependency, compatibility, and refactor details.
- Align the Thunderstore-facing `assets/CHANGELOG.md` with the canonical
  history where user-facing context matters:
    - Backfilled compatibility notes use wording about preparing the `v0.2.0`
      release.
    - No backfilled compatibility information for the yanked `v0.1.3`
      release.
    - An intro pointing users to the GitHub changelog for internal
      implementation details.
- Clarify current compatibility notes:
    - Lethal Company v81.5 is the compatible/current base-game target.
    - Imperium v1.3.0 is documented as the normally paired mod in the v81.5
      test environment.
    - Lethal Company v73 and v56 remain best-effort notes with different
      confidence levels.
- Clarify the Imperium workaround link text in `assets/CHANGELOG.md` and
  `assets/README.md`.

## Related Issues

- Refs #4
- Refs #6
- Refs #7
- Refs #8
- Refs #9
- Refs #11
- Refs #12
- Refs #13
- Refs #14
- Refs #15
- Refs #16
- Refs #17
- Refs #19

## Notes for reviewers

- This is a documentation-only changelog and release-note update.
- Review focus:
    - Whether the `v0.2.0-alpha.1` and `v0.2.0-alpha.2` release history is
      accurate.
    - Whether withdrawn or superseded prerelease wording is attached to the
      affected entries.
    - Whether root changelog wording and Thunderstore-facing wording stay
      appropriately distinct.
- `Mods` and `Tweaks & Quality Of Life` are not described as newly added by
  repository automation; only `AI Generated` is treated as the new automated
  Thunderstore category.

### AI disclosure

- Codex reviewed release notes, merged PR bodies, commit history, and local
  diffs, then drafted and revised the changelog and PR text.
- The generated changes were iteratively reviewed and adjusted from maintainer
  feedback in this PR branch.

## Testing

### Automated checks

- `docker run --rm --network none -v "${PWD}:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5`
- `git diff --check`
- `git diff --check origin/main...HEAD`

### AI-assisted inspections

- Request: Compare the changelog entries against release notes, merged PR
  summaries, commit history, and maintainer feedback.
    - AI-assisted result: The entries align with `v0.2.0-alpha.1` and
      `v0.2.0-alpha.2`, keep `Unreleased` as the stable-release roll-up,
      attach supersession notes to affected entries, and separate user-facing
      release notes from developer-facing changelog details.

### Manual checks

- Not applicable.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
