### PR TITLE
build(thunderstore)!: raise package dependency baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   category:
     - `AI Generated`
 - Aligned Thunderstore manifest dependency strings with the documented v81.5
-  test environment for BepInExPack and LethalCompany_InputUtils.
+  test environment for BepInExPack and LethalCompany_InputUtils:
+    - Treats the manifest dependency versions as part of the practical minimum
+      runtime baseline for Thunderstore installs.
+- Removed v0.2.0-alpha-and-later changelog compatibility notes for Lethal
+  Company v73 and v56 because they no longer match the updated Thunderstore
+  dependency baseline.
 
 ### Notes
 
@@ -43,11 +48,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
             - See
               <https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735>
               for a workaround.
-    - Lethal Company v73 still appears to work.
-    - Lethal Company v56 has lower-confidence compatibility:
-        - Core features appear to work in limited checks.
-        - A known minor issue was found early and is tracked in
-          <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
 - Test environment:
     - Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
       `6423525044216269478`)
@@ -93,8 +93,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - Focused the README on the latest stable Lethal Company version.
     - Withdrew the earlier alpha changelog wording that explicitly declared
       Lethal Company v73 support.
-    - Kept Lethal Company v73 and v56 as best-effort compatibility notes in
-      changelog context.
 - Documented safer GitHub CLI pull request body handling:
     - Pass Markdown through body files.
     - Verify stored pull request bodies after creation.
@@ -118,12 +116,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
       `6423525044216269478`).
         - Normally used together with Imperium; the v81.5 test environment
           used Imperium v1.3.0.
-    - Older base-game compatibility became best-effort after the project
-      stopped pursuing static multi-version validation through NuGet
-      references:
-        - Lethal Company v73 still appeared to work.
-        - Lethal Company v56 had lower-confidence compatibility, with a known
-          minor issue found early.
 
 ## v0.2.0-alpha.1 - 2026-04-25 UTC
 
@@ -155,13 +147,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
           changelog.
         - Compatibility information for older releases was backfilled as
           reference material at the same time.
-    - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
-      `1749099131234587692`).
-        - Later withdrawn as explicit support wording in v0.2.0-alpha.2.
-    - Lethal Company v56 has lower-confidence compatibility:
-        - Core features appeared to work in limited checks.
-        - A known minor issue was found early and is tracked in
-          <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
 - Test environment:
     - Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Marked automated Thunderstore uploads with an additional Thunderstore
   category:
     - `AI Generated`
+- Aligned Thunderstore manifest dependency strings with the documented v81.5
+  test environment for BepInExPack and LethalCompany_InputUtils.
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   test environment for BepInExPack and LethalCompany_InputUtils:
     - Treats the manifest dependency versions as part of the practical minimum
       runtime baseline for Thunderstore installs.
-- Removed v0.2.0-alpha-and-later changelog compatibility notes for Lethal
-  Company v73 and v56 because they no longer match the updated Thunderstore
-  dependency baseline.
+- Stopped carrying Lethal Company v73 and v56 compatibility notes forward into
+  the unreleased v0.2.0 release notes because they no longer match the updated
+  Thunderstore dependency baseline.
 
 ### Notes
 
@@ -93,6 +93,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - Focused the README on the latest stable Lethal Company version.
     - Withdrew the earlier alpha changelog wording that explicitly declared
       Lethal Company v73 support.
+    - Kept Lethal Company v73 and v56 as best-effort compatibility notes in
+      changelog context.
 - Documented safer GitHub CLI pull request body handling:
     - Pass Markdown through body files.
     - Verify stored pull request bodies after creation.
@@ -116,6 +118,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
       `6423525044216269478`).
         - Normally used together with Imperium; the v81.5 test environment
           used Imperium v1.3.0.
+    - Older base-game compatibility became best-effort after the project
+      stopped pursuing static multi-version validation through NuGet
+      references:
+        - Lethal Company v73 still appeared to work.
+        - Lethal Company v56 had lower-confidence compatibility, with a known
+          minor issue found early.
 
 ## v0.2.0-alpha.1 - 2026-04-25 UTC
 
@@ -147,6 +155,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
           changelog.
         - Compatibility information for older releases was backfilled as
           reference material at the same time.
