### PR TITLE
docs(gitignore-workflow): require template provenance checks

### DIFF
--- a/.agents/skills/gitignore-workflow/SKILL.md
+++ b/.agents/skills/gitignore-workflow/SKILL.md
@@ -14,7 +14,9 @@ description: "Create or update .gitignore files. Use when editing ignore rules."
 
 - Keep project-specific ignore rules explicit and easy to review.
 - Merge upstream template content from `github/gitignore` without losing local rules.
-- Record template provenance with commit-hash URLs for reproducibility.
+- Record external-template provenance with commit-hash URLs for reproducibility.
+- Review upstream license and SPDX expectations before copying, adapting, or refreshing external
+  template content.
 - Avoid introducing regressions, for example accidentally tracking generated files.
 - Support both minimal edits and full template refreshes.
 - Work across mixed-language repositories.
@@ -23,11 +25,21 @@ description: "Create or update .gitignore files. Use when editing ignore rules."
 
 1. Inspect the current repository state before editing.
 2. Read the current `.gitignore` and classify entries as project-specific vs template-derived.
-3. If template sync is requested, fetch template files from `github/gitignore` using a pinned
-   commit hash.
-4. Merge sections in a deterministic order requested by the user or a safe default order.
-5. Validate with `git status` that ignored/generated files behave as expected.
-6. Summarize behavior-impacting changes, especially `.env`, lockfiles, build artifacts, caches, and
+3. If template sync is requested, treat the copied template content as supply-chain-sensitive
+   external material:
+   - Use `security-check` for network-fetch safety, source provenance, pinning, and any blocker
+     decision.
+   - Use `code-quality-check` SPDX guidance for copied, adapted, downloaded, generated, or vendored
+     text, including upstream license-notice expectations.
+4. Verify the upstream template source before fetching or copying:
+   - Confirm the exact repository, template path, commit hash, and upstream license or notice
+     requirements.
+   - Prefer reviewer-visible commit-hash URLs over branch, tag, or `latest` references.
+   - Report a blocker instead of fetching or copying when provenance, license compatibility,
+     required attribution, or the safe network path cannot be verified.
+5. Merge sections in a deterministic order requested by the user or a safe default order.
+6. Validate with `git status` that ignored/generated files behave as expected.
+7. Summarize behavior-impacting changes, especially `.env`, lockfiles, build artifacts, caches, and
    IDE folders.
 
 ## Recommended Section Order
@@ -61,7 +73,8 @@ For multi-stack repositories, repeat this pattern per template:
 
 ## Template Fetch Pattern
 
-Use shell commands that pin the source to one commit hash.
+Use network fetches only after the safety and provenance checks above pass.
+Pin the source to one reviewed commit hash and keep the command reviewer-visible.
 
 ```bash
 hash=$(git ls-remote https://github.com/github/gitignore.git refs/heads/main | awk '{print $1}')
@@ -70,11 +83,14 @@ curl -fsSL "https://raw.githubusercontent.com/github/gitignore/$hash/Python.giti
 
 For other templates, replace paths with exact file paths from `github/gitignore`.
 For example, use `Global/VisualStudioCode.gitignore`.
+If the command, source repository, template path, commit hash, upstream license, or required notice
+cannot be verified, stop and report the blocker instead of fetching or copying template content.
 
 ## Safety Checks
 
 - Do not remove project-specific entries unless explicitly requested.
 - Keep duplicate patterns if they come from upstream templates; avoid semantic edits to upstream blocks.
+- Preserve upstream notices or attribution required by the reviewed template license.
 - Preserve `.env` handling intentionally. If behavior changes, call it out in the summary.
 - Never include secrets or real environment values in `.gitignore` comments.
 - If files are already tracked, mention that `.gitignore` alone does not untrack them.
@@ -83,6 +99,9 @@ For example, use `Global/VisualStudioCode.gitignore`.
 ## Output Checklist
 
 - `.gitignore` updated in requested format.
-- All upstream template URLs include commit hashes.
+- All upstream template URLs include commit hashes, exact paths, and reviewed provenance.
+- Upstream license/SPDX requirements were reviewed, preserved when needed, or reported as a blocker.
+- Network fetches were either avoided, performed through a pinned and verified source, or blocked
+  with the reason recorded.
 - `git status --short` reviewed after edits.
 - User summary includes what changed, why, and any follow-up commands if tracked files must be untracked.

--- a/.agents/skills/gitignore-workflow/agents/openai.yaml
+++ b/.agents/skills/gitignore-workflow/agents/openai.yaml
@@ -4,4 +4,5 @@ interface:
   short_description: "Create or update .gitignore files."
   default_prompt: >-
     Create or update .gitignore rules while preserving project-specific entries
-    and validating ignored file behavior.
+    and validating ignored file behavior, external-template provenance, and
+    license/SPDX expectations.


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Require `gitignore-workflow` to check external template provenance before syncing from `github/gitignore`.
- Add explicit handoff to `security-check` and `code-quality-check` for network fetches, copied template content, and upstream license/SPDX review.
- Update `agents/openai.yaml` so the skill metadata reflects template provenance and SPDX review.

## Related Issues

- Refs #72

## Notes for reviewers

- Review focus: whether the new external-template safety guidance is strict enough without making local-only `.gitignore` edits unnecessarily heavy.
- This PR does not fetch or copy any external template content.

### AI disclosure

- Codex used a dedicated implementation subagent for this skill and a separate review subagent before PR creation.
- I reviewed the reported diff scope, checks, security handoff, and scenario validation before opening this PR.

## Testing

### Automated checks

- `git diff --check` passed.
- 120-column scan for changed `SKILL.md` passed.
- Pinned no-network `markdownlint-cli2` Docker check for repo Markdown passed with `0 error(s)`.
- Direct pinned no-network `markdownlint-cli2` check for changed skill Markdown passed with `0 error(s)`.

### AI-assisted inspections

- Request: Implement Issue #72 for `gitignore-workflow` with `skill-quality-check` and `security-check` validation.
  - AI-assisted result: Added external-template provenance, network-fetch safety, license/SPDX review, and blocker handling before fetching or copying template content.
- Request: Review `issue-72-gitignore-workflow` before PR creation against `skill-quality-check`, `security-check`, `code-quality-check`, `document-quality-check`, and Issue #72 requirements.
  - AI-assisted result: No blocking findings. Confirmed the skill routes external-template sync through provenance, network-fetch safety, pinning, license/SPDX review, and blocker handling, and confirmed `agents/openai.yaml` remains present and aligned.
- Request: Validate gitignore-workflow scenarios for the materially revised skill.
  - AI-assisted result: Passed. Median case for syncing `Python.gitignore` from `github/gitignore` requires exact repo/path/commit provenance, reviewed upstream license expectations, and commit-hash URLs. Edge case for unverifiable provenance, license compatibility, attribution, or safe network fetch requires stopping and reporting a blocker. Minimal local edit case does not force external fetch work while still preserving local entries and validating behavior with `git status`.

### Manual checks

- Not applicable.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.