### PR TITLE
docs: reorganize README maintenance guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ CI action together after the repository cooldown period has elapsed.
 
 ## Package management
 
-### NuGet lock file updates
+### Dependency updates
 
 To update the lock file after modifying your package references, run:
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,38 @@ dotnet format --no-restore --verify-no-changes
 style, and fixable analyzer diagnostics. Roslyn analyzers also run during build,
 including diagnostics that cannot be automatically fixed.
 
+### Markdown lint
+
+Markdown is checked with `markdownlint-cli2`. The project uses the pinned Docker
+image below so contributors do not need a local Node.js project.
+The image's default working directory is `/workdir`, so mount the repository
+there. Run it without network access and as a non-root user.
+
+On Windows with PowerShell, use UID/GID `1000:1000`:
+
+```powershell
+docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5
+```
+
+On Linux, use `sudo docker` and pass the host user's UID and GID:
+
+```bash
+sudo docker run --rm --network none --user "$(id -u):$(id -g)" -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5
+```
+
+When updating Markdown lint tooling, update both the local Docker image and the
+CI action together after the repository cooldown period has elapsed.
+
+## Package management
+
+### NuGet lock file updates
+
+To update the lock file after modifying your package references, run:
+
+```powershell
+dotnet restore --use-lock-file
+```
+
 ### .NET and C# tooling updates
 
 This project separates the SDK used to build and format the mod from the target
@@ -79,36 +111,6 @@ Maintenance references:
 - [.NET SDK, MSBuild, and Visual Studio versioning](https://learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs)
 - [Configure C# language version](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version)
 - [`dotnet format`](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-format)
-
-### Markdown lint
-
-Markdown is checked with `markdownlint-cli2`. The project uses the pinned Docker
-image below so contributors do not need a local Node.js project.
-The image's default working directory is `/workdir`, so mount the repository
-there. Run it without network access and as a non-root user.
-
-On Windows with PowerShell, use UID/GID `1000:1000`:
-
-```powershell
-docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5
-```
-
-On Linux, use `sudo docker` and pass the host user's UID and GID:
-
-```bash
-sudo docker run --rm --network none --user "$(id -u):$(id -g)" -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5
-```
-
-When updating Markdown lint tooling, update both the local Docker image and the
-CI action together after the repository cooldown period has elapsed.
-
-## Package management
-
-To update the lock file after modifying your package references, run:
-
-```powershell
-dotnet restore --use-lock-file
-```
 
 ## GitHub Actions
 

--- a/README.md
+++ b/README.md
@@ -180,13 +180,6 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
    **NOTE: Thunderstore does not support prerelease versions such as
    `1.2.3-beta.1`.**
 
-### AI Disclosure
-
-Some parts of this project were developed with AI tools based on large language
-models (LLMs), including agent-based tools.
-The author reviews the code.
-This disclosure is made in compliance with Thunderstore policies.
-
 ## Debugging
 
 ### r2modman
@@ -210,3 +203,10 @@ This disclosure is made in compliance with Thunderstore policies.
 5. Set `Logging.Console.Enabled` to `true`.
 6. Set `Logging.Console.LogLevels` to `All`.
 7. Launch `Lethal Company.exe` again.
+
+## AI Disclosure
+
+Some parts of this project were developed with AI tools based on large language
+models (LLMs), including agent-based tools.
+The author reviews the code.
+This disclosure is made in compliance with Thunderstore policies.


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Reorganizes top-level `README.md` maintenance guidance for clearer scanning.
- Moves the AI Disclosure out of the `Release` section and into a final top-level `## AI Disclosure` section.
- Moves `.NET and C# tooling updates` under `Package management`.
- Splits package update guidance into `Dependency updates` and `.NET and C# tooling updates` subsections.

## Related Issues

- Follow-up to #58.

## Notes for reviewers

- This is a README structure-only change; it moves existing guidance without changing the AI disclosure text.
- #58 was already merged, so this follow-up PR starts from latest `main` instead of updating that closed PR.
- Follow-up `5f7c867` expanded the PR responsibility from AI Disclosure placement to README maintenance-guidance organization.
- Follow-up `073f404` renames `NuGet lock file updates` to `Dependency updates` because the restore command can refresh dependency versions when direct package ranges permit it.

### AI disclosure

- Codex moved the existing README disclosure block, reorganized package-management guidance, and verified the resulting Markdown structure.

## Testing

### Automated checks

- `git diff --check origin/main...HEAD` - passed with no whitespace errors.
- `rg -n "^## Package management|^### Dependency updates|^### NuGet lock file updates|^### \\.NET and C# tooling updates" README.md` - confirmed the package-management subsection names.
- `docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5` - passed; `Summary: 0 error(s)`.
- `dotnet restore --locked-mode` - passed.
- `dotnet format --no-restore --verify-no-changes` - passed.
- `$env:DOTNET_CLI_UI_LANGUAGE='en'; dotnet build --no-restore` - passed; 0 warnings, 0 errors.

### AI-assisted inspections

- Request: Move the top-level README AI disclosure to the current end because it is hard to read inside `Release`.
  - AI-assisted result: Confirmed the disclosure is now the final top-level README section.
- Request: Move `.NET and C# tooling updates` into `Package management` and sectionize the existing update operation.
  - AI-assisted result: Confirmed `Package management` now contains separate dependency update and `.NET and C# tooling updates` subsections.
- Request: Rename `NuGet lock file updates` to `Dependency updates`.
  - AI-assisted result: Renamed the subsection after confirming it better covers updates from package reference changes and version ranges.
- Request: Update the PR title and description because the PR responsibility expanded.
  - AI-assisted result: Retitled the PR from `docs: move AI disclosure to README end` to `docs: reorganize README maintenance guidance` and refreshed the description around the broader README organization scope.

### Manual checks

- Reviewed the README diff for accidental content changes.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.