### PR TITLE
docs: audit user-facing prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
 
 Some parts of this project were developed with AI tools based on large language
 models (LLMs), including agent-based tools.
-The code is reviewed by the project maintainer.
+The code is reviewed by the author.
 This disclosure is made in compliance with Thunderstore policies.
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
 
 Some parts of this project were developed with the assistance of AI tools based on large language models (LLMs),
 including agent-based tools.
-The code is reviewed by the author.
+The code is reviewed by the project maintainer.
 This disclosure is made in compliance with Thunderstore policies.
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
 
 Some parts of this project were developed with AI tools based on large language
 models (LLMs), including agent-based tools.
-The code is reviewed by the author.
+The author reviews the code.
 This disclosure is made in compliance with Thunderstore policies.
 
 ## Debugging

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -37,7 +37,7 @@ No gameplay changes are introduced.
 
 ### Changed
 
-- Enables keybind actions while the player is dead, same as Imperium.
+- Enables keybind actions while the player is dead, matching Imperium.
 
 ### Notes
 
@@ -60,7 +60,7 @@ No gameplay changes are introduced.
 ### Changed
 
 - Disables keybind actions while the player is in a menu, using the terminal,
-  typing in chat, or is dead.
+  typing in chat, or dead.
 
 ### Fixed
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,7 +1,7 @@
 # CruiserJumpPractice
 
-A Lethal Company mod that saves/loads cruiser position, rotation, and condition,
-and lets you toggle the magnet remotely.
+A Lethal Company mod that saves and loads cruiser position, rotation, and
+condition. It also lets you toggle the magnet remotely.
 
 This mod helps you practice cruiser jumps repeatedly without having to manually
 reset the cruiser every attempt.
