### PR TITLE
docs: clarify prerelease upload behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ the `lethal-company` community with these categories:
 The `THUNDERSTORE_TOKEN` secret must belong to a Thunderstore service account
 that can publish to that team.
 
-**NOTE: Thunderstore does not support prerelease versions such as
-`1.2.3-beta.1`.**
+**NOTE: Prerelease versions such as `1.2.3-beta.1` are uploaded only to GitHub,
+because Thunderstore does not support them.**
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ the `lethal-company` community with these categories:
 The `THUNDERSTORE_TOKEN` secret must belong to a Thunderstore service account
 that can publish to that team.
 
-**NOTE: Prerelease versions such as `1.2.3-beta.1` are uploaded only to GitHub,
+**NOTE: Prerelease versions such as `1.2.3-alpha.1` are uploaded only to GitHub,
 because Thunderstore does not support them.**
 
 ## Debugging


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Clarifies that prerelease versions are uploaded only to GitHub because Thunderstore does not support prerelease versions.
- Keeps the README release guidance concise.

## Related Issues

None

## Notes for reviewers

Documentation-only follow-up to #81.

### AI disclosure

Codex updated the README wording, checked the diff scope, and ran Markdown lint.

## Testing

### Automated checks

- `docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5` - passed, 0 errors.
- `git diff --check` - passed, no whitespace errors.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.