### PR TITLE
docs: add issue reporting guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,9 @@ Only share material that you have the right to share, and do not include
 secrets, personal information, private data, or content that should not be made
 public.
 
-Do not submit sample code, documentation text, patches, or other material for
-direct inclusion in the project unless you provide it under the Contribution
-License Agreement.
+Do not submit sample code, documentation text, patches, or other material that
+could be included or adapted into the project unless you provide it under the
+Contribution License Agreement.
 Clearly state your agreement to that license agreement when you submit that
 material.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,9 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
   documentation improvement requests.
     - To minimize the personal burden this project places on maintainers,
       maintainers try to keep the project's responsibilities as small as
-      practical. Please still report issues or requests that seem relevant,
-      because they can be useful as related information even if they are closed
-      as not planned. This is likely for requests outside the project's scope,
+      practical. However, issues or requests that seem relevant can still be
+      useful as related information even if they are closed as not planned. This
+      is likely for requests outside the project's scope,
       requests for large or complex features, or compatibility requests for base
       game versions that are no longer current.
 - Before opening a new issue, check the existing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
 
 ## Reporting issues
 
-Use GitHub Issues for ordinary bug reports, feature requests, and
-documentation errors.
+Use GitHub Issues for ordinary bug reports, feature requests, compatibility
+notes, and documentation error reports.
 Before opening a new issue, check the existing issues and pull requests to
 avoid duplicates.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,13 +53,9 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
   cannot move forward because needed information is missing, the issue is no
   longer reproducible, the reported behavior no longer matches the current
   project, or the discussion has been inactive for a reasonable period may be
-  closed.
-- This is not a judgment on the reporter or the report, and it does not prevent
-  you from adding new information later if the issue is still relevant.
-- If a closed issue becomes relevant again, reopen it or ask maintainers to
-  reopen it when the existing context is still useful. Open a new issue instead
-  if the current behavior is different enough that a fresh report would be
-  clearer.
+  closed. This is not a judgment on the reporter or the report, and it does not
+  prevent you from reopening the issue or asking maintainers to reopen it later
+  if the issue is still relevant.
 
 ## Development setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,14 @@ notes, and documentation improvement requests.
 Before opening a new issue, check the existing issues and pull requests to
 avoid duplicates.
 
