### PR TITLE
docs(skills): add document quality guidance

### DIFF
--- a/.agents/skills/changelog-workflow/SKILL.md
+++ b/.agents/skills/changelog-workflow/SKILL.md
@@ -69,10 +69,35 @@ Reference:
      they are maintainer-confirmed or clearly sourced. Otherwise list them as
      missing inputs or draft source material needing confirmation, not as final
      compatibility facts.
+   - When compatibility notes cover several platform, runtime, dependency, or
+     companion-product versions, preserve confidence differences instead of
+     flattening them into one generic compatibility statement. For example,
+     distinguish confirmed compatibility, "appears to work" best-effort
+     compatibility, lower-confidence limited checks, and known issues.
+   - Keep related compatibility claims grouped by relationship. Put companion
+     tools, required plugins, or paired dependencies under the product/version
+     they were tested with when that relationship matters, instead of listing
+     them as another peer product version.
+   - When historical entries are backfilled with metadata such as
+     compatibility information, state that the metadata was backfilled, when it
+     was backfilled, and whether it is reference information rather than an
+     original release claim.
+   - For yanked releases, explicitly say when historical metadata was not
+     backfilled because the release was yanked, if nearby releases did receive
+     backfilled metadata.
 7. When prerelease entries are later superseded, keep enough canonical history
    to explain what changed and what reached the stable release. If the stable
    release is still only planned, leave the stable roll-up material under
    `Unreleased` instead of creating an unfinished stable heading.
+   - Attach withdrawn or superseded notes to the specific entry they affect,
+     rather than only adding a broad later correction. Name the later version
+     or release timing that withdrew or superseded the earlier wording.
+   - Avoid shorthand prerelease references such as `alpha.1` or `beta.2` when
+     the base version matters. Use the full prerelease version, such as
+     `v1.2.0-alpha.1`, in durable changelog text.
+   - Split long bullets into concise parent items with indented subitems when a
+     change contains several facts, reasons, affected versions, or follow-up
+     notes.
 8. If the user asks for user-facing release notes, verify or prepare only the
    canonical source material here, then use the appropriate release-note
    workflow for the user-facing rewrite and release-readiness checks.

--- a/.agents/skills/changelog-workflow/SKILL.md
+++ b/.agents/skills/changelog-workflow/SKILL.md
@@ -98,11 +98,10 @@ Reference:
    - Split long bullets into concise parent items with indented subitems when a
      change contains several facts, reasons, affected versions, or follow-up
      notes.
-   - When splitting or rewording changelog prose, follow the
-     `code-quality-check` wording guidance: improve readability while
-     preserving certainty, scope, timing, compatibility confidence,
-     dependency relationships, and whether a statement is original,
-     backfilled, inferred, superseded, or withdrawn.
+   - Use `document-quality-check` when splitting or rewording changelog prose.
+     Preserve changelog-specific nuance such as compatibility confidence,
+     dependency relationships, and whether a statement is original, backfilled,
+     inferred, superseded, or withdrawn.
 8. If the user asks for user-facing release notes, verify or prepare only the
    canonical source material here, then use the appropriate release-note
    workflow for the user-facing rewrite and release-readiness checks.

--- a/.agents/skills/changelog-workflow/SKILL.md
+++ b/.agents/skills/changelog-workflow/SKILL.md
@@ -98,6 +98,11 @@ Reference:
    - Split long bullets into concise parent items with indented subitems when a
      change contains several facts, reasons, affected versions, or follow-up
      notes.
+   - When splitting or rewording changelog prose, follow the
+     `code-quality-check` wording guidance: improve readability while
+     preserving certainty, scope, timing, compatibility confidence,
+     dependency relationships, and whether a statement is original,
+     backfilled, inferred, superseded, or withdrawn.
 8. If the user asks for user-facing release notes, verify or prepare only the
    canonical source material here, then use the appropriate release-note
    workflow for the user-facing rewrite and release-readiness checks.

--- a/.agents/skills/code-quality-check/SKILL.md
+++ b/.agents/skills/code-quality-check/SKILL.md
@@ -99,6 +99,9 @@ readability without flattening meaning.
 
 - Split overloaded sentences when they carry multiple ideas, conditions, time references, confidence
   levels, or relationships.
