### PR TITLE
docs: audit repository docs and comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,8 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
 
 ## Development setup
 
-Follow the setup, formatting, build, package management, debugging, and release notes in [README.md](./README.md).
+Follow the setup, formatting, build, package management, debugging, and release
+notes in [README.md](./README.md).
 At minimum, install the documented .NET SDK and restore packages before building:
 
 ```powershell
@@ -27,7 +28,8 @@ dotnet restore --locked-mode
 ## Making changes
 
 - Prefer the existing project structure and naming conventions.
-- Keep user-facing behavior explicit in code, documentation, or changelog entries when the behavior changes.
+- Keep user-facing behavior explicit in code, documentation, or changelog
+  entries when the behavior changes.
 - Update `CHANGELOG.md` for developer-facing changes that should appear in release history.
 - Update files under `assets/` when the Thunderstore package metadata, icon, README, or release notes change.
 - Do not commit build output, downloaded game files, local mod manager profiles, or local machine configuration.
@@ -71,8 +73,8 @@ For package or release changes, also verify the release documentation in
   pull request. The original contributor may not be available to respond, but
   the maintainer can confirm whether the change is still wanted and coordinate
   attribution or next steps.
-- To keep work moving, maintainers may accept another contribution for the same issue without first rejecting an
-  inactive pull request.
+- To keep work moving, maintainers may accept another contribution for the same
+  issue without first rejecting an inactive pull request.
 - If a pull request stalls, maintainers or another contributor may continue the
   work in a separate pull request. This may include reusing or adapting the
   stalled pull request's commits, patch, tests, documentation, or ideas under
@@ -86,7 +88,8 @@ For package or release changes, also verify the release documentation in
 
 ## Contribution License Agreement
 
-By submitting a contribution to this project, you agree to this Contribution License Agreement.
+By submitting a contribution to this project, you agree to this Contribution
+License Agreement.
 If this agreement changes, new pull requests must use the current agreement.
 
 For this agreement, "you" means the person or organization submitting the
@@ -98,8 +101,10 @@ them for inclusion in the project.
 
 By submitting a contribution, you represent and agree that:
 
-- You have the legal right to submit the contribution and to grant the rights described in this agreement.
-- Your contribution may be distributed under the same license as this project, without additional terms or conditions.
+- You have the legal right to submit the contribution and to grant the rights
+  described in this agreement.
+- Your contribution may be distributed under the same license as this project,
+  without additional terms or conditions.
 - You grant the maintainer and downstream recipients a perpetual, worldwide,
   non-exclusive, no-charge, royalty-free, irrevocable copyright license to use,
   copy, modify, merge, publish, distribute, sublicense, and otherwise use your
@@ -110,8 +115,10 @@ By submitting a contribution, you represent and agree that:
   contribution as part of this project. This patent license applies only to
   patent claims that you can license and that are necessarily infringed by your
   contribution alone or by combining your contribution with the project.
-- You keep any copyright you hold in your contribution. This agreement is a license grant, not a copyright assignment.
-- The maintainer is not required to accept, publish, retain, or distribute any contribution.
+- You keep any copyright you hold in your contribution. This agreement is a
+  license grant, not a copyright assignment.
+- The maintainer is not required to accept, publish, retain, or distribute any
+  contribution.
 - Do not submit code, documentation, assets, generated output, or other
   materials if you do not have the right to contribute them under this
   agreement.
@@ -148,7 +155,8 @@ Examples that normally do not need disclosure:
 
 When in doubt:
 
-- If you are unsure whether assistance was "significant", treat it as significant and describe what you did.
+- If you are unsure whether assistance was "significant", treat it as
+  significant and describe what you did.
 
 Contributor responsibilities:
 
@@ -167,10 +175,12 @@ Contributor responsibilities:
 - Agent-generated pull requests are allowed only when a human contributor
   understands the change, adapts it to this codebase, verifies it, discloses the
   assistance, and can personally explain and maintain it.
-- Do not submit low-effort AI-generated or "vibe-coded" pull requests that do not meet those requirements.
+- Do not submit low-effort AI-generated or "vibe-coded" pull requests that do
+  not meet those requirements.
 - Write pull request descriptions and review replies in your own words. Use AI
   for editing help only if you still review and stand behind the final text.
-- Maintainers may close undisclosed, unverified, low-quality, or spam-like AI-assisted contributions.
+- Maintainers may close undisclosed, unverified, low-quality, or spam-like
+  AI-assisted contributions.
 
 ## Reporting security issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
 - Check the existing issues and pull requests to avoid duplicate work.
 - Open an issue first for larger behavior changes, compatibility changes, or
   anything that may affect release packaging.
-- Keep changes focused. Separate unrelated fixes, refactors, and documentation updates into separate pull requests
-  when practical.
+- Keep changes focused. Separate unrelated fixes, refactors, and documentation
+  updates into separate pull requests when practical.
 
 ## Development setup
 
@@ -54,7 +54,8 @@ For package or release changes, also verify the release documentation in
 - Use a clear title that summarizes the change.
 - Describe what changed and how you verified it.
 - Link related issues when applicable.
-- Keep the pull request small enough for maintainers to review without guessing at unrelated intent.
+- Keep the pull request small enough for maintainers to review without guessing
+  at unrelated intent.
 - Pull requests must include the pull request template checkbox confirmation for
   the Contribution License Agreement before they can be merged. Pull requests
   without that confirmation may be closed without further notice.
@@ -65,19 +66,23 @@ For package or release changes, also verify the release documentation in
   blocked, or no longer plan to continue the pull request, leave a short comment
   so maintainers know what to expect. Even if a long time has passed, it is
   always fine to reply with an update.
-- If you want to continue work from a stalled pull request, leave a short comment for the maintainer and the original
-  contributor before opening a new pull request. The original contributor may not be available to respond, but the
-  maintainer can confirm whether the change is still wanted and coordinate attribution or next steps.
+- If you want to continue work from a stalled pull request, leave a short
+  comment for the maintainer and the original contributor before opening a new
+  pull request. The original contributor may not be available to respond, but
+  the maintainer can confirm whether the change is still wanted and coordinate
+  attribution or next steps.
 - To keep work moving, maintainers may accept another contribution for the same issue without first rejecting an
   inactive pull request.
-- If a pull request stalls, maintainers or another contributor may continue the work in a separate pull request,
-  including by reusing or adapting the stalled pull request's commits, patch, tests, documentation, or ideas under the
-  Contribution License Agreement.
-- If your pull request reuses substantial work from another pull request, credit the original pull request and
-  contributor in your pull request description.
-- To keep maintainer work manageable and the review queue current, pull requests that remain inactive for a reasonable
-  period may be closed. This is not a judgment on the contributor, and it does not prevent you from opening a new pull
-  request later if the change is still useful.
+- If a pull request stalls, maintainers or another contributor may continue the
+  work in a separate pull request. This may include reusing or adapting the
+  stalled pull request's commits, patch, tests, documentation, or ideas under
+  the Contribution License Agreement.
+- If your pull request reuses substantial work from another pull request, credit
+  the original pull request and contributor in your pull request description.
+- To keep maintainer work manageable and the review queue current, pull requests
+  that remain inactive for a reasonable period may be closed. This is not a
+  judgment on the contributor, and it does not prevent you from opening a new
+  pull request later if the change is still useful.
 
 ## Contribution License Agreement
 
@@ -113,7 +118,8 @@ By submitting a contribution, you represent and agree that:
 
 ## AI-assisted contributions
 
-AI tools may be used as aids, but the human contributor remains responsible for the contribution.
+AI tools may be used as aids, but the human contributor remains responsible for
+the contribution.
 When AI assistance significantly affects a pull request, disclosure is required
 in the pull request description. The purpose of disclosure is to give reviewers
 enough context to understand where to focus, including areas you may not have
@@ -126,8 +132,11 @@ Examples that should be disclosed:
 - In the pull request description, specifically disclose AI assistance that
   significantly affected the pull request, but keep the disclosure practical.
   You do not need to provide a file-by-file table of AI involvement.
-- When possible, mention the rough prompt you gave an agent, the changes you asked it to make, changes made after
-  automated review, and what you focused on when reviewing or adapting the result.
+- When possible, mention:
+    - The rough prompt you gave an agent.
+    - The changes you asked it to make.
+    - Changes made after automated review.
+    - What you focused on when reviewing or adapting the result.
 - If there are areas you did not review closely or are less confident about,
   mention them so reviewers can check those areas more carefully.
 
@@ -143,8 +152,8 @@ When in doubt:
 
 Contributor responsibilities:
 
-- Review every AI-assisted change yourself. Do not assume generated code, documentation, tests, or explanations are
-  correct.
+- Review every AI-assisted change yourself. Do not assume generated code,
+  documentation, tests, or explanations are correct.
 - Provide verification evidence that matches the change, such as automated test
   output, build output, screenshots, or a clear description of any hands-on
   checks that could not reasonably be automated.
@@ -152,19 +161,30 @@ Contributor responsibilities:
   checks should be performed without AI automation. If an AI-assisted
   inspection is included, describe the request first, nest the AI result under
   it, and clearly label the result as AI-assisted.
-- Keep changes reviewable. Do not submit large, hard-to-review changes that cannot reasonably be checked by a
-  maintainer, whether they were generated by AI tools or written manually.
+- Keep changes reviewable. Do not submit large, hard-to-review changes that a
+  maintainer cannot reasonably check, whether they were generated by AI tools or
+  written manually.
 - Agent-generated pull requests are allowed only when a human contributor
   understands the change, adapts it to this codebase, verifies it, discloses the
   assistance, and can personally explain and maintain it.
 - Do not submit low-effort AI-generated or "vibe-coded" pull requests that do not meet those requirements.
-- Write pull request descriptions and review replies in your own words. Use AI for editing help only if you still
-  review and stand behind the final text.
+- Write pull request descriptions and review replies in your own words. Use AI
+  for editing help only if you still review and stand behind the final text.
 - Maintainers may close undisclosed, unverified, low-quality, or spam-like AI-assisted contributions.
 
 ## Reporting security issues
 
-If you suspect you found a security issue, do not share exploit details publicly or with untrusted recipients. This
-includes, but is not limited to, public issues, social media, blog posts, livestreams, video uploads, and similar public
-channels. Report it to the maintainer through a private and secure channel when possible, or to a trusted security
-organization.
+If you suspect you found a security issue, do not share exploit details publicly
+or with untrusted recipients.
+
+This includes, but is not limited to:
+
+- Public issues.
+- Social media.
+- Blog posts.
+- Livestreams.
+- Video uploads.
+- Similar public channels.
+
+Report the issue to the maintainer through a private and secure channel when
+possible, or to a trusted security organization.

--- a/CruiserJumpPractice/Core/UseCases/Client/PresentLoadCruiserStateResultUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/PresentLoadCruiserStateResultUseCase.cs
@@ -5,8 +5,9 @@ using CruiserJumpPractice.Core.Ports;
 
 namespace CruiserJumpPractice.Core.UseCases.Client;
 
-// Load result messages are emitted after the RPC returns to the requesting client. The server
-// restores state and reports a result; this use case owns how that result is explained to players.
+// Load result messages are emitted after the RPC returns to the requesting
+// client. The server restores state and reports a result; this use case owns how
+// that result is explained to players.
 internal sealed class PresentLoadCruiserStateResultUseCase
 {
     private readonly IGameInterop gameInterop;

--- a/CruiserJumpPractice/Core/UseCases/Client/ToggleMagnetUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/ToggleMagnetUseCase.cs
@@ -5,8 +5,9 @@ using CruiserJumpPractice.Core.Ports;
 
 namespace CruiserJumpPractice.Core.UseCases.Client;
 
-// Magnet toggling reuses the game's own synchronized lever behavior. The custom RPC surrogate is
-// reserved for cruiser snapshot save/load, so this use case only guards host authority and feedback.
+// Magnet toggling reuses the game's own synchronized lever behavior. The custom
+// RPC surrogate is reserved for cruiser snapshot save/load, so this use case
+// only guards host authority and feedback.
 internal sealed class ToggleMagnetUseCase
 {
     private readonly IGameInterop gameInterop;

--- a/CruiserJumpPractice/CruiserJumpPractice.cs
+++ b/CruiserJumpPractice/CruiserJumpPractice.cs
@@ -18,9 +18,9 @@ public class CruiserJumpPractice : BaseUnityPlugin
 
     private static PluginController? controller;
 
-    // Harmony and Netcode construct their callback objects outside our construction path. This
-    // static entry exposes one plugin-level controller instead of scattering use cases across
-    // patch and NetworkBehaviour classes.
+    // Harmony and Netcode construct their callback objects outside our
+    // construction path. This static entry exposes one plugin-level controller
+    // instead of scattering use cases across patch and NetworkBehaviour classes.
     internal static PluginController Controller => controller!;
 
     private void Awake()

--- a/CruiserJumpPractice/CruiserJumpPractice.csproj
+++ b/CruiserJumpPractice/CruiserJumpPractice.csproj
@@ -11,7 +11,8 @@
     <Version>0.2.0-alpha.2</Version>
     <!-- Target framework. https://learn.microsoft.com/en-us/dotnet/standard/frameworks -->
     <TargetFramework>netstandard2.1</TargetFramework>
-    <!-- C# language version. https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version -->
+    <!-- C# language version.
+         https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version -->
     <LangVersion>13.0</LangVersion>
   </PropertyGroup>
 

--- a/CruiserJumpPractice/Interop/Game/Adapters/ShipMagnetAdapter.cs
+++ b/CruiserJumpPractice/Interop/Game/Adapters/ShipMagnetAdapter.cs
@@ -7,8 +7,9 @@ using CruiserJumpPractice.Interop.Game;
 
 namespace CruiserJumpPractice.Interop.Game.Adapters;
 
-// ShipMagnetAdapter exposes the ship magnet state and toggle action used by practice mode.
-// Toggling goes through the game's lever animation because that path already sends the needed RPC.
+// ShipMagnetAdapter exposes the ship magnet state and toggle action used by
+// practice mode. Toggling goes through the game's lever animation because that
+// path already sends the needed RPC.
 internal sealed class ShipMagnetAdapter
 {
     private readonly ManualLogSource logger;
@@ -43,7 +44,8 @@ internal sealed class ShipMagnetAdapter
                 throw new GameInteropException("StartOfRound.magnetLever is null.");
             }
 
-            // NOTE: AnimatedObjectTrigger calls StartOfRound.SetMagnetOn and sends a ServerRpc internally.
+            // NOTE: AnimatedObjectTrigger calls StartOfRound.SetMagnetOn and
+            // sends a ServerRpc internally.
             magnetLever.TriggerAnimation(gameObjects.GetLocalPlayer());
         }
         catch (System.Exception error)

--- a/CruiserJumpPractice/Interop/Game/Behaviours/RpcSurrogateBehaviour.cs
+++ b/CruiserJumpPractice/Interop/Game/Behaviours/RpcSurrogateBehaviour.cs
@@ -10,8 +10,9 @@ using CruiserJumpPractice.Core.UseCases;
 
 namespace CruiserJumpPractice.Interop.Game.Behaviours;
 
-// Netcode RPC methods must live on a NetworkBehaviour, so this bridge stays in Interop. It crosses
-// the client/server boundary, then hands execution and result presentation back to PluginController.
+// Netcode RPC methods must live on a NetworkBehaviour, so this bridge stays in
+// Interop. It crosses the client/server boundary, then hands execution and
+// result presentation back to PluginController.
 internal class RpcSurrogateBehaviour : NetworkBehaviour
 {
     internal static ManualLogSource Logger => CruiserJumpPractice.Logger!;

--- a/CruiserJumpPractice/Interop/InputUtils/InputUtilsActions.cs
+++ b/CruiserJumpPractice/Interop/InputUtils/InputUtilsActions.cs
@@ -12,8 +12,8 @@ namespace CruiserJumpPractice.Interop.InputUtils;
 
 // InputUtilsActions declares the keybindings that InputUtils registers for the
 // plugin.
-// Practice-facing input behavior is adapted in InputUtilsPracticeInput, so this file stays as a
-// small attribute table with layout notes beside each binding.
+// Practice-facing input behavior is adapted in InputUtilsPracticeInput, so this
+// file stays as a small attribute table with layout notes beside each binding.
 // The repeated "Keymap:" rows are intentional table data, not prose that needs varied wording.
 internal sealed class InputUtilsActions : LcInputActions
 {

--- a/CruiserJumpPractice/Interop/InputUtils/InputUtilsActions.cs
+++ b/CruiserJumpPractice/Interop/InputUtils/InputUtilsActions.cs
@@ -10,7 +10,8 @@ using LethalCompanyInputUtils::LethalCompanyInputUtils.BindingPathEnums;
 
 namespace CruiserJumpPractice.Interop.InputUtils;
 
-// InputUtilsActions declares the keybindings that InputUtils registers for the plugin.
+// InputUtilsActions declares the keybindings that InputUtils registers for the
+// plugin.
 // Practice-facing input behavior is adapted in InputUtilsPracticeInput, so this file stays as a
 // small attribute table with layout notes beside each binding.
 // The repeated "Keymap:" rows are intentional table data, not prose that needs varied wording.

--- a/CruiserJumpPractice/Interop/InputUtils/InputUtilsPracticeInput.cs
+++ b/CruiserJumpPractice/Interop/InputUtils/InputUtilsPracticeInput.cs
@@ -7,8 +7,8 @@ namespace CruiserJumpPractice.Interop.InputUtils;
 
 // InputUtilsPracticeInput turns the InputUtilsActions declaration table into
 // Core's IPracticeInput.
-// Missing InputAction objects are treated as not triggered, so frame handling sees only simple
-// one-frame practice commands.
+// Missing InputAction objects are treated as not triggered, so frame handling
+// sees only simple one-frame practice commands.
 internal sealed class InputUtilsPracticeInput : IPracticeInput
 {
     private readonly InputUtilsActions inputActions;

--- a/CruiserJumpPractice/Interop/InputUtils/InputUtilsPracticeInput.cs
+++ b/CruiserJumpPractice/Interop/InputUtils/InputUtilsPracticeInput.cs
@@ -5,7 +5,8 @@ using CruiserJumpPractice.Core.Ports;
 
 namespace CruiserJumpPractice.Interop.InputUtils;
 
-// InputUtilsPracticeInput turns the InputUtilsActions declaration table into Core's IPracticeInput.
+// InputUtilsPracticeInput turns the InputUtilsActions declaration table into
+// Core's IPracticeInput.
 // Missing InputAction objects are treated as not triggered, so frame handling sees only simple
 // one-frame practice commands.
 internal sealed class InputUtilsPracticeInput : IPracticeInput

--- a/CruiserJumpPractice/PluginController.cs
+++ b/CruiserJumpPractice/PluginController.cs
@@ -14,9 +14,10 @@ using CruiserJumpPractice.Interop.InputUtils;
 
 namespace CruiserJumpPractice;
 
-// The controller is the plugin-facing facade: callbacks ask it to perform named plugin actions,
-// while the controller keeps the actual Core use cases private. It lives beside the BepInEx
-// entrypoint because it wires BepInEx logging, InputUtils input, and game interop into Core.
+// The controller is the plugin-facing facade. Callbacks ask it to perform named
+// plugin actions, while the controller keeps the actual Core use cases private.
+// It lives beside the BepInEx entrypoint because it wires BepInEx logging,
+// InputUtils input, and game interop into Core.
 internal sealed class PluginController
 {
     private readonly FrameHandler frameHandler;
@@ -45,9 +46,9 @@ internal sealed class PluginController
 
     public static PluginController Create(ManualLogSource logger)
     {
-        // Concrete integrations become Core ports here. Adding a new
-        // external dependency should usually mean adding another adapter here, not another
-        // static property on CruiserJumpPractice.
+        // Concrete integrations become Core ports here. Adding a new external
+        // dependency should usually mean adding another adapter here, not
+        // another static property on CruiserJumpPractice.
         var coreLogger = new BepInExCoreLogger(logger);
         var inputActions = new InputUtilsActions();
         var practiceInput = new InputUtilsPracticeInput(inputActions);

--- a/README.md
+++ b/README.md
@@ -168,11 +168,14 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
       project version.
 5. Commit and push the changes.
 6. CI will create a GitHub Release automatically.
-7. For stable releases, CI will upload the release artifact to Thunderstore automatically.
+7. For stable releases, CI will upload the release artifact to Thunderstore
+   automatically.
 
-   The current workflow deploys to the Thunderstore `aoirint` team and publishes to the `lethal-company`
-   community with the `Mods`, `Tweaks & Quality Of Life`, and `AI Generated` categories.
-   The `THUNDERSTORE_TOKEN` secret must belong to a Thunderstore service account that can publish to that team.
+   The current workflow deploys to the Thunderstore `aoirint` team and
+   publishes to the `lethal-company` community with the `Mods`,
+   `Tweaks & Quality Of Life`, and `AI Generated` categories.
+   The `THUNDERSTORE_TOKEN` secret must belong to a Thunderstore service
+   account that can publish to that team.
 
    **NOTE: Thunderstore does not support prerelease versions such as
    `1.2.3-beta.1`.**

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # CruiserJumpPractice
 
-A Lethal Company mod that saves/loads cruiser position, rotation, and condition, and lets you toggle the magnet
-remotely.
+A Lethal Company mod that saves and loads cruiser position, rotation, and condition.
+It also lets you toggle the magnet remotely.
 
 - [User guide](./assets/README.md)
 
@@ -158,11 +158,14 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
 ## Release
 
 1. Update the canonical developer changelog in `CHANGELOG.md`.
-2. For a stable release, derive the Thunderstore-facing release notes in `assets/CHANGELOG.md` from stable entries
-   in `CHANGELOG.md`.
-3. Replace version in `CruiserJumpPractice/CruiserJumpPractice.csproj` as semver format, e.g. `1.2.3`.
-4. Verify that `.github/workflows/build.yml` packages `assets/CHANGELOG.md` and that the `generate-version` action
-   updates `assets/manifest.json` from the project version.
+2. For a stable release, derive the Thunderstore-facing release notes in
+   `assets/CHANGELOG.md` from stable entries in `CHANGELOG.md`.
+3. Replace version in `CruiserJumpPractice/CruiserJumpPractice.csproj` with a
+   SemVer version such as `1.2.3`.
+4. Verify the release packaging flow:
+    - `.github/workflows/build.yml` packages `assets/CHANGELOG.md`.
+    - The `generate-version` action updates `assets/manifest.json` from the
+      project version.
 5. Commit and push the changes.
 6. CI will create a GitHub Release automatically.
 7. For stable releases, CI will upload the release artifact to Thunderstore automatically.
@@ -171,13 +174,14 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
    community with the `Mods`, `Tweaks & Quality Of Life`, and `AI Generated` categories.
    The `THUNDERSTORE_TOKEN` secret must belong to a Thunderstore service account that can publish to that team.
 
-   **NOTE: prerelease version is not supported by Thunderstore, e.g. `1.2.3-beta.1`.**
+   **NOTE: Thunderstore does not support prerelease versions such as
+   `1.2.3-beta.1`.**
 
 ### AI Disclosure
 
-Some parts of this project were developed with the assistance of AI tools based on large language models (LLMs),
-including agent-based tools.
-The code is reviewed by the author.
+Some parts of this project were developed with AI tools based on large language
+models (LLMs), including agent-based tools.
+The author reviews the code.
 This disclosure is made in compliance with Thunderstore policies.
 
 ## Debugging


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Audits maintainer-facing repository prose in `README.md` and `CONTRIBUTING.md`.
- Clarifies C# source comments and one `.csproj` comment without changing runtime behavior.
- Incorporates latest `origin/main` with a merge commit and adds a focused follow-up wrap pass for repository prose.

## Related Issues

- Refs #55
- Split from #57.

## Notes for reviewers

- This PR contains repository operations documentation, README, and code-comment prose only.
- User-facing Thunderstore prose and Agent Skill prose are handled in separate PRs.
- Latest `origin/main` was merged into `docs-audit-repo-prose` without rebasing or force-pushing.

### AI disclosure

- Codex split these changes out of #57, preserved the original prose-audit edits, merged latest main, and reviewed the scoped diff for accidental behavior changes.

## Testing

### Automated checks

- `git diff --check origin/main...HEAD` - passed; no whitespace errors.
- `docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5` - passed; 7 files linted, 0 errors.
- `dotnet restore --locked-mode` - passed; all projects up to date.
- `dotnet format --no-restore --verify-no-changes` - passed; no formatting changes required.
- `$env:DOTNET_CLI_UI_LANGUAGE='en'; dotnet build --no-restore` - passed; 0 warnings, 0 errors.

### AI-assisted inspections

- Request: Check that this split PR only contains repository docs, README, and code-comment prose.
  - AI-assisted result: Confirmed changed paths are limited to `README.md`, `CONTRIBUTING.md`, and `CruiserJumpPractice/` comments/project prose.

### Manual checks

- Reviewed the scoped diff for behavior, release-content, Agent Skill, and Thunderstore prose leakage.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.