### PR TITLE
docs(skills): require skill metadata checks

### DIFF
--- a/.agents/skills/skill-quality-check/SKILL.md
+++ b/.agents/skills/skill-quality-check/SKILL.md
@@ -62,7 +62,12 @@ description: Quality-check Agent Skills for trigger clarity, scope, structure, p
    - For copied, adapted, generated, vendored, or reusable example files, preserve upstream
      copyright/license notices and apply the SPDX guidance from `code-quality-check`.
 8. Check metadata alignment:
+   - Check every changed skill folder for `agents/openai.yaml`. For new skills, create it unless
+     the repository has an explicit reason to omit app metadata for that skill.
+   - Treat a missing `agents/openai.yaml` as a blocking gap, not as an optional follow-up.
    - Keep `agents/openai.yaml` aligned with `SKILL.md` trigger wording, scope, and expected output.
+   - Include an SPDX notice, `interface.display_name`, `interface.short_description`, and
+     `interface.default_prompt` when creating app metadata.
    - Update or remove metadata that no longer directly supports the skill.
 9. Validate and iterate:
    - Run the available skill validator, if the project has one.
@@ -77,6 +82,8 @@ description: Quality-check Agent Skills for trigger clarity, scope, structure, p
      consecutive rounds with no new unclear points and no meaningful accuracy or effort improvement.
 10. Record verification:
    - Note external sources consulted, why they were needed, and how their guidance was applied.
+   - Note that each changed skill folder has `agents/openai.yaml`, or explain the repository policy
+     that intentionally omits it.
    - Note whether docs, changelog, PR notes, or follow-up domain skills are needed.
 
 When validating with scenarios, keep the report categories separate:


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Updates `skill-quality-check` to explicitly check every changed skill folder for `agents/openai.yaml`.
- Treats missing app metadata as a blocking gap instead of an optional follow-up.
- Documents the expected minimum fields when creating app metadata.

## Related Issues

- Follow-up from #60.

## Notes for reviewers

- Analysis: `document-quality-check` gained or changed `SKILL.md` content, but `skill-quality-check` only said to keep existing `agents/openai.yaml` aligned. It did not explicitly require checking that metadata exists for every changed skill folder or creating it for new skills. That made a missing metadata file easy to miss during a prose-only skill change.
- This PR tightens the metadata step and final verification note so future skill changes have an explicit metadata gate.

### AI disclosure

- Codex analyzed the #60 metadata omission and updated `skill-quality-check` to make the missing check explicit.

## Testing

### Automated checks

- `git diff --check`
- `docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5`

### AI-assisted inspections

- Request: Check whether the `skill-quality-check` workflow now blocks the class of omission found in #60.
  - AI-assisted result: The workflow now requires `agents/openai.yaml` existence checks for every changed skill folder and says missing metadata is a blocking gap.

### Manual checks

- Reviewed the scoped diff for unrelated skill policy changes.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.