+- Prefer lists when presenting enumerations.
+  - Use prose only when the enumeration is short enough to read naturally or when the local document
+    style clearly favors inline wording.
 - Split or restructure paragraphs and list items when they become too dense to scan.
   - Use separate paragraphs, parent bullets with indented child bullets, or another local document
     pattern that makes each idea easy to review.

--- a/.agents/skills/code-quality-check/SKILL.md
+++ b/.agents/skills/code-quality-check/SKILL.md
@@ -37,8 +37,8 @@ validation expectations.
 4. Add or update comments only when the design intent is not obvious from the code and cannot be
    made obvious with a small refactor.
 5. Remove stale, redundant, or misleading comments.
-6. Classify changed text as developer-facing, user-facing, or external-contract text before
-   recommending wording changes.
+6. Use `document-quality-check` for documentation, comments, release notes, PR text, issue text,
+   and other explanatory prose that needs readability or wording changes.
 7. Re-run the project's language-specific quality checks after edits.
 8. Summarize which checks ran, which passed, and why any relevant check was skipped.
 
@@ -91,27 +91,6 @@ When adding a comment:
   standalone comment would split an import block, list, mapping, or generated section in a way tools
   rewrite or reject, use a same-line comment or another nearby location that preserves the group.
 - Update nearby tests or verification notes if the comment documents behavior that must stay true.
-
-## Documentation and Comment Wording
-
-When editing documentation, comments, release notes, PR text, or other explanatory prose, improve
-readability without flattening meaning.
-
-- Split overloaded sentences when they carry multiple ideas, conditions, time references, confidence
-  levels, or relationships.
-- Prefer lists when presenting enumerations.
-  - Use prose only when the enumeration is short enough to read naturally or when the local document
-    style clearly favors inline wording.
-- Split or restructure paragraphs and list items when they become too dense to scan.
-  - Use separate paragraphs, parent bullets with indented child bullets, or another local document
-    pattern that makes each idea easy to review.
-- Preserve the nuance that made the original wording important. Keep distinctions such as certainty,
-  scope, timing, exception status, dependency relationships, and whether a statement is original,
-  backfilled, inferred, or superseded.
-- Use as many short sentences or nested bullets as needed to make the relationship readable. Do not
-  force a fixed sentence count when the content needs a different shape.
-- After splitting text, re-read the result as a whole and confirm it still answers the same question
-  as the original wording.
 
 ### CI and Configuration Comments
 

--- a/.agents/skills/code-quality-check/SKILL.md
+++ b/.agents/skills/code-quality-check/SKILL.md
@@ -92,6 +92,21 @@ When adding a comment:
   rewrite or reject, use a same-line comment or another nearby location that preserves the group.
 - Update nearby tests or verification notes if the comment documents behavior that must stay true.
 
+## Documentation and Comment Wording
+
+When editing documentation, comments, release notes, PR text, or other explanatory prose, improve
+readability without flattening meaning.
+
+- Split overloaded sentences when they carry multiple ideas, conditions, time references, confidence
+  levels, or relationships.
+- Preserve the nuance that made the original wording important. Keep distinctions such as certainty,
+  scope, timing, exception status, dependency relationships, and whether a statement is original,
+  backfilled, inferred, or superseded.
+- Use as many short sentences or nested bullets as needed to make the relationship readable. Do not
+  force a fixed sentence count when the content needs a different shape.
+- After splitting text, re-read the result as a whole and confirm it still answers the same question
+  as the original wording.
+
 ### CI and Configuration Comments
 
 For configuration-as-code, CI workflows, build files, and tool configuration, intent comments are

--- a/.agents/skills/code-quality-check/SKILL.md
+++ b/.agents/skills/code-quality-check/SKILL.md
@@ -99,6 +99,9 @@ readability without flattening meaning.
 
 - Split overloaded sentences when they carry multiple ideas, conditions, time references, confidence
   levels, or relationships.
+- Split or restructure paragraphs and list items when they become too dense to scan.
+  - Use separate paragraphs, parent bullets with indented child bullets, or another local document
+    pattern that makes each idea easy to review.
 - Preserve the nuance that made the original wording important. Keep distinctions such as certainty,
   scope, timing, exception status, dependency relationships, and whether a statement is original,
   backfilled, inferred, or superseded.

