### PR TITLE
docs(thunderstore): document tested compatibility marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Dropped backward compatibility with older CruiserJumpPractice versions:
     - Affects CruiserJumpPractice v0.1.4 and earlier.
     - Caused by a mod-internal `NetworkBehaviour` name change.
-- Documented tested Lethal Company and dependency versions in the Thunderstore
-  package description metadata and release checklist.
+- Documented the tested Lethal Company version in the Thunderstore package
+  description metadata and release checklist.
 - Marked automated Thunderstore uploads with an additional Thunderstore
   category:
     - `AI Generated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Dropped backward compatibility with older CruiserJumpPractice versions:
     - Affects CruiserJumpPractice v0.1.4 and earlier.
     - Caused by a mod-internal `NetworkBehaviour` name change.
+- Documented tested Lethal Company and dependency versions in the Thunderstore
+  package description metadata and release checklist.
 - Marked automated Thunderstore uploads with an additional Thunderstore
   category:
     - `AI Generated`

--- a/README.md
+++ b/README.md
@@ -165,15 +165,23 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
 3. Update the Thunderstore package description compatibility marker in
    `assets/manifest.json` when the `assets/README.md` `Compatibility` section
    records a newly tested Lethal Company version.
-   Use the compact marker format `[v<version>]` at the start of the
-   description.
-   In this marker, `version` means the tested Lethal Company version.
+   Use the compact marker format `[v<version>]` or
+   `[v<older-version>/<newer-version>]` at the start of the description.
+   For example, use `[v72/v81.5]` when the marker intentionally covers both
+   Lethal Company versions.
+   In this marker, versions mean tested or maintainer-confirmed Lethal Company
+   versions from `assets/README.md`.
+   List slash-separated versions from older to newer.
+   Keep best-effort or lower-confidence compatibility notes out of the marker;
+   document those in `assets/README.md` or `CHANGELOG.md` instead.
    Restore or update the description by replacing any existing leading marker
    with the new marker, then preserving the base description:
-   `[v<version>] <description without the compatibility marker>`.
-   Do not prepend a new marker to a description that already starts with
-   `[v...]`; the manifest description should have exactly one compatibility
-   marker.
+   `[v<version-or-versions>] <description without the compatibility marker>`.
+   Treat single-version markers such as `[v81.5]` and slash-separated markers
+   such as `[v72/v81.5]` as the same leading compatibility marker.
+   Do not prepend a new marker to a description that already starts with a
+   compatibility marker; the manifest description should have exactly one
+   leading compatibility marker group.
    Keep detailed compatibility and test environment information in
    `assets/README.md` and `CHANGELOG.md`.
    Handle dependency string changes in `assets/manifest.json` as separate

--- a/README.md
+++ b/README.md
@@ -170,8 +170,7 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
    In this marker, `version` means the tested Lethal Company version.
    Restore or update the description by prepending the marker to the preserved
    base description:
-   `[v<version>] Saves and loads cruiser position, rotation, and condition, and
-   lets you toggle the magnet remotely.`
+   `[v<version>] <description without the compatibility marker>`.
    Keep detailed compatibility and test environment information in
    `assets/README.md` and `CHANGELOG.md`.
    Handle dependency string changes in `assets/manifest.json` as separate

--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
    Use the compact marker format `[LC v<version> tested]` at the start of the
    description, and keep the dependency versions aligned with the latest
    tested environment there.
+   Keep the `assets/manifest.json` dependency strings aligned with dependency
+   versions named in the package description unless the package intentionally
+   supports an older dependency baseline.
    Treat `CHANGELOG.md` as the developer-facing compatibility history.
 4. Replace version in `CruiserJumpPractice/CruiserJumpPractice.csproj` with a
    SemVer version such as `1.2.3`.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
    records a newly tested Lethal Company version.
    Use the compact marker format `[v<version>]` at the start of the
    description.
+   In this marker, `version` means the tested Lethal Company version.
+   Keep detailed compatibility and test environment information in
+   `assets/README.md` and `CHANGELOG.md`.
+   Handle dependency string changes in `assets/manifest.json` as separate
+   dependency maintenance, with the reason and compatibility impact documented
+   in that change.
    Treat `CHANGELOG.md` as the developer-facing compatibility history.
 4. Replace version in `CruiserJumpPractice/CruiserJumpPractice.csproj` with a
    SemVer version such as `1.2.3`.

--- a/README.md
+++ b/README.md
@@ -168,9 +168,10 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
    Use the compact marker format `[v<version>]` at the start of the
    description.
    In this marker, `version` means the tested Lethal Company version.
-   Example:
-   `[v81.5] Saves and loads cruiser position, rotation, and condition, and lets
-   you toggle the magnet remotely.`
+   Restore or update the description by prepending the marker to the preserved
+   base description:
+   `[v<version>] Saves and loads cruiser position, rotation, and condition, and
+   lets you toggle the magnet remotely.`
    Keep detailed compatibility and test environment information in
    `assets/README.md` and `CHANGELOG.md`.
    Handle dependency string changes in `assets/manifest.json` as separate

--- a/README.md
+++ b/README.md
@@ -164,10 +164,9 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
    `assets/CHANGELOG.md` from stable entries in `CHANGELOG.md`.
 3. Update the Thunderstore package description compatibility marker in
    `assets/manifest.json` when the `assets/README.md` `Compatibility` section
-   records a newly tested Lethal Company version or dependency version.
-   Use the compact marker format `[LC v<version> tested]` at the start of the
-   description, and keep the dependency versions aligned with the latest
-   tested environment there.
+   records a newly tested Lethal Company version.
+   Use the compact marker format `[v<version>]` at the start of the
+   description.
    Treat `CHANGELOG.md` as the developer-facing compatibility history.
 4. Replace version in `CruiserJumpPractice/CruiserJumpPractice.csproj` with a
    SemVer version such as `1.2.3`.

--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
    Use the compact marker format `[v<version>]` at the start of the
    description.
    In this marker, `version` means the tested Lethal Company version.
+   Example:
+   `[v81.5] Saves and loads cruiser position, rotation, and condition, and lets
+   you toggle the magnet remotely.`
    Keep detailed compatibility and test environment information in
    `assets/README.md` and `CHANGELOG.md`.
    Handle dependency string changes in `assets/manifest.json` as separate

--- a/README.md
+++ b/README.md
@@ -168,9 +168,6 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
    Use the compact marker format `[LC v<version> tested]` at the start of the
    description, and keep the dependency versions aligned with the latest
    tested environment there.
-   Keep the `assets/manifest.json` dependency strings aligned with dependency
-   versions named in the package description unless the package intentionally
-   supports an older dependency baseline.
    Treat `CHANGELOG.md` as the developer-facing compatibility history.
 4. Replace version in `CruiserJumpPractice/CruiserJumpPractice.csproj` with a
    SemVer version such as `1.2.3`.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
    records a newly tested Lethal Company version.
    Use the compact marker format `[v<version>]` or
    `[v<older-version>/<newer-version>]` at the start of the description.
-   For example, use `[v72/v81.5]` when the marker intentionally covers both
+   For example, use `[v73/v81.5]` when the marker intentionally covers both
    Lethal Company versions.
    In this marker, versions mean tested or maintainer-confirmed Lethal Company
    versions from `assets/README.md`.
@@ -178,7 +178,7 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
    with the new marker, then preserving the base description:
    `[v<version-or-versions>] <description without the compatibility marker>`.
    Treat single-version markers such as `[v81.5]` and slash-separated markers
-   such as `[v72/v81.5]` as the same leading compatibility marker.
+   such as `[v73/v81.5]` as the same leading compatibility marker.
    Do not prepend a new marker to a description that already starts with a
    compatibility marker; the manifest description should have exactly one
    leading compatibility marker group.

--- a/README.md
+++ b/README.md
@@ -168,9 +168,12 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
    Use the compact marker format `[v<version>]` at the start of the
    description.
    In this marker, `version` means the tested Lethal Company version.
-   Restore or update the description by prepending the marker to the preserved
-   base description:
+   Restore or update the description by replacing any existing leading marker
+   with the new marker, then preserving the base description:
    `[v<version>] <description without the compatibility marker>`.
+   Do not prepend a new marker to a description that already starts with
+   `[v...]`; the manifest description should have exactly one compatibility
+   marker.
    Keep detailed compatibility and test environment information in
    `assets/README.md` and `CHANGELOG.md`.
    Handle dependency string changes in `assets/manifest.json` as separate

--- a/README.md
+++ b/README.md
@@ -162,15 +162,22 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
 1. Update the canonical developer changelog in `CHANGELOG.md`.
 2. For a stable release, derive the Thunderstore-facing release notes in
    `assets/CHANGELOG.md` from stable entries in `CHANGELOG.md`.
-3. Replace version in `CruiserJumpPractice/CruiserJumpPractice.csproj` with a
+3. Update the Thunderstore package description compatibility marker in
+   `assets/manifest.json` when the `assets/README.md` `Compatibility` section
+   records a newly tested Lethal Company version or dependency version.
+   Use the compact marker format `[LC v<version> tested]` at the start of the
+   description, and keep the dependency versions aligned with the latest
+   tested environment there.
+   Treat `CHANGELOG.md` as the developer-facing compatibility history.
+4. Replace version in `CruiserJumpPractice/CruiserJumpPractice.csproj` with a
    SemVer version such as `1.2.3`.
-4. Verify the release packaging flow:
+5. Verify the release packaging flow:
     - `.github/workflows/build.yml` packages `assets/CHANGELOG.md`.
     - The `generate-version` action updates `assets/manifest.json` from the
       project version.
-5. Commit and push the changes.
-6. CI will create a GitHub Release automatically.
-7. For stable releases, CI will upload the release artifact to Thunderstore
+6. Commit and push the changes.
+7. CI will create a GitHub Release automatically.
+8. For stable releases, CI will upload the release artifact to Thunderstore
    automatically.
 
    The current workflow deploys to the Thunderstore `aoirint` team and

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -4,7 +4,7 @@
     "website_url": "https://github.com/aoirint/CruiserJumpPractice",
     "description": "[LC v81.5 tested] Saves and loads cruiser state, and toggles the magnet remotely. Tested with BepInExPack v5.4.2305, InputUtils v0.7.13, and Imperium v1.3.0.",
     "dependencies": [
-        "BepInEx-BepInExPack-5.4.2305",
-        "Rune580-LethalCompany_InputUtils-0.7.13"
+        "BepInEx-BepInExPack-5.4.2100",
+        "Rune580-LethalCompany_InputUtils-0.7.12"
     ]
 }

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
     "name": "CruiserJumpPractice",
     "version_number": "0.0.0",
     "website_url": "https://github.com/aoirint/CruiserJumpPractice",
-    "description": "[LC v81.5 tested] Saves and loads cruiser state, and toggles the magnet remotely. Tested with BepInExPack v5.4.2305, InputUtils v0.7.13, and Imperium v1.3.0.",
+    "description": "[v81.5] Saves and loads cruiser position, rotation, and condition, and lets you toggle the magnet remotely.",
     "dependencies": [
         "BepInEx-BepInExPack-5.4.2100",
         "Rune580-LethalCompany_InputUtils-0.7.12"

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -4,7 +4,7 @@
     "website_url": "https://github.com/aoirint/CruiserJumpPractice",
     "description": "[LC v81.5 tested] Saves and loads cruiser state, and toggles the magnet remotely. Tested with BepInExPack v5.4.2305, InputUtils v0.7.13, and Imperium v1.3.0.",
     "dependencies": [
-        "BepInEx-BepInExPack-5.4.2100",
-        "Rune580-LethalCompany_InputUtils-0.7.12"
+        "BepInEx-BepInExPack-5.4.2305",
+        "Rune580-LethalCompany_InputUtils-0.7.13"
     ]
 }

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
     "name": "CruiserJumpPractice",
     "version_number": "0.0.0",
     "website_url": "https://github.com/aoirint/CruiserJumpPractice",
-    "description": "Saves and loads cruiser position, rotation, and condition, and lets you toggle the magnet remotely.",
+    "description": "[LC v81.5 tested] Saves and loads cruiser state, and toggles the magnet remotely. Tested with BepInExPack v5.4.2305, InputUtils v0.7.13, and Imperium v1.3.0.",
     "dependencies": [
         "BepInEx-BepInExPack-5.4.2100",
         "Rune580-LethalCompany_InputUtils-0.7.12"


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Adds the compact `[v81.5]` compatibility marker to the start of the Thunderstore package description metadata.
- Preserves the original manifest description wording after the marker.
- Documents the release-time maintenance rule for keeping single-version and multiple-version marker formats aligned with canonical compatibility notes.
- Clarifies that marker updates should replace any existing leading marker group so the manifest description has exactly one compatibility marker group.
- Clarifies that dependency string changes are separate dependency maintenance work that should document their own reason and compatibility impact.
- Records the metadata/documentation update in the developer changelog.

## Related Issues

- Closes #67.

## Notes for reviewers

- No Thunderstore publication or package upload was performed.
- This PR only changes repository documentation and the manifest description.
- Thunderstore dependency string changes were intentionally removed from this PR and split into #78.

### AI disclosure

- Codex helped inspect issue #67, update the repository files, run validation checks, split dependency changes out of this PR, run fresh median and edge scenario inspections with subagents, run duplicate-marker and multi-version marker edge inspections, and draft this pull request.
- The resulting manifest description, README maintenance note, changelog entry, and PR body were reviewed against the issue acceptance criteria and the requested marker formats.

## Testing

### Automated checks

- `Get-Content assets/manifest.json -Raw | ConvertFrom-Json` passed; manifest description length is 107 characters and dependency strings remain `BepInEx-BepInExPack-5.4.2100` and `Rune580-LethalCompany_InputUtils-0.7.12`.
- `docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5` passed with 0 errors.
- `git diff --check` passed with no whitespace errors; Git reported only the repository's normal Windows line-ending conversion warning while checking the working copy.

### AI-assisted inspections

Request: Fresh median-scenario review for ordinary Thunderstore readers and maintainers after correcting the marker and dependency split.

- AI-assisted result: No blocker on the `[v81.5]` marker, original description preservation, or dependency split. Recommended clarifying that marker updates should replace any existing leading marker.

Request: Fresh edge-scenario review for marker ambiguity, Thunderstore metadata constraints, dependency drift, and future release-process confusion.

- AI-assisted result: No JSON, description-length, or dependency-contamination blocker. Recommended explicitly preventing duplicate markers during future marker updates.

Request: Fresh duplicate-marker edge review for future updates such as `[v82] [v81.5] ...`.

- AI-assisted result: Current manifest has exactly one marker. Recommended changing README guidance from prepending to replacing any existing leading marker, and stating that the description should have exactly one compatibility marker. Addressed in `README.md`.

Request: Fresh median and edge reviews for multiple-version markers, using `[v73/v81.5]` as the requested format example.

- AI-assisted result: Current implementation handled the single-version marker but did not clearly document multiple-version markers. Recommended documenting `[v<version>]` and `[v<older-version>/<newer-version>]`, limiting marker versions to tested or maintainer-confirmed Lethal Company versions, keeping best-effort/lower-confidence notes out of the marker, and replacing the whole leading marker group during updates. Addressed in `README.md`.

Request: Fresh duplicate-marker edge review for multi-version markers such as `[v73/v81.5]`.

- AI-assisted result: Multiple-version markers are compatible with the duplicate-marker rule if the whole leading bracketed group is treated as one marker. Recommended treating `[v81.5]` and `[v73/v81.5]` as the same leading marker class and replacing the group instead of prepending another marker. Addressed in `README.md`.

### Manual checks

- None.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
