### PR TITLE
refactor(presentation): prepare HUD and magnet validation tokens

### DIFF
--- a/CruiserJumpPractice/Core/Ports/IGameInterop.cs
+++ b/CruiserJumpPractice/Core/Ports/IGameInterop.cs
@@ -2,6 +2,7 @@
 #nullable enable
 
 using CruiserJumpPractice.Core.Snapshots;
+using CruiserJumpPractice.Core.Presentation;
 
 namespace CruiserJumpPractice.Core.Ports;
 
@@ -14,7 +15,7 @@ internal interface IGameInterop
 
     bool IsLocalPlayerBusy();
 
-    void DisplayTip(string headerText, string bodyText);
+    void DisplayTip(HudTipMessage message);
 
     void SpawnRpcSurrogate();
 

--- a/CruiserJumpPractice/Core/Presentation/HudTipMessage.cs
+++ b/CruiserJumpPractice/Core/Presentation/HudTipMessage.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 namespace CruiserJumpPractice.Core.Presentation;

--- a/CruiserJumpPractice/Core/Presentation/HudTipMessage.cs
+++ b/CruiserJumpPractice/Core/Presentation/HudTipMessage.cs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Unlicense
+#nullable enable
+
+namespace CruiserJumpPractice.Core.Presentation;
+
+internal sealed class HudTipMessage
+{
+    private const string DefaultHeaderText = "CruiserJumpPractice";
+
+    public static readonly HudTipMessage SaveSuccess = new(
+        "save_success",
+        DefaultHeaderText,
+        "Cruiser state saved."
+    );
+
+    public static readonly HudTipMessage SaveNoCruiser = new(
+        "save_no_cruiser",
+        DefaultHeaderText,
+        "No cruiser found to save."
+    );
+
+    public static readonly HudTipMessage SaveHostOnly = new(
+        "save_host_only",
+        DefaultHeaderText,
+        "Only the host can save the cruiser state."
+    );
+
+    public static readonly HudTipMessage LoadSuccess = new(
+        "load_success",
+        DefaultHeaderText,
+        "Cruiser state loaded."
+    );
+
+    public static readonly HudTipMessage LoadNoCruiser = new(
+        "load_no_cruiser",
+        DefaultHeaderText,
+        "No cruiser found to load."
+    );
+
+    public static readonly HudTipMessage LoadNoSavedState = new(
+        "load_no_saved_state",
+        DefaultHeaderText,
+        "No saved cruiser state to load."
+    );
+
+    public static readonly HudTipMessage LoadMagnetedToShip = new(
+        "load_magneted_to_ship",
+        DefaultHeaderText,
+        "Cannot load cruiser state while magneted to ship."
+    );
+
+    public static readonly HudTipMessage LoadHostOnly = new(
+        "load_host_only",
+        DefaultHeaderText,
+        "Only the host can load the cruiser state."
+    );
+
+    public static readonly HudTipMessage MagnetHostOnly = new(
+        "magnet_host_only",
+        DefaultHeaderText,
+        "Only the host can toggle the magnet."
+    );
+
+    public static readonly HudTipMessage MagnetOn = new(
+        "magnet_on",
+        DefaultHeaderText,
+        "Magnet is now ON."
+    );
+
+    public static readonly HudTipMessage MagnetOff = new(
+        "magnet_off",
+        DefaultHeaderText,
+        "Magnet is now OFF."
+    );
+
+    private HudTipMessage(string token, string headerText, string bodyText)
+    {
+        Token = token;
+        HeaderText = headerText;
+        BodyText = bodyText;
+    }
+
+    public string Token { get; }
+
+    public string HeaderText { get; }
+
+    public string BodyText { get; }
+}