--- a/.agents/skills/document-quality-check/SKILL.md
+++ b/.agents/skills/document-quality-check/SKILL.md
@@ -1,0 +1,65 @@
+---
+# SPDX-License-Identifier: Unlicense
+name: document-quality-check
+description: Quality-check documentation, comments, release notes, issue text, pull request text, and Agent Skill prose for readability, structure, audience fit, and preserved nuance.
+---
+
+# Document Quality Check
+
+## When to Use
+
+- Use this skill when creating, updating, or reviewing explanatory prose.
+- Use this skill for documentation, comments, release notes, issue text, pull request text, Agent
+  Skill prose, changelog entries, and handoff notes.
+- Use this skill together with domain-specific skills when those skills own the document type, such
+  as changelogs, release notes, issues, pull requests, or Agent Skills.
+
+## Goals
+
+- Make prose easy to scan without flattening meaning.
+- Preserve nuance that affects reader decisions, implementation safety, or release interpretation.
+- Match structure to content: sentences for simple ideas, lists for enumerations, and nested bullets
+  for grouped details.
+- Keep wording aligned with the target audience and the local document style.
+
+## Workflow
+
+1. Classify the text audience before rewriting:
+   - Developer-facing.
+   - User-facing.
+   - Maintainer-facing.
+   - External-contract text.
+2. Identify overloaded prose:
+   - Sentences carrying multiple ideas, conditions, time references, confidence levels, or
+     relationships.
+   - Paragraphs that mix context, decision, evidence, and consequence.
+   - List items that contain several facts, exceptions, examples, or follow-up notes.
+3. Prefer lists when presenting enumerations.
+   - Use inline prose only when the enumeration is short enough to read naturally or when the local
+     document style clearly favors inline wording.
+4. Split or restructure dense text when it becomes hard to scan.
+   - Use separate paragraphs, parent bullets with indented child bullets, tables, or another local
+     document pattern that makes each idea easy to review.
+5. Preserve the nuance that made the original wording important:
+   - Certainty or confidence level.
+   - Scope and applicability.
+   - Timing and sequence.
+   - Exception or limitation status.
+   - Dependency or compatibility relationships.
+   - Whether a statement is original, backfilled, inferred, superseded, withdrawn, or still
+     unconfirmed.
+6. Use as many short sentences or nested bullets as needed.
+   - Do not force a fixed sentence count when the content needs a different shape.
+7. Re-read the result as a whole.
+   - Confirm it still answers the same question as the original wording.
+   - Confirm each list or paragraph has one clear job.
+   - Confirm the structure did not imply a stronger, weaker, broader, or narrower claim than the
+     source material supports.
+
+## Output Checklist
+
+- Audience and document type were considered before rewriting.
+- Enumerations are lists unless inline prose is clearer for the local context.
+- Dense paragraphs or list items were split or intentionally left intact.
+- Important certainty, scope, timing, relationship, and status nuances were preserved.
+- The final text is easier to scan and still communicates the same claim.

--- a/.agents/skills/issue-quality-check/SKILL.md
+++ b/.agents/skills/issue-quality-check/SKILL.md
@@ -68,6 +68,9 @@ can trace the relationship without relying on transient comments elsewhere.
 - Preserve non-English text only when quoting source text, branch names, commit messages, file
   contents, logs, or existing discussion snippets that must remain exact.
 - Keep issue bodies short and scannable.
+- Follow the `code-quality-check` wording guidance for explanatory prose: split overloaded
+  sentences when needed, while preserving certainty, scope, timing, relationships, and other
+  important nuance.
 - Prefer bullets for facts, steps, and criteria.
 - Mention paths, commands, classes, and config keys in backticks.
 - Include exact expected and actual behavior for bugs.

--- a/.agents/skills/issue-quality-check/SKILL.md
+++ b/.agents/skills/issue-quality-check/SKILL.md
@@ -68,9 +68,9 @@ can trace the relationship without relying on transient comments elsewhere.
 - Preserve non-English text only when quoting source text, branch names, commit messages, file
   contents, logs, or existing discussion snippets that must remain exact.
 - Keep issue bodies short and scannable.
-- Follow the `code-quality-check` wording guidance for explanatory prose: split overloaded
-  sentences when needed, while preserving certainty, scope, timing, relationships, and other
-  important nuance.
+- Use `document-quality-check` for explanatory prose.
+  - Preserve issue-specific nuance such as certainty, scope, timing, relationships, and whether a
+    statement is confirmed, inferred, untested, or unknown.
 - Prefer bullets for facts, steps, and criteria.
 - Mention paths, commands, classes, and config keys in backticks.
 - Include exact expected and actual behavior for bugs.

