### PR TITLE
docs: use maintainer in AI disclosures

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
 
 Some parts of this project were developed with AI tools based on large language
 models (LLMs), including agent-based tools.
-The author reviews the code.
+The code is reviewed by the project maintainer.
 This disclosure is made in compliance with Thunderstore policies.
 
 ## Debugging

--- a/assets/README.md
+++ b/assets/README.md
@@ -58,7 +58,7 @@ Clients cannot use all features even if they install this mod.
 
 Some parts of this project were developed with the assistance of AI tools based
 on large language models (LLMs), including agent-based tools.
-The code is reviewed by the author.
+The code is reviewed by the project maintainer.
 This disclosure is made in compliance with Thunderstore policies.
 
 [imperium-cruiser-workaround]: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Updates the top-level `README.md` AI Disclosure to say the code is reviewed by the project maintainer.
- Updates the Thunderstore-facing `assets/README.md` AI Disclosure to use the same `project maintainer` wording.
- Aligns both disclosures with `CONTRIBUTING.md`, which identifies the project maintainer via `CODEOWNERS`.

## Related Issues

- Split follow-up from #59 and #62.

## Notes for reviewers

- This PR contains only the AI Disclosure reviewer terminology change.
- The change was split out because #59 is focused on user-facing package prose and #62 is focused on README maintenance-guidance organization.
- Top-level `README.md` currently uses `The author reviews the code.` on `main`; `assets/README.md` uses `The code is reviewed by the author.`. This PR makes both use `The code is reviewed by the project maintainer.`.

### AI disclosure

- Codex split this wording change out of broader documentation PRs and verified the two README disclosures against `CONTRIBUTING.md` maintainer terminology.

## Testing

### Automated checks

- `git diff --check origin/main...HEAD` - passed with no whitespace errors.
- `docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5` - passed; `Summary: 0 error(s)`.
- `dotnet restore --locked-mode` - passed.
- `dotnet format --no-restore --verify-no-changes` - passed.
- `$env:DOTNET_CLI_UI_LANGUAGE='en'; dotnet build --no-restore` - passed; 0 warnings, 0 errors.

### AI-assisted inspections

- Request: Separate the `author` to `project maintainer` AI Disclosure wording change into a new PR.
  - AI-assisted result: Confirmed the new PR changes only `README.md` and `assets/README.md` AI Disclosure reviewer wording.

### Manual checks

- Reviewed both README diffs for unrelated content changes.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.