### PR TITLE
refactor(interop): expose cruiser restore observation

### DIFF
--- a/CruiserJumpPractice/Core/Ports/IGameInterop.cs
+++ b/CruiserJumpPractice/Core/Ports/IGameInterop.cs
@@ -26,7 +26,7 @@ internal interface IGameInterop
 
     CruiserSnapshot? CaptureCruiser();
 
-    void RestoreCruiser(CruiserSnapshot snapshot);
+    CruiserRestoreObservation RestoreCruiser(CruiserSnapshot snapshot);
 
     bool IsCruiserMagnetedToShip();
 

--- a/CruiserJumpPractice/Core/Snapshots/CruiserRestoreObservation.cs
+++ b/CruiserJumpPractice/Core/Snapshots/CruiserRestoreObservation.cs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Unlicense
+#nullable enable
+
+namespace CruiserJumpPractice.Core.Snapshots;
+
+// Restore observations carry only numeric cruiser state that future restore validation can use
+// without exposing Unity objects or environment-specific identifiers.
+internal sealed class CruiserRestoreObservation
+{
+    public Vector3Value SavedCarPosition { get; }
+
+    public Vector3Value SavedCarRotation { get; }
+
+    public Vector3Value BeforeCarPosition { get; }
+
+    public Vector3Value AfterCarPosition { get; }
+
+    public int SavedCarHP { get; }
+
+    public int BeforeCarHP { get; }
+
+    public int AfterCarHP { get; }
+
+    public int SavedTurboBoosts { get; }
+
+    public int BeforeTurboBoosts { get; }
+
+    public int AfterTurboBoosts { get; }
+
+    public CruiserRestoreObservation(
+        Vector3Value savedCarPosition,
+        Vector3Value savedCarRotation,
+        Vector3Value beforeCarPosition,
+        Vector3Value afterCarPosition,
+        int savedCarHP,
+        int beforeCarHP,
+        int afterCarHP,
+        int savedTurboBoosts,
+        int beforeTurboBoosts,
+        int afterTurboBoosts
+    )
+    {
+        SavedCarPosition = savedCarPosition;
+        SavedCarRotation = savedCarRotation;
+        BeforeCarPosition = beforeCarPosition;
+        AfterCarPosition = afterCarPosition;
+        SavedCarHP = savedCarHP;
+        BeforeCarHP = beforeCarHP;
+        AfterCarHP = afterCarHP;
+        SavedTurboBoosts = savedTurboBoosts;
+        BeforeTurboBoosts = beforeTurboBoosts;
+        AfterTurboBoosts = afterTurboBoosts;
+    }
+}

--- a/CruiserJumpPractice/Core/Snapshots/CruiserRestoreObservation.cs
+++ b/CruiserJumpPractice/Core/Snapshots/CruiserRestoreObservation.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 namespace CruiserJumpPractice.Core.Snapshots;

--- a/CruiserJumpPractice/Core/UseCases/Server/LoadCruiserStateUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Server/LoadCruiserStateUseCase.cs
@@ -48,7 +48,7 @@ internal sealed class LoadCruiserStateUseCase
                 return LoadCruiserStateResult.MagnetedToShip;
             }
 
-            gameInterop.RestoreCruiser(savedCruiserState);
+            _ = gameInterop.RestoreCruiser(savedCruiserState);
             return LoadCruiserStateResult.Success;
         }
         catch (System.Exception error)

--- a/CruiserJumpPractice/Core/UseCases/Server/LoadCruiserStateUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Server/LoadCruiserStateUseCase.cs
@@ -48,6 +48,8 @@ internal sealed class LoadCruiserStateUseCase
                 return LoadCruiserStateResult.MagnetedToShip;
             }
 
+            // The restore observation is collected on the server path for later validation
+            // logging; until then, load result semantics stay enum-only for the client RPC.
             _ = gameInterop.RestoreCruiser(savedCruiserState);
             return LoadCruiserStateResult.Success;
         }

--- a/CruiserJumpPractice/Interop/Game/Adapters/CruiserAdapter.cs
+++ b/CruiserJumpPractice/Interop/Game/Adapters/CruiserAdapter.cs
@@ -78,6 +78,8 @@ internal sealed class CruiserAdapter
         var localPlayerId = gameObjects.GetLocalPlayerId();
         try
         {
+            // Capture observation values from this live cruiser instance only; restore validation
+            // should not add another scene search or polling loop when logging is wired later.
             var beforeCarPosition = FromUnityVector3(cruiser.transform.position);
             var beforeCarHP = cruiser.carHP;
             var beforeTurboBoosts = GetCruiserTurboBoosts(cruiser);

--- a/CruiserJumpPractice/Interop/Game/Adapters/CruiserAdapter.cs
+++ b/CruiserJumpPractice/Interop/Game/Adapters/CruiserAdapter.cs
@@ -73,11 +73,15 @@ internal sealed class CruiserAdapter
         }
     }
 
