### PR TITLE
refactor(input): expose local busy state detail

### DIFF
--- a/CruiserJumpPractice/Core/Handlers/FrameHandler.cs
+++ b/CruiserJumpPractice/Core/Handlers/FrameHandler.cs
@@ -33,6 +33,8 @@ internal sealed class FrameHandler
 
     public void HandleFrame()
     {
+        // Snapshot one-frame triggers before suppression so later validation logging can
+        // report the intended action without retaining raw input, chat, or terminal text.
         var saveTriggered = practiceInput.SaveCruiserTriggered;
         var loadTriggered = practiceInput.LoadCruiserTriggered;
         var toggleMagnetTriggered = practiceInput.ToggleMagnetTriggered;

--- a/CruiserJumpPractice/Core/Handlers/FrameHandler.cs
+++ b/CruiserJumpPractice/Core/Handlers/FrameHandler.cs
@@ -33,43 +33,33 @@ internal sealed class FrameHandler
 
     public void HandleFrame()
     {
-        if (gameInterop.IsLocalPlayerBusy())
+        var saveTriggered = practiceInput.SaveCruiserTriggered;
+        var loadTriggered = practiceInput.LoadCruiserTriggered;
+        var toggleMagnetTriggered = practiceInput.ToggleMagnetTriggered;
+
+        if (!saveTriggered && !loadTriggered && !toggleMagnetTriggered)
         {
             return;
         }
 
-        UpdateSaveCruiser();
-        UpdateLoadCruiser();
-        UpdateToggleMagnet();
-    }
-
-    private void UpdateSaveCruiser()
-    {
-        if (!practiceInput.SaveCruiserTriggered)
+        if (gameInterop.GetLocalPlayerBusyState().IsBusy)
         {
             return;
         }
 
-        requestSaveCruiserStateUseCase.Execute();
-    }
-
-    private void UpdateLoadCruiser()
-    {
-        if (!practiceInput.LoadCruiserTriggered)
+        if (saveTriggered)
         {
-            return;
+            requestSaveCruiserStateUseCase.Execute();
         }
 
-        requestLoadCruiserStateUseCase.Execute();
-    }
-
-    private void UpdateToggleMagnet()
-    {
-        if (!practiceInput.ToggleMagnetTriggered)
+        if (loadTriggered)
         {
-            return;
+            requestLoadCruiserStateUseCase.Execute();
         }
 
-        toggleMagnetUseCase.Execute();
+        if (toggleMagnetTriggered)
+        {
+            toggleMagnetUseCase.Execute();
+        }
     }
 }

--- a/CruiserJumpPractice/Core/Ports/IGameInterop.cs
+++ b/CruiserJumpPractice/Core/Ports/IGameInterop.cs
@@ -2,6 +2,7 @@
 #nullable enable
 
 using CruiserJumpPractice.Core.Snapshots;
+using CruiserJumpPractice.Core.State;
 
 namespace CruiserJumpPractice.Core.Ports;
 