@@ -31,8 +31,13 @@ Only the host can use all features of this mod. Clients will still receive the
 synced cruiser state even without this mod installed.
 
 [giosuel/Imperium](https://thunderstore.io/c/lethal-company/p/giosuel/Imperium/)
-is practically required. This mod does not provide any way to instantly spawn
-cruiser, teleport player, or **restore destroyed cruiser**.
+is practically required.
+
+This mod does not provide a way to:
+
+- Instantly spawn a cruiser.
+- Teleport a player.
+- **Restore a destroyed cruiser**.
 
 ## Keybinds
 
@@ -56,9 +61,9 @@ Clients cannot use all features even if they install this mod.
 
 ## AI Disclosure
 
-Some parts of this project were developed with the assistance of AI tools based
-on large language models (LLMs), including agent-based tools.
-The code is reviewed by the author.
+Some parts of this project were developed with AI tools based on large language
+models (LLMs), including agent-based tools.
+The author reviews the code.
 This disclosure is made in compliance with Thunderstore policies.
 
 [imperium-cruiser-workaround]: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735

--- a/assets/README.md
+++ b/assets/README.md
@@ -63,7 +63,7 @@ Clients cannot use all features even if they install this mod.
 
 Some parts of this project were developed with AI tools based on large language
 models (LLMs), including agent-based tools.
-The author reviews the code.
+The code is reviewed by the author.
 This disclosure is made in compliance with Thunderstore policies.
 
 [imperium-cruiser-workaround]: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735

--- a/assets/README.md
+++ b/assets/README.md
@@ -33,7 +33,7 @@ synced cruiser state even without this mod installed.
 [giosuel/Imperium](https://thunderstore.io/c/lethal-company/p/giosuel/Imperium/)
 is practically required.
 
-This mod does not provide a way to:
+Important: this mod **does not** provide any way to:
 
 - Instantly spawn a cruiser.
 - Teleport a player.

--- a/assets/README.md
+++ b/assets/README.md
@@ -35,9 +35,9 @@ is practically required.
 
 Important: this mod **does not** provide any way to:
 
-- Instantly spawn a cruiser.
-- Teleport a player.
-- **Restore a destroyed cruiser**.
+- ❌ Instantly spawn a cruiser.
+- ❌ Teleport a player.
+- ❌ **Restore a destroyed cruiser**.
 
 ## Keybinds
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -63,7 +63,7 @@ Clients cannot use all features even if they install this mod.
 
 Some parts of this project were developed with AI tools based on large language
 models (LLMs), including agent-based tools.
-The code is reviewed by the author.
+The code is reviewed by the project maintainer.
 This disclosure is made in compliance with Thunderstore policies.
 
 [imperium-cruiser-workaround]: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735

--- a/assets/README.md
+++ b/assets/README.md
@@ -23,9 +23,9 @@ reset the cruiser every attempt.
 
 ## What it does
 
-- Keybind to save the current cruiser state (position, rotation, HP, turbo boosts).
-- Keybind to load the saved cruiser state.
-- Keybind to toggle the magnet on/off remotely.
+- ✅ Keybind to save the current cruiser state (position, rotation, HP, turbo boosts).
+- ✅ Keybind to load the saved cruiser state.
+- ✅ Keybind to toggle the magnet on/off remotely.
 
 Only the host can use all features of this mod. Clients will still receive the
 synced cruiser state even without this mod installed.

--- a/assets/README.md
+++ b/assets/README.md
@@ -63,7 +63,7 @@ Clients cannot use all features even if they install this mod.
 
 Some parts of this project were developed with AI tools based on large language
 models (LLMs), including agent-based tools.
-The code is reviewed by the project maintainer.
+The code is reviewed by the author.
 This disclosure is made in compliance with Thunderstore policies.
 
 [imperium-cruiser-workaround]: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
     "name": "CruiserJumpPractice",
     "version_number": "0.0.0",
     "website_url": "https://github.com/aoirint/CruiserJumpPractice",
-    "description": "Saves/loads cruiser position, rotation, and condition, and lets you toggle the magnet remotely.",
+    "description": "Saves and loads cruiser position, rotation, and condition, and lets you toggle the magnet remotely.",
     "dependencies": [
         "BepInEx-BepInExPack-5.4.2100",
         "Rune580-LethalCompany_InputUtils-0.7.12"


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Audits Thunderstore-facing README prose, manifest description metadata, and package changelog wording.
- Incorporates latest `origin/main` with normal merge commits, without rebasing or rewriting PR history.
- Keeps user-facing compatibility and release-note meaning aligned with the latest `main` changelog content.
- Uses paired visual markers for supported actions and unsupported cruiser/player actions.

## Related Issues

- Refs #55
- Split from #57.
- AI Disclosure `author` to `project maintainer` wording was split out to #63.
- Explicit compatible/tested version wording for Thunderstore package description metadata was split out to #67.

## Notes for reviewers

- This PR contains user-visible package prose and `assets/CHANGELOG.md` only.
- The user is aware that this PR changes Thunderstore-facing package description metadata, not only rendered README content.
- Repository operations docs, code comments, Agent Skill prose, AI Disclosure maintainer terminology, and new compatibility-version wording are handled in separate PRs/issues.
- Follow-up `4ae5634` strengthens the unsupported-actions wording in `assets/README.md` to avoid implying those actions are available.
- Follow-up `e00b4a5` adds `❌` markers to each unsupported-action bullet for clearer scanability.
- Follow-up `7a582e6` adds matching `✅` markers to each supported-action bullet in `What it does`.
- Follow-ups `e300b99` and `4d58076` remove the AI Disclosure maintainer wording changes from this PR so #63 can own them.

### AI disclosure

- Codex split these changes out of #57, preserved the original prose-audit edits, merged latest `origin/main`, and reviewed the scoped diff for release-note nuance and supported/unsupported-action clarity.

## Testing

### Automated checks

- `git diff --check origin/main...HEAD` - passed with no whitespace errors.
- `git diff --name-only origin/main...HEAD | Where-Object { $_ -notin @('assets/README.md','assets/manifest.json','assets/CHANGELOG.md') }` - passed with no output after splitting AI Disclosure maintainer wording to #63.
- `docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5` - passed; `Summary: 0 error(s)`.
- `Get-Content -Raw assets/manifest.json | ConvertFrom-Json | Out-Null` - passed.

### AI-assisted inspections

- Request: Check that this refreshed PR only contains user-facing package prose and changelog wording after incorporating latest `origin/main`.
  - AI-assisted result: Confirmed the completed diff is limited to `assets/README.md`, `assets/manifest.json`, and `assets/CHANGELOG.md`.
- Request: Address reviewer feedback that `This mod does not provide a way to:` under-emphasized the negative and could mislead readers.
  - AI-assisted result: Updated the README wording to `Important: this mod **does not** provide any way to:` and rechecked the scoped diff.
- Request: Add visual emphasis to the unsupported-action bullets.
  - AI-assisted result: Added `❌` markers to each unsupported-action bullet and re-ran Markdown and scope checks.
- Request: Add matching positive visual emphasis to the supported keybind bullets.
  - AI-assisted result: Added `✅` markers to each `What it does` bullet and re-ran Markdown and scope checks.
- Request: Split the AI Disclosure `author` to `project maintainer` wording changes out of this PR.
  - AI-assisted result: Removed those wording changes from this PR and opened #63 to own both README disclosure updates.
- Request: Track explicit compatible/tested version wording for the Thunderstore package description metadata separately.
  - AI-assisted result: Opened #67 so this PR does not take on new compatibility-documentation policy decisions.

### Manual checks

- Reviewed the scoped diff for unintended source, Agent Skill, repository README, and unrelated asset leakage.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.