### PR TITLE
build: pin compile-only dependency ranges

### DIFF
--- a/CruiserJumpPractice/CruiserJumpPractice.csproj
+++ b/CruiserJumpPractice/CruiserJumpPractice.csproj
@@ -18,14 +18,14 @@
 
   <ItemGroup>
     <!-- Compile-only game dependencies -->
-    <PackageReference Include="BepInEx.Core" Version="5.4.21" IncludeAssets="compile" />
-    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="81.0.5-ngd.0" IncludeAssets="compile">
+    <PackageReference Include="BepInEx.Core" Version="[5.4.21]" IncludeAssets="compile" />
+    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="[81.0.5-ngd.0]" IncludeAssets="compile">
       <Aliases>LethalCompany</Aliases>
     </PackageReference>
-    <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" IncludeAssets="compile">
+    <PackageReference Include="UnityEngine.Modules" Version="[2022.3.62]" IncludeAssets="compile">
       <Aliases>UnityEngine</Aliases>
     </PackageReference>
-    <PackageReference Include="Rune580.Mods.LethalCompany.InputUtils" Version="0.7.13" IncludeAssets="compile">
+    <PackageReference Include="Rune580.Mods.LethalCompany.InputUtils" Version="[0.7.13]" IncludeAssets="compile">
       <Aliases>LethalCompanyInputUtils</Aliases>
     </PackageReference>
 

--- a/CruiserJumpPractice/packages.lock.json
+++ b/CruiserJumpPractice/packages.lock.json
@@ -10,7 +10,7 @@
       },
       "BepInEx.Core": {
         "type": "Direct",
-        "requested": "[5.4.21, )",
+        "requested": "[5.4.21, 5.4.21]",
         "resolved": "5.4.21",
         "contentHash": "NMUPlbHTTfJ+qIQCI90uIvjuUQ4wnwt4cpRsK3ItBh1DhsWFzAHXNiZjBxZkPysljEKQ2iu89sxMTga4bxBXVQ==",
         "dependencies": {
@@ -26,7 +26,7 @@
       },
       "LethalCompany.GameLibs.Steam": {
         "type": "Direct",
-        "requested": "[81.0.5-ngd.0, )",
+        "requested": "[81.0.5-ngd.0, 81.0.5-ngd.0]",
         "resolved": "81.0.5-ngd.0",
         "contentHash": "q1+j5z4lP0TKO16uZ2NclNr9/mb3BUgl6mUO7zbPwbyEHIPJ4m6805rxP0w8mxe4NWNcQRoBkWrIpiNrwak8Hg==",
         "dependencies": {
@@ -36,7 +36,7 @@
       },
       "Rune580.Mods.LethalCompany.InputUtils": {
         "type": "Direct",
-        "requested": "[0.7.13, )",
+        "requested": "[0.7.13, 0.7.13]",
         "resolved": "0.7.13",
         "contentHash": "Hebm2vcU6R+02x27MJMAAnKwe9H6iIOSYB4bIVAaAPcv0vOqUktiG6FRQkN9v+POGRgAp6E2qTuuw09eAY40Lg==",
         "dependencies": {
@@ -47,7 +47,7 @@
       },
       "UnityEngine.Modules": {
         "type": "Direct",
-        "requested": "[2022.3.62, )",
+        "requested": "[2022.3.62, 2022.3.62]",
         "resolved": "2022.3.62",
         "contentHash": "zpu5dELUCFt7Rvvzp50iTrfVusJg+2gmlcaytGEoHYuIP+AOv57X272czjp+sA8N1onPo/IiHFnOEFtT9rLJBA=="
       },


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Pins compile-only game dependency `PackageReference` versions to exact NuGet ranges.
- Updates `CruiserJumpPractice/packages.lock.json` requested ranges to match the exact bounds.
- Leaves build/development-only dependencies unchanged.

## Related Issues

- Closes #66

## Notes for reviewers

The initial locked restore failed as expected because the lock file still recorded lower-bound ranges. I refreshed the lock file with `--force-evaluate`, then confirmed locked restore succeeds with the updated metadata.

### AI disclosure

Codex implemented the scoped dependency metadata change, reviewed the diff, and ran the restore/build checks listed below. The resulting changes were limited to the project file and NuGet lock file.

## Testing

### Automated checks

- `dotnet restore --locked-mode CruiserJumpPractice.sln` before lock-file refresh: failed with NU1004 because requested ranges changed from lower-bound to exact ranges.
- `dotnet restore --force-evaluate CruiserJumpPractice.sln`: passed.
- `dotnet build --no-restore CruiserJumpPractice.sln`: passed with 0 warnings and 0 errors.
- `dotnet restore --locked-mode CruiserJumpPractice.sln` after lock-file refresh: passed.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.