+    - Compatible with Lethal Company v73 (2025-10-04 UTC, Manifest ID:
+      `1749099131234587692`).
+        - Later withdrawn as explicit support wording in v0.2.0-alpha.2.
+    - Lethal Company v56 has lower-confidence compatibility:
+        - Core features appeared to work in limited checks.
+        - A known minor issue was found early and is tracked in
+          <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
 - Test environment:
     - Lethal Company v73 (2025-10-04 UTC, Manifest ID:
       `1749099131234587692`)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,21 @@ To update the lock file after modifying your package references, run:
 dotnet restore --use-lock-file
 ```
 
+### Thunderstore manifest dependency updates
+
+When changing `assets/manifest.json` dependency strings:
+
+- Compare them with the current documented test environment in
+  `assets/README.md` and `CHANGELOG.md`.
+- Treat the change as Thunderstore install metadata, not only documentation:
+  fresh installs or profile resolution may pull the listed dependency versions.
+- Do not describe tested-environment alignment as a minimum required version
+  bump unless older dependency versions are confirmed incompatible.
+- Document the reason, install impact, compatibility impact, and rollback risk
+  in the pull request and `CHANGELOG.md`.
+- Keep dependency string updates separate from manifest description or
+  compatibility-marker prose when practical.
+
 ### .NET and C# tooling updates
 
 This project separates the SDK used to build and format the mod from the target
@@ -162,15 +177,21 @@ DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release
 1. Update the canonical developer changelog in `CHANGELOG.md`.
 2. For a stable release, derive the Thunderstore-facing release notes in
    `assets/CHANGELOG.md` from stable entries in `CHANGELOG.md`.
-3. Replace version in `CruiserJumpPractice/CruiserJumpPractice.csproj` with a
+3. Verify Thunderstore package metadata in `assets/manifest.json`:
+    - Confirm dependency strings match the intended release baseline.
+    - Confirm dependency string changes have documented reason, install impact,
+      compatibility impact, rollback risk, and test-environment evidence.
+    - Confirm the manifest description still matches the Thunderstore-facing
+      release intent.
+4. Replace version in `CruiserJumpPractice/CruiserJumpPractice.csproj` with a
    SemVer version such as `1.2.3`.
-4. Verify the release packaging flow:
+5. Verify the release packaging flow:
     - `.github/workflows/build.yml` packages `assets/CHANGELOG.md`.
     - The `generate-version` action updates `assets/manifest.json` from the
       project version.
-5. Commit and push the changes.
-6. CI will create a GitHub Release automatically.
-7. For stable releases, CI will upload the release artifact to Thunderstore
+6. Commit and push the changes.
+7. CI will create a GitHub Release automatically.
+8. For stable releases, CI will upload the release artifact to Thunderstore
    automatically.
 
    The current workflow deploys to the Thunderstore `aoirint` team and

--- a/README.md
+++ b/README.md
@@ -92,10 +92,12 @@ When changing `assets/manifest.json` dependency strings:
   `assets/README.md` and `CHANGELOG.md`.
 - Treat the change as Thunderstore install metadata, not only documentation:
   fresh installs or profile resolution may pull the listed dependency versions.
-- Do not describe tested-environment alignment as a minimum required version
-  bump unless older dependency versions are confirmed incompatible.
+- Treat dependency version increases as possible practical minimum runtime
+  baseline changes for Thunderstore installs.
 - Document the reason, install impact, compatibility impact, and rollback risk
   in the pull request and `CHANGELOG.md`.
+- Remove or revise changelog compatibility notes that no longer match the
+  dependency baseline.
 - Keep dependency string updates separate from manifest description or
   compatibility-marker prose when practical.
 

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -27,11 +27,6 @@ No gameplay changes are introduced.
         - Imperium v1.3.0 appears to have some cruiser-related issues:
             - See the [Imperium issue comment][imperium-cruiser-workaround]
               for a workaround.
-    - Lethal Company v73 still appears to work.
-    - Lethal Company v56 has lower-confidence compatibility:
-        - Core features appear to work in limited checks.
-        - A known minor issue was found early and is tracked in
-          <https://github.com/aoirint/CruiserJumpPractice/issues/5>.
 
 ## v0.1.4 - 2025-11-30 UTC
 

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -4,7 +4,7 @@
     "website_url": "https://github.com/aoirint/CruiserJumpPractice",
     "description": "Saves and loads cruiser position, rotation, and condition, and lets you toggle the magnet remotely.",
     "dependencies": [
-        "BepInEx-BepInExPack-5.4.2100",
-        "Rune580-LethalCompany_InputUtils-0.7.12"
+        "BepInEx-BepInExPack-5.4.2305",
+        "Rune580-LethalCompany_InputUtils-0.7.13"
     ]
 }


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Raises the Thunderstore package dependency baseline to the documented v81.5 test environment:
    - BepInExPack `5.4.2100` to `5.4.2305`.
    - LethalCompany_InputUtils `0.7.12` to `0.7.13`.
- Treats the manifest dependency version increase as a practical minimum runtime baseline change for Thunderstore installs and profile resolution.
- Stops carrying Lethal Company v73 and v56 compatibility notes forward into the unreleased v0.2.0 release notes, because those notes no longer match the updated Thunderstore dependency baseline.
- Preserves the historical `v0.2.0-alpha.1` and `v0.2.0-alpha.2` compatibility records in the root developer changelog.
- Updates maintainer guidance for Thunderstore manifest dependency changes and release-time metadata checks.

## Related Issues

- Refs #77.

## Notes for reviewers

- This PR is intentionally separate from #77 because changing Thunderstore dependency strings is packaging metadata behavior with install and compatibility impact, not only compatibility marker prose.
- PR #77 adds the tested Lethal Company marker to the manifest description; this PR carries the corresponding dependency baseline update.
- The root `CHANGELOG.md` now records the policy change only in `Unreleased`; historical alpha sections remain unchanged as history.
- `assets/CHANGELOG.md` is user-facing unreleased release-note material, so its v73/v56 notes are removed.
- Historical v0.1.x changelog compatibility entries remain as older-release reference history.
- This PR changes packaging metadata and documentation only. It does not change gameplay code.

### AI disclosure

- Codex helped split this dependency update from #77, update the manifest, changelogs, and README guidance, resolve the main-branch conflict, run validation checks, perform the requested blank reviews, and update this pull request description.
- The resulting changes were reviewed against the user decision that the manifest dependency bump is within this PR's responsibility and should be treated as a minimum-runtime-requirement policy change.

## Testing

### Automated checks

- `Get-Content assets/manifest.json -Raw | ConvertFrom-Json` passed.
- `docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5` passed with 0 errors.
- `git diff --check origin/main..HEAD` passed with no whitespace errors.
- `dotnet build` not run; this PR changes Thunderstore metadata and documentation only.

### AI-assisted inspections

Request: Fresh median-scenario review for ordinary maintainers checking whether manifest dependency strings match the documented v81.5 test environment.

- AI-assisted result: No blocker on the core dependency string update. Recommended adding README guidance for Thunderstore manifest dependency maintenance and release-time metadata checks. Addressed in `README.md`.

Request: Fresh edge-scenario review for minimum-version overclaiming, Thunderstore install behavior, PR #77 merge-order dependency, release checklist gaps, and compatibility/rollback risk.

- AI-assisted result: The dependency string update can affect Thunderstore installs and should be treated as a possible minimum runtime baseline change. Addressed by updating `CHANGELOG.md`, `assets/CHANGELOG.md`, `README.md`, and this PR body.

Request: Blank review after applying the user decision that the dependency bump should proceed and v73/v56 compatibility notes should stop being carried into the unreleased v0.2.0 release notes.

- AI-assisted result: Found stale README guidance that still discouraged describing tested-environment alignment as a minimum-version bump; fixed it to treat dependency version increases as possible practical minimum runtime baseline changes. A later review found that root `CHANGELOG.md` historical alpha records should remain unchanged; addressed by restoring the past `v0.2.0-alpha.1` and `v0.2.0-alpha.2` compatibility notes while keeping the Unreleased policy change and user-facing `assets/CHANGELOG.md` removal.

### Manual checks

- None.

### Screenshots / videos

- Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.