### PR TITLE
docs: align mod description wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # CruiserJumpPractice
 
-A Lethal Company mod that saves and loads cruiser position, rotation, and condition.
-It also lets you toggle the magnet remotely.
+A Lethal Company mod that saves and loads cruiser position, rotation, and condition,
+and lets you toggle the magnet remotely.
 
 - [User guide](./assets/README.md)
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,7 +1,7 @@
 # CruiserJumpPractice
 
 A Lethal Company mod that saves and loads cruiser position, rotation, and
-condition. It also lets you toggle the magnet remotely.
+condition, and lets you toggle the magnet remotely.
 
 This mod helps you practice cruiser jumps repeatedly without having to manually
 reset the cruiser every attempt.


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Aligns the project and Thunderstore README descriptions so the magnet feature is described in the same sentence as the cruiser save/load behavior.
- Preserves the intentional `A Lethal Company mod that` wording in both README descriptions.
- Leaves the Thunderstore manifest description unchanged because it already uses the preferred `and lets you` phrasing.

## Related Issues

None.

## Notes for reviewers

- This is a prose-only documentation consistency change.
- Review focus: confirm the description reads naturally without implying a different feature scope.

### AI disclosure

- Codex found the inconsistent wording, updated the README prose, ran Markdown lint, and prepared this pull request.

## Testing

### Automated checks

- `docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5` passed with 0 errors.
- `git diff --check` passed with no whitespace errors; Git reported only the repository's normal Windows line-ending conversion warning while checking the working copy.

### AI-assisted inspections

None.

### Manual checks

- Reviewed the prose-only diff for scope preservation and consistency with the existing manifest description.

### Screenshots / videos

Not applicable.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.