--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -132,6 +132,8 @@ Use fallback sections this way:
 - Preserve non-English text only when quoting source text, branch names, commit messages, file
   contents, logs, or existing discussion snippets that must remain exact.
 - Keep PR bodies short and reviewable.
+- Use `document-quality-check` for explanatory prose that needs readability, structure, or nuance
+  review.
 - Prefer bullets over long paragraphs.
 - Mention paths or commands in backticks.
 - Do not paste large diffs.

--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -118,7 +118,9 @@ Use fallback sections this way:
 - `Related Issues`: GitHub issues, pull requests, external references, or `None`.
   When linking related work, state how it is related. If the explanation is too
   long for the reference line, put the reference on the parent bullet and the
-  explanation on an indented child bullet.
+  explanation on an indented child bullet. Keep the child explanation readable:
+  split packed relationship-and-purpose wording into as many short sentences as
+  needed when one sentence carries too many ideas.
 - `Notes for reviewers`: limitations, skipped checks, migration notes, reviewer attention points, or review focus.
 - `AI disclosure`: significant AI assistance details, or `None` when no significant AI assistance was used.
 - `Testing`: automated commands, CI results, AI-assisted inspections, manual checks, screenshots, or videos.

--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -116,6 +116,9 @@ Use fallback sections this way:
 
 - `Summary`: user-facing or maintainer-facing changes, grouped by behavior or area.
 - `Related Issues`: GitHub issues, pull requests, external references, or `None`.
+  When linking related work, state how it is related. If the explanation is too
+  long for the reference line, put the reference on the parent bullet and the
+  explanation on an indented child bullet.
 - `Notes for reviewers`: limitations, skipped checks, migration notes, reviewer attention points, or review focus.
 - `AI disclosure`: significant AI assistance details, or `None` when no significant AI assistance was used.
 - `Testing`: automated commands, CI results, AI-assisted inspections, manual checks, screenshots, or videos.

--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -145,14 +145,24 @@ It must appear at the very top of the comment or review body:
 
 The alert should appear before every other paragraph, heading, checklist, quote, finding, or metadata block.
 
-Use `Update Note` or `Discussion Note` sections only when the active task asks for process notes, decision logs, or granular PR-thread updates. Do not add them by default. Frequent process notes can clutter the PR conversation and may expose unnecessary implementation context. When enabled:
+Use `Update Note`, `Discussion Note`, or `Review Note` sections only when the
+active task asks for process notes, decision logs, review summaries, or granular
+PR-thread updates. Do not add them by default. Frequent process notes can
+clutter the PR conversation and may expose unnecessary implementation context.
+When enabled:
 
 - Use `Update Note` for a concrete change that was just made to the pull request.
 - Use `Discussion Note` for a decision, tradeoff, or rationale that should remain visible in the PR thread.
+- Use `Review Note` when reporting a review pass, consistency check, readiness
+  check, or retrospective verification that did not itself make a concrete
+  change.
 - If the active task asks for "history so far", "notes so far", or similar retrospective PR-thread notes,
   do not dump raw commit history. Create separate concise notes grouped by meaningful decision or
   change theme, using `Update Note` for concrete PR changes and `Discussion Note` for decisions,
   tradeoffs, or rationale.
+- If the requester asks for notes to be separate, or a correction includes two
+  independently reviewable changes, post separate PR comments for each theme
+  instead of combining them into one broad note.
 - Immediately after the required LLM alert and before the note heading, add a neutral `Request addressed: ...` line.
   Use it only as a concise marker for later PR-body `### AI-assisted inspections` summaries; do not use it to classify
   requester identity, role, or authority.

--- a/.agents/skills/release-note-workflow/SKILL.md
+++ b/.agents/skills/release-note-workflow/SKILL.md
@@ -78,6 +78,11 @@ description: Create, update, or review user-facing release notes. Use when deriv
      Keep exact prerelease identifiers in the canonical developer changelog.
 6. Rewrite the stable entries around user-visible behavior, installation,
    compatibility, update impact, security, and known limitations.