--- a/CruiserJumpPractice/Core/Presentation/HudTipMessage.cs
+++ b/CruiserJumpPractice/Core/Presentation/HudTipMessage.cs
@@ -7,6 +7,8 @@ internal sealed class HudTipMessage
 {
     private const string DefaultHeaderText = "CruiserJumpPractice";
 
+    // Use cases select a closed token before display so future validation can
+    // record stable intent without treating HUD text as an input boundary.
     public static readonly HudTipMessage SaveSuccess = new(
         "save_success",
         DefaultHeaderText,

--- a/CruiserJumpPractice/Core/UseCases/Client/MagnetToggleObservation.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/MagnetToggleObservation.cs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Unlicense
+#nullable enable
+
+namespace CruiserJumpPractice.Core.UseCases.Client;
+
+internal enum MagnetState
+{
+    Unknown,
+    On,
+    Off
+}
+
+internal sealed class MagnetToggleObservation
+{
+    private MagnetToggleObservation(
+        MagnetState beforeState,
+        MagnetState expectedAfterState,
+        MagnetState observedAfterState
+    )
+    {
+        BeforeState = beforeState;
+        ExpectedAfterState = expectedAfterState;
+        ObservedAfterState = observedAfterState;
+    }
+
+    public MagnetState BeforeState { get; }
+
+    public MagnetState ExpectedAfterState { get; }
+
+    public MagnetState ObservedAfterState { get; }
+
+    public static MagnetToggleObservation FromBeforeState(bool beforeIsOn)
+    {
+        var beforeState = beforeIsOn ? MagnetState.On : MagnetState.Off;
+        var expectedAfterState = beforeIsOn ? MagnetState.Off : MagnetState.On;
+
+        return new MagnetToggleObservation(
+            beforeState,
+            expectedAfterState,
+            MagnetState.Unknown
+        );
+    }
+}

--- a/CruiserJumpPractice/Core/UseCases/Client/MagnetToggleObservation.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/MagnetToggleObservation.cs
@@ -34,6 +34,8 @@ internal sealed class MagnetToggleObservation
         var beforeState = beforeIsOn ? MagnetState.On : MagnetState.Off;
         var expectedAfterState = beforeIsOn ? MagnetState.Off : MagnetState.On;
 
+        // The vanilla lever/RPC boundary is asynchronous from here; this use
+        // case intentionally does not claim to observe the synced result.
         return new MagnetToggleObservation(
             beforeState,
             expectedAfterState,

--- a/CruiserJumpPractice/Core/UseCases/Client/MagnetToggleObservation.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/MagnetToggleObservation.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 namespace CruiserJumpPractice.Core.UseCases.Client;

--- a/CruiserJumpPractice/Core/UseCases/Client/PresentLoadCruiserStateResultUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/PresentLoadCruiserStateResultUseCase.cs
@@ -2,6 +2,7 @@
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;
+using CruiserJumpPractice.Core.Presentation;
 
 namespace CruiserJumpPractice.Core.UseCases.Client;
 
@@ -23,19 +24,19 @@ internal sealed class PresentLoadCruiserStateResultUseCase
     {
         if (result == LoadCruiserStateResult.Success)
         {
-            DisplayTip("Cruiser state loaded.");
+            DisplayTip(HudTipMessage.LoadSuccess);
         }
         else if (result == LoadCruiserStateResult.NoCruiserFound)
         {
-            DisplayTip("No cruiser found to load.");
+            DisplayTip(HudTipMessage.LoadNoCruiser);
         }
         else if (result == LoadCruiserStateResult.NoSavedState)
         {
-            DisplayTip("No saved cruiser state to load.");
+            DisplayTip(HudTipMessage.LoadNoSavedState);
         }
         else if (result == LoadCruiserStateResult.MagnetedToShip)
         {
-            DisplayTip("Cannot load cruiser state while magneted to ship.");
+            DisplayTip(HudTipMessage.LoadMagnetedToShip);
         }
         else
         {
@@ -43,8 +44,8 @@ internal sealed class PresentLoadCruiserStateResultUseCase
         }
     }
 
-    private void DisplayTip(string message)
+    private void DisplayTip(HudTipMessage message)
     {
-        gameInterop.DisplayTip("CruiserJumpPractice", message);
+        gameInterop.DisplayTip(message);
     }
 }

--- a/CruiserJumpPractice/Core/UseCases/Client/PresentSaveCruiserStateResultUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/PresentSaveCruiserStateResultUseCase.cs
@@ -2,6 +2,7 @@
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;
+using CruiserJumpPractice.Core.Presentation;
 
 namespace CruiserJumpPractice.Core.UseCases.Client;
 
@@ -22,11 +23,11 @@ internal sealed class PresentSaveCruiserStateResultUseCase
     {
         if (result == SaveCruiserStateResult.Success)
         {
-            DisplayTip("Cruiser state saved.");
+            DisplayTip(HudTipMessage.SaveSuccess);
         }
         else if (result == SaveCruiserStateResult.NoCruiserFound)
         {
-            DisplayTip("No cruiser found to save.");
+            DisplayTip(HudTipMessage.SaveNoCruiser);
         }
         else
         {
@@ -34,8 +35,8 @@ internal sealed class PresentSaveCruiserStateResultUseCase
         }
     }
 
-    private void DisplayTip(string message)
+    private void DisplayTip(HudTipMessage message)
     {
-        gameInterop.DisplayTip("CruiserJumpPractice", message);
+        gameInterop.DisplayTip(message);
     }
 }

--- a/CruiserJumpPractice/Core/UseCases/Client/RequestLoadCruiserStateUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/RequestLoadCruiserStateUseCase.cs
@@ -2,6 +2,7 @@
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;
+using CruiserJumpPractice.Core.Presentation;
 
 namespace CruiserJumpPractice.Core.UseCases.Client;
 
@@ -20,7 +21,7 @@ internal sealed class RequestLoadCruiserStateUseCase
     {
         if (!gameInterop.IsHost())
         {
-            gameInterop.DisplayTip("CruiserJumpPractice", "Only the host can load the cruiser state.");
+            gameInterop.DisplayTip(HudTipMessage.LoadHostOnly);
             return RequestLoadCruiserStateResult.HostOnly;
         }
 

--- a/CruiserJumpPractice/Core/UseCases/Client/RequestSaveCruiserStateUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/RequestSaveCruiserStateUseCase.cs
@@ -2,6 +2,7 @@
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;
+using CruiserJumpPractice.Core.Presentation;
 
 namespace CruiserJumpPractice.Core.UseCases.Client;
 
@@ -20,7 +21,7 @@ internal sealed class RequestSaveCruiserStateUseCase
     {
         if (!gameInterop.IsHost())
         {
-            gameInterop.DisplayTip("CruiserJumpPractice", "Only the host can save the cruiser state.");
+            gameInterop.DisplayTip(HudTipMessage.SaveHostOnly);
             return RequestSaveCruiserStateResult.HostOnly;
         }
 

--- a/CruiserJumpPractice/Core/UseCases/Client/ToggleMagnetUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/ToggleMagnetUseCase.cs
@@ -2,6 +2,7 @@
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;
+using CruiserJumpPractice.Core.Presentation;
 
 namespace CruiserJumpPractice.Core.UseCases.Client;
 
@@ -21,18 +22,22 @@ internal sealed class ToggleMagnetUseCase
     {
         if (!gameInterop.IsHost())
         {
-            gameInterop.DisplayTip("CruiserJumpPractice", "Only the host can toggle the magnet.");
+            gameInterop.DisplayTip(HudTipMessage.MagnetHostOnly);
             return ToggleMagnetResult.HostOnly;
         }
 
-        var newMagnetState = !gameInterop.IsShipMagnetOn();
+        var observation = MagnetToggleObservation.FromBeforeState(gameInterop.IsShipMagnetOn());
 
         // The game's built-in server RPC flow synchronizes this value.
         gameInterop.ToggleShipMagnet();
 
-        var result = newMagnetState ? ToggleMagnetResult.MagnetOn : ToggleMagnetResult.MagnetOff;
-        var magnetStateText = result == ToggleMagnetResult.MagnetOn ? "ON" : "OFF";
-        gameInterop.DisplayTip("CruiserJumpPractice", $"Magnet is now {magnetStateText}.");
+        var result = observation.ExpectedAfterState == MagnetState.On
+            ? ToggleMagnetResult.MagnetOn
+            : ToggleMagnetResult.MagnetOff;
+        var message = result == ToggleMagnetResult.MagnetOn
+            ? HudTipMessage.MagnetOn
+            : HudTipMessage.MagnetOff;
+        gameInterop.DisplayTip(message);
         return result;
     }
 }

--- a/CruiserJumpPractice/Interop/Game/GameInterop.cs
+++ b/CruiserJumpPractice/Interop/Game/GameInterop.cs
@@ -44,6 +44,8 @@ internal sealed class GameInterop : IGameInterop
 
     public void DisplayTip(HudTipMessage message)
     {
+        // Message selection stays in Core; Interop only unwraps the display text
+        // at the final HUD boundary.
         hudInterop.DisplayTip(message.HeaderText, message.BodyText);
     }
 

--- a/CruiserJumpPractice/Interop/Game/GameInterop.cs
+++ b/CruiserJumpPractice/Interop/Game/GameInterop.cs
@@ -2,6 +2,7 @@
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;
+using CruiserJumpPractice.Core.Presentation;
 using CruiserJumpPractice.Core.Snapshots;
 using CruiserJumpPractice.Interop.Game.Adapters;
 
@@ -41,9 +42,9 @@ internal sealed class GameInterop : IGameInterop
         return playerInterop.IsLocalPlayerBusy();
     }
 
-    public void DisplayTip(string headerText, string bodyText)
+    public void DisplayTip(HudTipMessage message)
     {
-        hudInterop.DisplayTip(headerText, bodyText);
+        hudInterop.DisplayTip(message.HeaderText, message.BodyText);
     }
 
     public void SpawnRpcSurrogate()


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Adds closed `HudTipMessage` constants with stable snake_case tokens plus the existing HUD header/body text.
- Updates presentation use cases and host-only feedback paths to select a HUD token first, then display the same user-visible text.
- Adds `MagnetToggleObservation` so `ToggleMagnetUseCase` keeps the existing before-state read, derives expected-after explicitly, and leaves observed-after as `Unknown` without extra polling.

## Related Issues

- Refs #93
- Implements PR C from issue comment https://github.com/aoirint/CruiserJumpPractice/issues/93#issuecomment-4377568167

## Notes for reviewers

- Security note: HUD validation candidates are closed constants only; magnet observation values are enum states limited to `Unknown`, `On`, and `Off`; this PR adds no validation logs, dependencies, network calls, file writes, secrets, player names, object names, exception text, or external strings to future validation data paths.
- Review focus: confirm HUD body text remains unchanged and `ToggleShipMagnet()` is still called exactly once per allowed toggle action.

### AI disclosure

Codex implemented this focused preparation refactor from the requested issue comment, reviewed the changed code paths for scope and security constraints, and ran the checks listed below. The final diff was inspected for unchanged HUD text, closed token/state data, and absence of validation logging.

## Testing

### Automated checks

- `dotnet build --configuration Release` - passed with 0 warnings and 0 errors.
- `dotnet format --verify-no-changes --verbosity minimal` - passed.
- `git diff --cached --check` - passed before commit.

### AI-assisted inspections

Request: Check PR C scope and security constraints for HUD tip tokens and magnet observation.

AI-assisted result: Confirmed no new validation logging, dependencies, network calls, file writes, or arbitrary HUD/external strings were added; HUD tokens are closed constants and magnet observation uses closed enum states only.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.