+When you share sample code, logs, screenshots, or other supporting material in a
+public issue, expect maintainers to use that material within a reasonable scope
+to understand, reproduce, discuss, fix, and communicate about the reported
+issue.
+Only share material that you have the right to share, and do not include
+secrets, personal information, private data, or content that should not be made
+public.
+
 Do not report security issues in public GitHub Issues.
 See [Reporting security issues](#reporting-security-issues) instead.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,8 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
   longer reproducible, the reported behavior no longer matches the current
   project, or the discussion has been inactive for a reasonable period may be
   closed. This is not a judgment on the reporter or the report, and it does not
-  prevent you from reopening the issue or asking maintainers to reopen it later
-  if the issue is still relevant.
+  prevent you from reopening the issue, or asking maintainers to reopen it, if
+  the issue is still relevant and it is reasonable to do so.
 
 ## Development setup
 
@@ -131,7 +131,8 @@ For package or release changes, also verify the release documentation in
 - To keep maintainer work manageable and the review queue current, pull requests
   that remain inactive for a reasonable period may be closed. This is not a
   judgment on the contributor, and it does not prevent you from opening a new
-  pull request later if the change is still useful.
+  pull request later if the change is still useful and it is reasonable to do
+  so.
 
 ## Contribution License Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,13 +47,14 @@ See [Reporting security issues](#reporting-security-issues) instead.
 
 ## Stalled Issues
 
-Respond to maintainer questions as much as you reasonably can.
-To keep maintainer work manageable and the issue list current, maintainers may
-close issues that cannot move forward because needed information is missing, the
-issue is no longer reproducible, the reported behavior no longer matches the
-current project, or the discussion has been inactive for a reasonable period.
-This is not a judgment on the reporter or the report, and it does not prevent
-you from adding new information later if the issue is still relevant.
+- Respond to maintainer questions as much as you reasonably can.
+- To keep maintainer work manageable and the issue list current, maintainers may
+  close issues that cannot move forward because needed information is missing,
+  the issue is no longer reproducible, the reported behavior no longer matches
+  the current project, or the discussion has been inactive for a reasonable
+  period.
+- This is not a judgment on the reporter or the report, and it does not prevent
+  you from adding new information later if the issue is still relevant.
 
 ## Development setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,12 +44,16 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
 
 ## Stalled Issues
 
-- Respond to maintainer questions as much as you reasonably can.
-- To keep maintainer work manageable and the issue list current, maintainers may
-  close issues that cannot move forward because needed information is missing,
-  the issue is no longer reproducible, the reported behavior no longer matches
-  the current project, or the discussion has been inactive for a reasonable
-  period.
+- Respond to maintainer questions as much as you reasonably can. If you need
+  more time, are blocked from providing the requested information, or find that
+  the issue is no longer reproducible, leave a short comment so maintainers know
+  what to expect. Even if a long time has passed, it is always fine to reply
+  with an update.
+- To keep maintainer work manageable and the issue list current, issues that
+  cannot move forward because needed information is missing, the issue is no
+  longer reproducible, the reported behavior no longer matches the current
+  project, or the discussion has been inactive for a reasonable period may be
+  closed.
 - This is not a judgment on the reporter or the report, and it does not prevent
   you from adding new information later if the issue is still relevant.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,10 +24,11 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
   documentation improvement requests.
     - To minimize the personal burden this project places on maintainers,
       maintainers try to keep the project's responsibilities as small as
-      practical. Reports and requests outside that scope can still be useful as
-      related information, but requests for large or complex features or
-      compatibility with base game versions that are no longer current are
-      likely to be closed as not planned.
+      practical. Please still report issues or requests that seem relevant,
+      because they can be useful as related information even if they are closed
+      as not planned. This is likely for requests outside the project's scope,
+      requests for large or complex features, or compatibility requests for base
+      game versions that are no longer current.
 - Before opening a new issue, check the existing
   [issues](https://github.com/aoirint/CruiserJumpPractice/issues) and
   [pull requests](https://github.com/aoirint/CruiserJumpPractice/pulls) to avoid

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,11 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
   documentation improvement requests.
     - To minimize the personal burden this project places on maintainers,
       maintainers try to keep the project's responsibilities as small as
-      practical. They are unlikely to accept requests that fall outside that
-      scope, requests for large or complex features, or compatibility requests
-      for base game versions that are no longer current.
+      practical. Reports and requests can still be useful as related
+      information even when maintainers cannot accept them. Requests that fall
+      outside that scope, requests for large or complex features, or
+      compatibility requests for base game versions that are no longer current
+      are likely to be closed as not planned.
 - Before opening a new issue, check the existing
   [issues](https://github.com/aoirint/CruiserJumpPractice/issues) and
   [pull requests](https://github.com/aoirint/CruiserJumpPractice/pulls) to avoid

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,11 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
 - Use [GitHub Issues](https://github.com/aoirint/CruiserJumpPractice/issues)
   for ordinary bug reports, feature requests, compatibility notes, and
   documentation improvement requests.
+    - To minimize the personal burden this project places on maintainers,
+      maintainers try to keep the project's responsibilities as small as
+      practical. They are unlikely to accept requests that fall outside that
+      scope, requests for large or complex features, or compatibility requests
+      for base game versions that are no longer current.
 - Before opening a new issue, check the existing
   [issues](https://github.com/aoirint/CruiserJumpPractice/issues) and
   [pull requests](https://github.com/aoirint/CruiserJumpPractice/pulls) to avoid

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,10 @@ Only share material that you have the right to share, and do not include
 secrets, personal information, private data, or content that should not be made
 public.
 
+Do not submit sample code, documentation text, patches, or other material for
+direct inclusion in the project unless you are willing to provide it under the
+Contribution License Agreement.
+
 Do not report security issues in public GitHub Issues.
 See [Reporting security issues](#reporting-security-issues) instead.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
 ## Reporting issues
 
 Use GitHub Issues for ordinary bug reports, feature requests, compatibility
-notes, and documentation error reports.
+notes, and documentation improvement requests.
 Before opening a new issue, check the existing issues and pull requests to
 avoid duplicates.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,9 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
 
 ## Before you start
 
-- Check the existing issues and pull requests to avoid duplicate work.
+- Check the existing [issues](https://github.com/aoirint/CruiserJumpPractice/issues)
+  and [pull requests](https://github.com/aoirint/CruiserJumpPractice/pulls)
+  to avoid duplicate work.
 - Open an issue first for larger behavior changes, compatibility changes, or
   anything that may affect release packaging.
 - Keep changes focused. Separate unrelated fixes, refactors, and documentation
@@ -17,10 +19,13 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
 
 ## Reporting issues
 
-Use GitHub Issues for ordinary bug reports, feature requests, compatibility
-notes, and documentation improvement requests.
-Before opening a new issue, check the existing issues and pull requests to
-avoid duplicates.
+Use [GitHub Issues](https://github.com/aoirint/CruiserJumpPractice/issues) for
+ordinary bug reports, feature requests, compatibility notes, and documentation
+improvement requests.
+Before opening a new issue, check the existing
+[issues](https://github.com/aoirint/CruiserJumpPractice/issues) and
+[pull requests](https://github.com/aoirint/CruiserJumpPractice/pulls) to avoid
+duplicates.
 
 When you share logs, screenshots, or other supporting material in a public
 issue, expect maintainers to use that material within a reasonable scope related
@@ -32,7 +37,7 @@ public.
 
 Do not submit sample code, documentation text, patches, or other material that
 could be included or adapted into the project unless you provide it under the
-Contribution License Agreement.
+[Contribution License Agreement](#contribution-license-agreement).
 Clearly state the same confirmation used for pull requests when you submit that
 material: `I have read CONTRIBUTING.md and agree to the Contribution License
 Agreement.`
@@ -66,8 +71,10 @@ dotnet restore --locked-mode
 - Prefer the existing project structure and naming conventions.
 - Keep user-facing behavior explicit in code, documentation, or changelog
   entries when the behavior changes.
-- Update `CHANGELOG.md` for developer-facing changes that should appear in release history.
-- Update files under `assets/` when the Thunderstore package metadata, icon, README, or release notes change.
+- Update [CHANGELOG.md](./CHANGELOG.md) for developer-facing changes that should
+  appear in release history.
+- Update files under [assets/](./assets/) when the Thunderstore package
+  metadata, icon, README, or release notes change.
 - Do not commit build output, downloaded game files, local mod manager profiles, or local machine configuration.
 
 ## Verification
@@ -94,9 +101,12 @@ For package or release changes, also verify the release documentation in
 - Link related issues when applicable.
 - Keep the pull request small enough for maintainers to review without guessing
   at unrelated intent.
-- Pull requests must include the pull request template checkbox confirmation for
-  the Contribution License Agreement before they can be merged. Pull requests
-  without that confirmation may be closed without further notice.
+- Pull requests must include the
+  [pull request template](./.github/pull_request_template.md) checkbox
+  confirmation for the
+  [Contribution License Agreement](#contribution-license-agreement) before they
+  can be merged. Pull requests without that confirmation may be closed without
+  further notice.
 
 ## Stalled Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ avoid duplicates.
 
 When you share logs, screenshots, or other supporting material in a public
 issue, expect maintainers to use that material within a reasonable scope related
-to the reported issue, including to understand, reproduce, discuss, fix, and
-communicate with end users about it.
+to the reported issue, including for understanding, reproducing, discussing,
+fixing, and communicating with end users about it.
 Only share material that you have the right to share, and do not include
 secrets, personal information, private data, or content that should not be made
 public.
@@ -33,8 +33,9 @@ public.
 Do not submit sample code, documentation text, patches, or other material that
 could be included or adapted into the project unless you provide it under the
 Contribution License Agreement.
-Clearly state your agreement to that license agreement when you submit that
-material.
+Clearly state the same confirmation used for pull requests when you submit that
+material: `I have read CONTRIBUTING.md and agree to the Contribution License
+Agreement.`
 
 Do not report security issues in public GitHub Issues.
 See [Reporting security issues](#reporting-security-issues) instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,10 @@ secrets, personal information, private data, or content that should not be made
 public.
 
 Do not submit sample code, documentation text, patches, or other material for
-direct inclusion in the project unless you are willing to provide it under the
-Contribution License Agreement.
-Clearly state your agreement to the Contribution License Agreement when you
-submit that material.
+direct inclusion in the project unless you provide it under the Contribution
+License Agreement.
+Clearly state your agreement to that license agreement when you submit that
+material.
 
 Do not report security issues in public GitHub Issues.
 See [Reporting security issues](#reporting-security-issues) instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,10 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
   documentation improvement requests.
     - To minimize the personal burden this project places on maintainers,
       maintainers try to keep the project's responsibilities as small as
-      practical. Reports and requests can still be useful as related
-      information even when maintainers cannot accept them. Requests that fall
-      outside that scope, requests for large or complex features, or
-      compatibility requests for base game versions that are no longer current
-      are likely to be closed as not planned.
+      practical. Reports and requests outside that scope can still be useful as
+      related information, but requests for large or complex features or
+      compatibility with base game versions that are no longer current are
+      likely to be closed as not planned.
 - Before opening a new issue, check the existing
   [issues](https://github.com/aoirint/CruiserJumpPractice/issues) and
   [pull requests](https://github.com/aoirint/CruiserJumpPractice/pulls) to avoid

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,16 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
 - Keep changes focused. Separate unrelated fixes, refactors, and documentation
   updates into separate pull requests when practical.
 
+## Reporting issues
+
+Use GitHub Issues for ordinary bug reports, documentation errors,
+compatibility notes, and release-note corrections.
+Before opening a new issue, check the existing issues and pull requests to
+avoid duplicates.
+
+Do not report security issues in public GitHub Issues.
+See [Reporting security issues](#reporting-security-issues) instead.
+
 ## Development setup
 
 Follow the setup, formatting, build, package management, debugging, and release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,13 +48,12 @@ See [Reporting security issues](#reporting-security-issues) instead.
 ## Stalled Issues
 
 Respond to maintainer questions as much as you reasonably can.
-Maintainers may close issues that cannot move forward because needed
-information is missing, the issue is no longer reproducible, the reported
-behavior no longer matches the current project, or the discussion has been
-inactive for a reasonable period.
-
-This keeps the issue list current and does not prevent you from adding new
-information later if the issue is still relevant.
+To keep maintainer work manageable and the issue list current, maintainers may
+close issues that cannot move forward because needed information is missing, the
+issue is no longer reproducible, the reported behavior no longer matches the
+current project, or the discussion has been inactive for a reasonable period.
+This is not a judgment on the reporter or the report, and it does not prevent
+you from adding new information later if the issue is still relevant.
 
 ## Development setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,15 +36,13 @@ See [Reporting security issues](#reporting-security-issues) instead.
 ## Stalled Issues
 
 Respond to maintainer questions when possible.
-If needed information is missing, the issue is no longer reproducible, the
-reported behavior no longer matches the current project, or the discussion has
-been inactive for a reasonable period, maintainers may close the issue to keep
-the issue list current.
+Maintainers may close issues that cannot move forward because needed
+information is missing, the issue is no longer reproducible, the reported
+behavior no longer matches the current project, or the discussion has been
+inactive for a reasonable period.
 
-This kind of closure is different from rejecting an issue or marking it as not
-planned.
-It is not a judgment on the reporter, and it does not prevent you from adding
-new information later if the issue is still relevant.
+This keeps the issue list current and does not prevent you from adding new
+information later if the issue is still relevant.
 
 ## Development setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ See [Reporting security issues](#reporting-security-issues) instead.
 
 ## Stalled Issues
 
-Respond to maintainer questions when possible.
+Respond to maintainer questions as much as you reasonably can.
 Maintainers may close issues that cannot move forward because needed
 information is missing, the issue is no longer reproducible, the reported
 behavior no longer matches the current project, or the discussion has been
@@ -110,10 +110,10 @@ For package or release changes, also verify the release documentation in
 
 ## Stalled Pull Requests
 
-- Respond to maintainer feedback when possible. If you need more time, are
-  blocked, or no longer plan to continue the pull request, leave a short comment
-  so maintainers know what to expect. Even if a long time has passed, it is
-  always fine to reply with an update.
+- Respond to maintainer feedback as much as you reasonably can. If you need
+  more time, are blocked, or no longer plan to continue the pull request, leave
+  a short comment so maintainers know what to expect. Even if a long time has
+  passed, it is always fine to reply with an update.
 - If you want to continue work from a stalled pull request, leave a short
   comment for the maintainer and the original contributor before opening a new
   pull request. The original contributor may not be available to respond, but

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,8 @@ public.
 Do not submit sample code, documentation text, patches, or other material for
 direct inclusion in the project unless you are willing to provide it under the
 Contribution License Agreement.
+Clearly state your agreement to the Contribution License Agreement when you
+submit that material.
 
 Do not report security issues in public GitHub Issues.
 See [Reporting security issues](#reporting-security-issues) instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,31 +19,28 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
 
 ## Reporting issues
 
-Use [GitHub Issues](https://github.com/aoirint/CruiserJumpPractice/issues) for
-ordinary bug reports, feature requests, compatibility notes, and documentation
-improvement requests.
-Before opening a new issue, check the existing
-[issues](https://github.com/aoirint/CruiserJumpPractice/issues) and
-[pull requests](https://github.com/aoirint/CruiserJumpPractice/pulls) to avoid
-duplicates.
-
-When you share logs, screenshots, or other supporting material in a public
-issue, expect maintainers to use that material within a reasonable scope related
-to the reported issue, including for understanding, reproducing, discussing,
-fixing, and communicating with end users about it.
-Only share material that you have the right to share, and do not include
-secrets, personal information, private data, or content that should not be made
-public.
-
-Do not submit sample code, documentation text, patches, or other material that
-could be included or adapted into the project unless you provide it under the
-[Contribution License Agreement](#contribution-license-agreement).
-Clearly state the same confirmation used for pull requests when you submit that
-material: `I have read CONTRIBUTING.md and agree to the Contribution License
-Agreement.`
-
-Do not report security issues in public GitHub Issues.
-See [Reporting security issues](#reporting-security-issues) instead.
+- Use [GitHub Issues](https://github.com/aoirint/CruiserJumpPractice/issues)
+  for ordinary bug reports, feature requests, compatibility notes, and
+  documentation improvement requests.
+- Before opening a new issue, check the existing
+  [issues](https://github.com/aoirint/CruiserJumpPractice/issues) and
+  [pull requests](https://github.com/aoirint/CruiserJumpPractice/pulls) to avoid
+  duplicates.
+- When you share logs, screenshots, or other supporting material in a public
+  issue, expect maintainers to use that material within a reasonable scope
+  related to the reported issue, including for understanding, reproducing,
+  discussing, fixing, and communicating with end users about it.
+- Only share material that you have the right to share, and do not include
+  secrets, personal information, private data, or content that should not be made
+  public.
+- Do not submit sample code, documentation text, patches, or other material that
+  could be included or adapted into the project unless you provide it under the
+  [Contribution License Agreement](#contribution-license-agreement). Clearly
+  state the same confirmation used for pull requests when you submit that
+  material: `I have read CONTRIBUTING.md and agree to the Contribution License
+  Agreement.`
+- Do not report security issues in public GitHub Issues. See
+  [Reporting security issues](#reporting-security-issues) instead.
 
 ## Stalled Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,8 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
     - To minimize the personal burden this project places on maintainers,
       maintainers try to keep the project's responsibilities as small as
       practical. However, issues or requests that seem relevant can still be
-      useful as related information even if they are closed as not planned. This
-      is likely for requests outside the project's scope,
+      useful as related information for other users even if they are closed as
+      not planned. This is likely for requests outside the project's scope,
       requests for large or complex features, or compatibility requests for base
       game versions that are no longer current.
 - Before opening a new issue, check the existing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,10 @@ notes, and documentation improvement requests.
 Before opening a new issue, check the existing issues and pull requests to
 avoid duplicates.
 
-When you share sample code, logs, screenshots, or other supporting material in a
-public issue, expect maintainers to use that material within a reasonable scope
-related to the reported issue, including to understand, reproduce, discuss,
-fix, and communicate with end users about it.
+When you share logs, screenshots, or other supporting material in a public
+issue, expect maintainers to use that material within a reasonable scope related
+to the reported issue, including to understand, reproduce, discuss, fix, and
+communicate with end users about it.
 Only share material that you have the right to share, and do not include
 secrets, personal information, private data, or content that should not be made
 public.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,19 @@ public.
 Do not report security issues in public GitHub Issues.
 See [Reporting security issues](#reporting-security-issues) instead.
 
+## Stalled Issues
+
+Respond to maintainer questions when possible.
+If needed information is missing, the issue is no longer reproducible, the
+reported behavior no longer matches the current project, or the discussion has
+been inactive for a reasonable period, maintainers may close the issue to keep
+the issue list current.
+
+This kind of closure is different from rejecting an issue or marking it as not
+planned.
+It is not a judgment on the reporter, and it does not prevent you from adding
+new information later if the issue is still relevant.
+
 ## Development setup
 
 Follow the setup, formatting, build, package management, debugging, and release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ avoid duplicates.
 
 When you share sample code, logs, screenshots, or other supporting material in a
 public issue, expect maintainers to use that material within a reasonable scope
-to understand, reproduce, discuss, fix, and communicate with end users about
-the reported issue.
+related to the reported issue, including to understand, reproduce, discuss,
+fix, and communicate with end users about it.
 Only share material that you have the right to share, and do not include
 secrets, personal information, private data, or content that should not be made
 public.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
 
 ## Reporting issues
 
-Use GitHub Issues for ordinary bug reports, documentation errors,
-compatibility notes, and release-note corrections.
+Use GitHub Issues for ordinary bug reports, feature requests, and
+documentation errors.
 Before opening a new issue, check the existing issues and pull requests to
 avoid duplicates.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,10 @@ The project maintainer is listed in [CODEOWNERS](./.github/CODEOWNERS).
   closed.
 - This is not a judgment on the reporter or the report, and it does not prevent
   you from adding new information later if the issue is still relevant.
+- If a closed issue becomes relevant again, reopen it or ask maintainers to
+  reopen it when the existing context is still useful. Open a new issue instead
+  if the current behavior is different enough that a fresh report would be
+  clearer.
 
 ## Development setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ avoid duplicates.
 
 When you share sample code, logs, screenshots, or other supporting material in a
 public issue, expect maintainers to use that material within a reasonable scope
-to understand, reproduce, discuss, fix, and communicate about the reported
-issue.
+to understand, reproduce, discuss, fix, and communicate with end users about
+the reported issue.
 Only share material that you have the right to share, and do not include
 secrets, personal information, private data, or content that should not be made
 public.

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -5,8 +5,8 @@ This changelog is the user-facing release notes for Thunderstore.
 For internal implementation details and developer-facing release history, see
 the [GitHub changelog][github-changelog].
 
-If you find an error or issue in these notes, see
-[CONTRIBUTING.md][contributing], then report it in
+If you find a release-note error, encounter a bug, or want to report another
+project issue, see [CONTRIBUTING.md][contributing], then report it in
 [GitHub Issues][github-issues].
 
 ## Unreleased

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ This changelog is the user-facing release notes for Thunderstore.
 For internal implementation details and developer-facing release history, see
 the [GitHub changelog][github-changelog].
 
+If you find an error or issue in these notes, read
+[CONTRIBUTING.md][contributing] and report it in
+[GitHub Issues][github-issues].
+
 ## Unreleased
 
 This is a maintenance release reflecting internal improvements.
@@ -99,4 +103,6 @@ No gameplay changes are introduced.
           the v0.2.0 release.
 
 [imperium-cruiser-workaround]: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735
+[contributing]: https://github.com/aoirint/CruiserJumpPractice/blob/main/CONTRIBUTING.md
 [github-changelog]: https://github.com/aoirint/CruiserJumpPractice/blob/main/CHANGELOG.md
+[github-issues]: https://github.com/aoirint/CruiserJumpPractice/issues

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -5,8 +5,8 @@ This changelog is the user-facing release notes for Thunderstore.
 For internal implementation details and developer-facing release history, see
 the [GitHub changelog][github-changelog].
 
-If you find an error or issue in these notes, read
-[CONTRIBUTING.md][contributing] and report it in
+If you find an error or issue in these notes, see
+[CONTRIBUTING.md][contributing], then report it in
 [GitHub Issues][github-issues].
 
 ## Unreleased


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Add linked `Reporting issues` guidance to `CONTRIBUTING.md` for ordinary bug reports, feature requests, compatibility notes, and documentation improvement requests.
- Clarify issue-request expectations: maintainers keep the project scope small to limit personal burden, while relevant reports can still be useful to other users even when closed as not planned.
- Clarify how maintainers may use public issue supporting material, and remind reporters not to share secrets, private data, or material they cannot share publicly.
- Clarify the CLA boundary for sample code, documentation text, patches, or other material that could be included or adapted into the project.
- Add `Stalled Issues` guidance aligned with the existing `Stalled Pull Requests` section, including reasonable-effort responses, closure for stale issues, and reasonable reopening or reopen requests.
- Add contributor-guide links for GitHub issues, pull requests, `CHANGELOG.md`, `assets/`, the pull request template, and the CLA section.
- Point users from the Thunderstore-facing changelog intro to `CONTRIBUTING.md` and GitHub Issues for release-note errors, bugs, and other project issues.

## Related Issues

- Closes #88
- Follow-up: #87

## Notes for reviewers

- This PR is split out from #85 and is intended to merge before that release-preparation PR.
- The change is documentation-only and does not alter release metadata or package contents beyond the published changelog text.
- GitHub issue-template design remains out of scope for this PR and is tracked separately in #87.
- The issue-scope note intentionally encourages relevant reports while making clear that out-of-scope, large, complex, or old-base-game compatibility requests may be closed as not planned.

### AI disclosure

Codex split this documentation guidance from the release-preparation branch, drafted and iteratively refined the `CONTRIBUTING.md` wording, added the Thunderstore-facing changelog route, updated #87 follow-up context, ran Markdown lint, and prepared PR-thread update and review notes. Human review focused on CLA boundaries, issue-reporting expectations, stalled issue wording, and maintainer-burden scope.

## Testing

### Automated checks

- `docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5`

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.