+   - Follow the `code-quality-check` wording guidance for explanatory prose:
+     split overloaded sentences when needed, while preserving certainty,
+     scope, timing, compatibility confidence, dependency relationships, and
+     whether context is original, backfilled, inferred, superseded, or
+     withdrawn.
 7. For each user-visible change, include one concise reason or background
    sentence from the canonical changelog or maintainer input.
    - Apply this requirement to the target release being prepared or reviewed.

--- a/.agents/skills/release-note-workflow/SKILL.md
+++ b/.agents/skills/release-note-workflow/SKILL.md
@@ -78,11 +78,10 @@ description: Create, update, or review user-facing release notes. Use when deriv
      Keep exact prerelease identifiers in the canonical developer changelog.
 6. Rewrite the stable entries around user-visible behavior, installation,
    compatibility, update impact, security, and known limitations.
-   - Follow the `code-quality-check` wording guidance for explanatory prose:
-     split overloaded sentences when needed, while preserving certainty,
-     scope, timing, compatibility confidence, dependency relationships, and
-     whether context is original, backfilled, inferred, superseded, or
-     withdrawn.
+   - Use `document-quality-check` for explanatory prose. Preserve
+     release-note-specific nuance such as compatibility confidence, dependency
+     relationships, and whether context is original, backfilled, inferred,
+     superseded, or withdrawn.
 7. For each user-visible change, include one concise reason or background
    sentence from the canonical changelog or maintainer input.
    - Apply this requirement to the target release being prepared or reviewed.

--- a/.agents/skills/release-note-workflow/SKILL.md
+++ b/.agents/skills/release-note-workflow/SKILL.md
@@ -72,6 +72,10 @@ description: Create, update, or review user-facing release notes. Use when deriv
 5. Omit prerelease-only details from the user-facing release notes when
    they were internal, superseded before stable release, or useful only to
    maintainers.
+   - When mentioning work that happened during a prerelease cycle in stable
+     user-facing notes, prefer the stable release timing or stable version
+     wording unless the prerelease identifier is user-visible and necessary.
+     Keep exact prerelease identifiers in the canonical developer changelog.
 6. Rewrite the stable entries around user-visible behavior, installation,
    compatibility, update impact, security, and known limitations.
 7. For each user-visible change, include one concise reason or background
@@ -98,6 +102,14 @@ description: Create, update, or review user-facing release notes. Use when deriv
    including breaking changes, compatibility changes, installation or update
    notes, removals, deprecations, security fixes, yanked releases, and known
    limitations.
+   - If user-facing notes backfill historical compatibility or limitation
+     context for older releases, state that the information was added while
+     preparing the relevant stable release. Avoid wording that makes the
+     backfilled information sound like an original claim from the older
+     release.
+   - If a yanked release intentionally does not receive backfilled
+     compatibility or limitation information, say so when neighboring releases
+     do receive backfilled notes.
 9. Keep test environment details in the canonical developer changelog. Include
    them in user-facing release notes only when they are needed as
    user-facing compatibility or support context.
@@ -108,6 +120,12 @@ description: Create, update, or review user-facing release notes. Use when deriv
      labeled bullets such as `Compatibility:` or `Known limitations:`, instead
      of creating standalone headings for metadata that is not a Keep a
      Changelog change category.
+   - Preserve useful confidence differences in compatibility notes. Distinguish
+     confirmed compatibility from best-effort "appears to work" notes,
+     lower-confidence limited checks, and known issues.
+   - Group companion tools, paired plugins, or required dependencies under the
+     product/version they were tested with when that relationship matters for
+     users.
    - Put `Notes` after all change-category sections within each release entry
      unless the publication channel explicitly requires another order.
 10. Before publication, verify:
@@ -182,6 +200,10 @@ Classify review items as:
   sourced from the canonical changelog or maintainer input.
   This applies to the target release; untouched historical entries in a
   cumulative file are not blockers solely because they predate this rule.
+- User-facing release-note files may include a short intro that identifies them
+  as user-facing notes and points readers to the canonical developer changelog
+  for internal implementation details, when both files are published or
+  discoverable.
 - Draft notes are clearly labeled as draft review text and list missing inputs
   before any proposed user-facing wording.
 - Blockers name the missing or failed readiness item directly, such as stable