@@ -12,7 +13,7 @@ internal interface IGameInterop
 {
     bool IsHost();
 
-    bool IsLocalPlayerBusy();
+    LocalPlayerBusyState GetLocalPlayerBusyState();
 
     void DisplayTip(string headerText, string bodyText);
 

--- a/CruiserJumpPractice/Core/State/LocalPlayerBusyState.cs
+++ b/CruiserJumpPractice/Core/State/LocalPlayerBusyState.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 namespace CruiserJumpPractice.Core.State;

--- a/CruiserJumpPractice/Core/State/LocalPlayerBusyState.cs
+++ b/CruiserJumpPractice/Core/State/LocalPlayerBusyState.cs
@@ -3,6 +3,8 @@
 
 namespace CruiserJumpPractice.Core.State;
 
+// Future validation logs need a suppression reason, but this state intentionally carries only
+// closed booleans/tokens and never raw input, UI text, player identifiers, or Unity objects.
 internal readonly struct LocalPlayerBusyState
 {
     public const string MenuReasonToken = "menu";

--- a/CruiserJumpPractice/Core/State/LocalPlayerBusyState.cs
+++ b/CruiserJumpPractice/Core/State/LocalPlayerBusyState.cs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Unlicense
+#nullable enable
+
+namespace CruiserJumpPractice.Core.State;
+
+internal readonly struct LocalPlayerBusyState
+{
+    public const string MenuReasonToken = "menu";
+    public const string TerminalReasonToken = "terminal";
+    public const string ChatReasonToken = "chat";
+    public const string MultipleReasonToken = "multiple";
+
+    public LocalPlayerBusyState(bool isMenuOpen, bool isInTerminal, bool isTypingChat)
+    {
+        IsMenuOpen = isMenuOpen;
+        IsInTerminal = isInTerminal;
+        IsTypingChat = isTypingChat;
+    }
+
+    public bool IsMenuOpen { get; }
+
+    public bool IsInTerminal { get; }
+
+    public bool IsTypingChat { get; }
+
+    public bool IsBusy => IsMenuOpen || IsInTerminal || IsTypingChat;
+
+    public string? GetBusyReasonToken()
+    {
+        var busyReasonCount = 0;
+        busyReasonCount += IsMenuOpen ? 1 : 0;
+        busyReasonCount += IsInTerminal ? 1 : 0;
+        busyReasonCount += IsTypingChat ? 1 : 0;
+
+        if (busyReasonCount > 1)
+        {
+            return MultipleReasonToken;
+        }
+
+        if (IsMenuOpen)
+        {
+            return MenuReasonToken;
+        }
+
+        if (IsInTerminal)
+        {
+            return TerminalReasonToken;
+        }
+
+        if (IsTypingChat)
+        {
+            return ChatReasonToken;
+        }
+
+        return null;
+    }
+}

--- a/CruiserJumpPractice/Interop/Game/Adapters/PlayerAdapter.cs
+++ b/CruiserJumpPractice/Interop/Game/Adapters/PlayerAdapter.cs
@@ -2,6 +2,7 @@
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;
+using CruiserJumpPractice.Core.State;
 using CruiserJumpPractice.Interop.Game;
 
 namespace CruiserJumpPractice.Interop.Game.Adapters;
@@ -17,7 +18,7 @@ internal sealed class PlayerAdapter
         this.gameObjects = gameObjects;
     }
 
-    public bool IsLocalPlayerBusy()
+    public LocalPlayerBusyState GetLocalPlayerBusyState()
     {
         var localPlayer = gameObjects.GetLocalPlayer();
         try
@@ -28,7 +29,11 @@ internal sealed class PlayerAdapter
                 throw new GameInteropException("quickMenuManager is null.");
             }
 
-            return quickMenuManager.isMenuOpen || localPlayer.inTerminalMenu || localPlayer.isTypingChat;
+            return new LocalPlayerBusyState(
+                quickMenuManager.isMenuOpen,
+                localPlayer.inTerminalMenu,
+                localPlayer.isTypingChat
+            );
         }
         catch (System.Exception error)
         {

--- a/CruiserJumpPractice/Interop/Game/GameInterop.cs
+++ b/CruiserJumpPractice/Interop/Game/GameInterop.cs
@@ -3,6 +3,7 @@
 
 using CruiserJumpPractice.Core.Ports;
 using CruiserJumpPractice.Core.Snapshots;
+using CruiserJumpPractice.Core.State;
 using CruiserJumpPractice.Interop.Game.Adapters;
 
 namespace CruiserJumpPractice.Interop.Game;
@@ -36,9 +37,9 @@ internal sealed class GameInterop : IGameInterop
         return networkInterop.IsHost();
     }
 
-    public bool IsLocalPlayerBusy()
+    public LocalPlayerBusyState GetLocalPlayerBusyState()
     {
-        return playerInterop.IsLocalPlayerBusy();
+        return playerInterop.GetLocalPlayerBusyState();
     }
 
     public void DisplayTip(string headerText, string bodyText)


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Prepares #93 PR A by reading save/load/toggle-magnet one-frame triggers once at the start of `FrameHandler.HandleFrame()`.
- Returns before busy-state interop when no relevant action was triggered, then preserves dispatch order from the saved trigger values: save, load, toggle magnet.
- Replaces the local-player busy boolean port with `LocalPlayerBusyState`, populated by `PlayerAdapter` with menu/terminal/chat booleans and closed reason tokens.
- Adds no validation logging and should not change user-facing behavior.

## Related Issues

- Refs #93
- Implements PR A from https://github.com/aoirint/CruiserJumpPractice/issues/93#issuecomment-4377568167

## Notes for reviewers

### Review focus

- `FrameHandler.HandleFrame()` reads each one-frame trigger once before any early return.
- Busy-state behavior remains equivalent to `menu OR terminal OR chat`.
- Dispatch order remains save, load, toggle magnet.

### Security note

- The new busy-state surface carries only booleans and closed tokens: `menu`, `terminal`, `chat`, and `multiple`.
- This PR adds no raw input text, key names, chat contents, terminal text, menu contents, names, paths, IDs, Unity object references, validation logs, dependencies, network calls, or file-write paths.

### AI disclosure

Codex assisted with implementing the scoped refactor, checking the diff against the issue comment, running build/format verification, and preparing this PR body. The generated changes were reviewed for scope, dispatch order, and input/busy-state data minimization.

## Testing

### Automated checks

- [x] `DOTNET_CLI_UI_LANGUAGE=en dotnet build --configuration Release` passed with 0 warnings and 0 errors.
- [x] `DOTNET_CLI_UI_LANGUAGE=en dotnet format --no-restore --verify-no-changes` passed.

### AI-assisted inspections

Request: Check the implementation against #93 PR A scope and the requested security constraints.

AI-assisted result: Confirmed the patch does not add validation logging, dependencies, network calls, file writes, or free-form/user-controlled input data to the future logging path. The new state object exposes only the three busy-state booleans and the closed reason-token helper.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.