-    public void RestoreCruiser(VehicleController cruiser, CruiserSnapshot snapshot)
+    public CruiserRestoreObservation RestoreCruiser(VehicleController cruiser, CruiserSnapshot snapshot)
     {
         var localPlayerId = gameObjects.GetLocalPlayerId();
         try
         {
+            var beforeCarPosition = FromUnityVector3(cruiser.transform.position);
+            var beforeCarHP = cruiser.carHP;
+            var beforeTurboBoosts = GetCruiserTurboBoosts(cruiser);
+
             // VehicleController already syncs transform and driving fields during its vanilla
             // update flow, while oil and turbo counts need the game's RPC helpers below.
             cruiser.transform.position = ToUnityVector3(snapshot.CarPosition);
@@ -90,6 +94,19 @@ internal sealed class CruiserAdapter
 
             cruiser.AddTurboBoostOnLocalClient(snapshot.TurboBoosts);
             cruiser.AddTurboBoostServerRpc(localPlayerId, snapshot.TurboBoosts);
+
+            return new CruiserRestoreObservation(
+                savedCarPosition: snapshot.CarPosition,
+                savedCarRotation: snapshot.CarRotation,
+                beforeCarPosition: beforeCarPosition,
+                afterCarPosition: FromUnityVector3(cruiser.transform.position),
+                savedCarHP: snapshot.CarHP,
+                beforeCarHP: beforeCarHP,
+                afterCarHP: cruiser.carHP,
+                savedTurboBoosts: snapshot.TurboBoosts,
+                beforeTurboBoosts: beforeTurboBoosts,
+                afterTurboBoosts: GetCruiserTurboBoosts(cruiser)
+            );
         }
         catch (System.Exception error)
         {

--- a/CruiserJumpPractice/Interop/Game/GameInterop.cs
+++ b/CruiserJumpPractice/Interop/Game/GameInterop.cs
@@ -77,7 +77,7 @@ internal sealed class GameInterop : IGameInterop
         return cruiserInterop.CaptureCruiser(cruiser);
     }
 
-    public void RestoreCruiser(CruiserSnapshot snapshot)
+    public CruiserRestoreObservation RestoreCruiser(CruiserSnapshot snapshot)
     {
         var cruiser = cruiserInterop.FindCruiser();
         if (cruiser == null)
@@ -85,7 +85,7 @@ internal sealed class GameInterop : IGameInterop
             throw new GameInteropException("No cruiser found.");
         }
 
-        cruiserInterop.RestoreCruiser(cruiser, snapshot);
+        return cruiserInterop.RestoreCruiser(cruiser, snapshot);
     }
 
     public bool IsCruiserMagnetedToShip()


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Adds `CruiserRestoreObservation` as a Core restore-observation value for the later validation work.
- Threads the observation through `IGameInterop.RestoreCruiser(...)`, `GameInterop`, and `CruiserAdapter` while keeping successful loads as `LoadCruiserStateResult.Success`.
- Captures saved/before/after restore values from the same cruiser restore path without adding validation logging.

## Related Issues

- Refs #93
- Refs https://github.com/aoirint/CruiserJumpPractice/issues/93#issuecomment-4377568167

## Notes for reviewers

- Restore side effects stay in the existing order: transform and drive fields, `AddEngineOilOnLocalClient`, `AddEngineOilServerRpc`, `AddTurboBoostOnLocalClient`, then `AddTurboBoostServerRpc`.
- The observation is created after the restore calls complete, and load behavior still ignores it until a later logging PR.
- Security note: the new observation carries only numeric cruiser state (`Vector3Value` floats and integer HP/turbo counts). It adds no Unity object names, scene/moon names, player identifiers, paths, lobby data, object instance IDs, validation logs, dependencies, network calls, or file writes.

### AI disclosure

Codex implemented the scoped restore-observation refactor, reviewed the resulting diff for restore ordering and data minimization, and prepared this PR body. The code and verification outputs were checked before submission.

## Testing

### Automated checks

- `dotnet build --configuration Release` - passed with 0 warnings and 0 errors.
- `dotnet format --verify-no-changes` - passed.
- `git diff --check` / `git diff --cached --check` - passed.

### AI-assisted inspections

Request: Check that PR B restores observation paths only and does not introduce validation logging or sensitive validation data.

AI-assisted result: Confirmed the changed files are limited to restore observation/Core interop paths, no `[CJP_VALIDATION]` or validation logger implementation was added, no extra cruiser search/polling was introduced, and the observation type contains only numeric cruiser state.

### Manual checks

- Not run - no in-game validation environment was used for this preparation refactor.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