--- a/.agents/skills/skill-quality-check/SKILL.md
+++ b/.agents/skills/skill-quality-check/SKILL.md
@@ -47,6 +47,9 @@ description: Quality-check Agent Skills for trigger clarity, scope, structure, p
    - Keep required steps explicit, ordered, and written as imperatives.
    - Match specificity to risk: flexible guidance for judgment-heavy work, exact commands or scripts
      for fragile operations.
+   - Follow the `code-quality-check` wording guidance for explanatory prose:
+     split overloaded sentences when needed, while preserving trigger
+     boundaries, scope, ordering, risk level, and domain-separation nuance.
 6. Check progressive disclosure:
    - Keep `SKILL.md` short enough to scan quickly.
    - Link every optional reference directly from `SKILL.md`; avoid nested reference chains.

--- a/.agents/skills/skill-quality-check/SKILL.md
+++ b/.agents/skills/skill-quality-check/SKILL.md
@@ -47,9 +47,9 @@ description: Quality-check Agent Skills for trigger clarity, scope, structure, p
    - Keep required steps explicit, ordered, and written as imperatives.
    - Match specificity to risk: flexible guidance for judgment-heavy work, exact commands or scripts
      for fragile operations.
-   - Follow the `code-quality-check` wording guidance for explanatory prose:
-     split overloaded sentences when needed, while preserving trigger
-     boundaries, scope, ordering, risk level, and domain-separation nuance.
+   - Use `document-quality-check` for explanatory prose. Preserve
+     skill-specific nuance such as trigger boundaries, scope, ordering, risk
+     level, and domain separation.
 6. Check progressive disclosure:
    - Keep `SKILL.md` short enough to scan quickly.
    - Link every optional reference directly from `SKILL.md`; avoid nested reference chains.


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Add `document-quality-check` as a shared prose-quality Agent Skill:
    - Cover documentation, comments, release notes, PR text, issue text,
      changelog entries, handoff notes, and Agent Skill prose.
    - Prefer lists for enumerations.
    - Split overloaded wording, dense paragraphs, and long list items when
      needed.
    - Preserve certainty, scope, timing, relationships, status, and other
      important nuance while improving readability.
- Wire the shared document-quality guidance into related skills:
    - `changelog-workflow`
    - `release-note-workflow`
    - `issue-quality-check`
    - `pull-request-quality-check`
    - `skill-quality-check`
    - `code-quality-check`
- Preserve #53-derived changelog and release-note guidance:
    - Compatibility confidence differences.
    - Withdrawn or superseded prerelease notes.
    - Historical metadata backfills and yanked-release omissions.
    - Stable user-facing release-note framing.
- Improve PR-thread guidance in `pull-request-quality-check`:
    - Add `Review Note` for review/check summaries.
    - Require separate PR comments when requested or when changes are
      independently reviewable.
    - Require related PRs, issues, and external references to describe the
      relationship.

## Related Issues

- Refs #53.
    - Source changelog/release-note PR for this follow-up.
    - Its reusable review and editing lessons are generalized into Agent Skill
      guidance here.
- Refs #55.
    - Follow-up issue for applying `document-quality-check` more thoroughly to
      existing Agent Skill prose after this PR.

## Notes for reviewers

- This is a documentation-only Agent Skill update.
- The main responsibility of this PR is to add the shared
  `document-quality-check` skill and connect it from the skills that produce or
  review prose.
- This PR also keeps the narrower #53-derived changelog/release-note lessons
  that motivated the extraction.
- Broader prose cleanup across existing skills is intentionally deferred to
  #55.

### AI disclosure

- Codex extracted reusable workflow lessons from an AI-assisted changelog PR and
  adapted them into repository-local Agent Skill guidance.
- The changes were checked against `skill-quality-check` guidance for scope,
  domain separation, and validation.

## Testing

### Automated checks

- `docker run --rm --network none -v "${PWD}:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5 ".agents/skills/**/*.md"`
- `git diff --check`
- `rg -n "CruiserJumpPractice|Lethal Company|Imperium|Thunderstore|v0\\.2\\.0|v0\\.1|aoirint" .agents/skills`

### AI-assisted inspections

- Request: Review the changed Agent Skills for trigger/body consistency,
  generality, and scenario fit.
    - AI-assisted result: The prose-quality rules live in
      `document-quality-check`; related skills preserve their domain-specific
      responsibilities and reference the shared skill instead of duplicating the
      general wording rules.

### Manual checks

- Not applicable.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
