### PR TITLE
docs(skills): align commit message quality skill

### DIFF
--- a/.agents/skills/commit-message-quality-check/SKILL.md
+++ b/.agents/skills/commit-message-quality-check/SKILL.md
@@ -1,4 +1,5 @@
 ---
+# SPDX-License-Identifier: Unlicense
 name: commit-message-quality-check
 description: >-
   Quality-check repository commit messages. Use when creating or updating commit
@@ -7,20 +8,39 @@ description: >-
 
 # Commit Message Quality Check
 
+## When to Use
+
+- Use this skill when creating, updating, reviewing, or validating a commit
+  message for this repository.
+
 ## Goals
 
 - Check commit messages against Conventional Commits 1.0.0.
 - Check repository attribution policy, including AI agent co-author trailers.
+- Recommend message changes that fit the actual staged or committed change.
+- Keep commit guidance focused on message quality, not on reviewing the
+  underlying code or documentation diff.
 
 Reference:
 - Conventional Commits 1.0.0: https://www.conventionalcommits.org/en/v1.0.0/
 - GitHub co-authored commits:
   https://docs.github.com/articles/creating-a-commit-with-multiple-authors
 
-## When to Use
+## Workflow
 
-- Use this skill when creating, updating, reviewing, or validating a commit
-  message for this repository.
+1. Read the proposed commit message and, when available, the staged diff or
+   commit diff it describes.
+2. Verify the first-line format, blank-line structure, body placement, and
+   footer placement.
+3. Check that the type, optional scope, breaking-change marker, and short
+   description match the dominant intent of the change.
+4. Check that any body explains useful context, motivation, or impact instead
+   of repeating the summary.
+5. Check required footer or trailer metadata, including `BREAKING CHANGE` and
+   AI agent `Co-authored-by:` trailers when applicable.
+6. Recommend the smallest correction that makes the message valid and accurate.
+7. If the diff contains multiple unrelated logical changes, recommend splitting
+   the commit when practical.
 
 ## Format
 


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Add the repository SPDX notice convention to `commit-message-quality-check`.
- Reorder the skill into the preferred `When to Use`, `Goals`, and `Workflow` shape.
- Keep the existing Conventional Commits and AI co-author trailer guidance focused on commit-message review.

## Related Issues

- Refs #72

## Notes for reviewers

- This PR intentionally changes only `.agents/skills/commit-message-quality-check/SKILL.md`.
- `agents/openai.yaml` was reviewed and left unchanged because its trigger and prompt still match the skill scope.

### AI disclosure

- Codex used a dedicated implementation subagent for this skill and a separate review subagent before PR creation.
- I reviewed the reported diff scope, checks, and scenario validation before opening this PR.

## Testing

### Automated checks

- `docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5 ".agents/skills/commit-message-quality-check/SKILL.md"` passed with `0 error(s)`.
- `git diff --check` passed.
- Structural check for SPDX and preferred headings passed.

### AI-assisted inspections

- Request: Implement Issue #72 for `commit-message-quality-check` with `skill-quality-check` validation.
  - AI-assisted result: Added SPDX notice, preferred structure, and focused workflow while preserving Conventional Commits and co-author guidance.
- Request: Review `issue-72-commit-message-skill` before PR creation against `skill-quality-check`, `document-quality-check`, and `commit-message-quality-check`.
  - AI-assisted result: No blocking findings. The skill follows the repository SPDX convention, uses the preferred structure, remains focused on commit-message quality, and stays aligned with `agents/openai.yaml`.
- Request: Validate commit-message-quality scenarios.
  - AI-assisted result: Median case passed for a docs-only skill commit using Conventional Commits and co-author trailer checks. Edge/out-of-scope case passed for passive AI review advice, which should not require an AI `Co-authored-by:` trailer, and for underlying diff review, which should route to other quality skills.

### Manual checks

- Not applicable.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.