### PR TITLE
chore(license): switch repository license to MIT

### DIFF
--- a/.agents/skills/changelog-workflow/SKILL.md
+++ b/.agents/skills/changelog-workflow/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 name: changelog-workflow
 description: >-
   Create and update a canonical developer changelog. Use when adding

--- a/.agents/skills/changelog-workflow/agents/openai.yaml
+++ b/.agents/skills/changelog-workflow/agents/openai.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 interface:
   display_name: "Changelog Workflow"
   short_description: "Update a canonical developer changelog."

--- a/.agents/skills/code-quality-check/SKILL.md
+++ b/.agents/skills/code-quality-check/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 name: code-quality-check
 description: >-
   Quality-check source code, generated code, tests, scripts,

--- a/.agents/skills/code-quality-check/agents/openai.yaml
+++ b/.agents/skills/code-quality-check/agents/openai.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 interface:
   display_name: "Code Quality Check"
   short_description: "Review code quality, maintainability, verification, and supply-chain-sensitive changes."

--- a/.agents/skills/code-quality-check/references/spdx-license-notices.md
+++ b/.agents/skills/code-quality-check/references/spdx-license-notices.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: Unlicense -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # SPDX License Notice Decision Guide
 
@@ -45,7 +45,7 @@ For files created wholly for this repository, use the repository's existing noti
 nearby files, `LICENSE*`, package metadata, repository docs, templates, generation scripts, and task
 instructions before adding a new header style.
 
-Default to [`Unlicense`](https://spdx.org/licenses/Unlicense.html) only when both checks are true:
+Default to [`MIT`](https://spdx.org/licenses/MIT.html) only when both checks are true:
 
 1. No project-specific instruction overrides it.
 2. The file is not copied, translated, generated from, adapted from, vendored from, or substantially
@@ -108,7 +108,7 @@ for the new file. Cite the source only when it materially helps reviewers unders
 
 ```python
 # SPDX-FileCopyrightText: 2026 Example Maintainer
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 # Design note: behavior cross-checked against Example Tool v2.0 documentation.
 ```
 
@@ -123,7 +123,7 @@ that one license identifier.
 
 ```shell
 # SPDX-FileCopyrightText: 2026 Example Maintainer
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 ```
 
 For a copied file:
@@ -156,7 +156,7 @@ reviewable in a nearby source comment or PR note:
  */
 ```
 
-Do not rewrite `MIT OR Apache-2.0` to `Unlicense` just because the repository default is Unlicense
+Do not rewrite `MIT OR Apache-2.0` to `MIT` just because the repository default is MIT
 unless the upstream grant allows that choice and the project intentionally makes it.
 
 ### Mixed Original and Copyleft Code
@@ -204,7 +204,7 @@ file.
 Use this when neighboring files use license-only headers and provenance is fully project-local:
 
 ```python
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 ```
 
 ### Recommended Header
@@ -213,7 +213,7 @@ Use this for most new reusable source, scripts, templates, and examples:
 
 ```python
 # SPDX-FileCopyrightText: 2026 Example Maintainer
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 ```
 
 ### Derivative Header
@@ -250,7 +250,7 @@ For generated files, prefer generator metadata when available:
 
 ```typescript
 // SPDX-FileCopyrightText: 2026 Example Maintainer
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 // Generated from schemas/widget.schema.json by scripts/generate-widget-types.ts.
 ```
 
@@ -272,28 +272,28 @@ Do not remove upstream notices:
 ```python
 # Bad: replaced the upstream copyright holder.
 # SPDX-FileCopyrightText: 2026 Example Maintainer
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 ```
 
 Do not change licenses casually:
 
 ```python
 # Bad: file was copied from Apache-2.0 upstream but relicensed without permission.
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 ```
 
 Do not erase dual-license choices without a recorded decision:
 
 ```python
 # Bad: upstream said MIT OR Apache-2.0, but the choice is not documented.
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 ```
 
 Do not label a file as original when it contains adapted copyleft code:
 
 ```python
 # Bad: adapted GPL logic cannot be hidden under a project-default permissive header.
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 ```
 
 ## Decision Flow

--- a/.agents/skills/commit-message-quality-check/SKILL.md
+++ b/.agents/skills/commit-message-quality-check/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 name: commit-message-quality-check
 description: >-
   Quality-check repository commit messages. Use when creating or updating commit

--- a/.agents/skills/commit-message-quality-check/agents/openai.yaml
+++ b/.agents/skills/commit-message-quality-check/agents/openai.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 interface:
   display_name: "Commit Message Quality Check"
   short_description: "Quality-check repository commit messages."

--- a/.agents/skills/document-quality-check/SKILL.md
+++ b/.agents/skills/document-quality-check/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 name: document-quality-check
 description: >-
   Quality-check documentation, comments, release notes, issue text, pull request

--- a/.agents/skills/document-quality-check/agents/openai.yaml
+++ b/.agents/skills/document-quality-check/agents/openai.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 interface:
   display_name: "Document Quality Check"
   short_description: "Quality-check explanatory prose."

--- a/.agents/skills/git-worktree-workflow/SKILL.md
+++ b/.agents/skills/git-worktree-workflow/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 name: git-worktree-workflow
 description: Use Git worktrees for repository implementation tasks unless explicitly told not to.
 ---

--- a/.agents/skills/git-worktree-workflow/agents/openai.yaml
+++ b/.agents/skills/git-worktree-workflow/agents/openai.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 interface:
   display_name: "Git Worktree Workflow"
   short_description: "Use Git worktrees for repository implementation tasks."

--- a/.agents/skills/gitignore-workflow/SKILL.md
+++ b/.agents/skills/gitignore-workflow/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 name: gitignore-workflow
 description: "Create or update .gitignore files. Use when editing ignore rules."
 ---

--- a/.agents/skills/gitignore-workflow/agents/openai.yaml
+++ b/.agents/skills/gitignore-workflow/agents/openai.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 interface:
   display_name: "Gitignore Workflow"
   short_description: "Create or update .gitignore files."

--- a/.agents/skills/issue-quality-check/SKILL.md
+++ b/.agents/skills/issue-quality-check/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 name: issue-quality-check
 description: >-
   Quality-check repository issues and issue replies. Use when creating,

--- a/.agents/skills/issue-quality-check/agents/openai.yaml
+++ b/.agents/skills/issue-quality-check/agents/openai.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 interface:
   display_name: "Issue Quality Check"
   short_description: "Quality-check repository issues and issue replies."

--- a/.agents/skills/pull-request-quality-check/SKILL.md
+++ b/.agents/skills/pull-request-quality-check/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 name: pull-request-quality-check
 description: Quality-check repository pull requests, review comments, replies, and PR-thread notes.
 ---

--- a/.agents/skills/pull-request-quality-check/agents/openai.yaml
+++ b/.agents/skills/pull-request-quality-check/agents/openai.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 interface:
   display_name: "Pull Request Quality Check"
   short_description: "Quality-check repository pull requests."

--- a/.agents/skills/pull-request-quality-check/references/fallback-pr-body.md
+++ b/.agents/skills/pull-request-quality-check/references/fallback-pr-body.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: Unlicense -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # Fallback Pull Request Body
 

--- a/.agents/skills/release-note-workflow/SKILL.md
+++ b/.agents/skills/release-note-workflow/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 name: release-note-workflow
 description: >-
   Create, update, or review user-facing release notes. Use when deriving stable

--- a/.agents/skills/release-note-workflow/agents/openai.yaml
+++ b/.agents/skills/release-note-workflow/agents/openai.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 interface:
   display_name: "Release Note Workflow"
   short_description: "Derive user-facing stable release notes."

--- a/.agents/skills/security-check/SKILL.md
+++ b/.agents/skills/security-check/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 name: security-check
 description: >-
   Check repository work for practical security risks, including secrets,

--- a/.agents/skills/security-check/agents/openai.yaml
+++ b/.agents/skills/security-check/agents/openai.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 interface:
   display_name: "Security Check"
   short_description: "Review repository work for practical security and supply-chain-sensitive risks."

--- a/.agents/skills/skill-quality-check/SKILL.md
+++ b/.agents/skills/skill-quality-check/SKILL.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 name: skill-quality-check
 description: >-
   Quality-check Agent Skills for trigger clarity, scope, structure, progressive

--- a/.agents/skills/skill-quality-check/agents/openai.yaml
+++ b/.agents/skills/skill-quality-check/agents/openai.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 interface:
   display_name: "Skill Quality Check"
   short_description: "Quality-check Agent Skills."

--- a/.agents/skills/skill-quality-check/references/authoring-best-practices.md
+++ b/.agents/skills/skill-quality-check/references/authoring-best-practices.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: Unlicense -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # Agent Skill Authoring Best Practices
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 # Enforce CRLF line endings
 * text=auto eol=crlf
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: MIT
 * @aoirint

--- a/.github/actions/generate-version/action.yml
+++ b/.github/actions/generate-version/action.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: Generate Version
 description: "Generate application and git version based on csproj version and git tags."
 

--- a/.github/actions/publish-thunderstore/action.yml
+++ b/.github/actions/publish-thunderstore/action.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 name: Publish Thunderstore Package
 description: Upload and submit a prebuilt Thunderstore package zip.
 

--- a/.github/actions/publish-thunderstore/publish-thunderstore.sh
+++ b/.github/actions/publish-thunderstore/publish-thunderstore.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 
 set -euo pipefail
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: MIT -->
+
 <!--
 If significant AI assistance affected this pull request, put this alert at the
 very top of the PR body:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: Build
 
 on:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: Lint
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 # Project specific files
 /work
 /profiles

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 ---
 # Lint every committed Markdown document by default so docs, release notes, and
 # GitHub templates follow one repository-wide style.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: MIT -->
+
 # Agent Instructions
 
 Use repository-local Agent Skills from:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: Unlicense -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # Changelog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: Unlicense -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # Contributing
 

--- a/CruiserJumpPractice/Core/Handlers/FrameHandler.cs
+++ b/CruiserJumpPractice/Core/Handlers/FrameHandler.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Core/Handlers/StartupHandler.cs
+++ b/CruiserJumpPractice/Core/Handlers/StartupHandler.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Core/Ports/IGameInterop.cs
+++ b/CruiserJumpPractice/Core/Ports/IGameInterop.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Snapshots;

--- a/CruiserJumpPractice/Core/Ports/IPluginLogger.cs
+++ b/CruiserJumpPractice/Core/Ports/IPluginLogger.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 namespace CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Core/Ports/IPracticeInput.cs
+++ b/CruiserJumpPractice/Core/Ports/IPracticeInput.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 namespace CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Core/Snapshots/CruiserSnapshot.cs
+++ b/CruiserJumpPractice/Core/Snapshots/CruiserSnapshot.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 namespace CruiserJumpPractice.Core.Snapshots;

--- a/CruiserJumpPractice/Core/Snapshots/Vector3Value.cs
+++ b/CruiserJumpPractice/Core/Snapshots/Vector3Value.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 namespace CruiserJumpPractice.Core.Snapshots;

--- a/CruiserJumpPractice/Core/State/CruiserStateStore.cs
+++ b/CruiserJumpPractice/Core/State/CruiserStateStore.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Snapshots;

--- a/CruiserJumpPractice/Core/UseCases/Client/PresentLoadCruiserStateResultUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/PresentLoadCruiserStateResultUseCase.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Core/UseCases/Client/PresentSaveCruiserStateResultUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/PresentSaveCruiserStateResultUseCase.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Core/UseCases/Client/RequestLoadCruiserStateUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/RequestLoadCruiserStateUseCase.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Core/UseCases/Client/RequestSaveCruiserStateUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/RequestSaveCruiserStateUseCase.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Core/UseCases/Client/ToggleMagnetUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/ToggleMagnetUseCase.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Core/UseCases/Server/LoadCruiserStateUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Server/LoadCruiserStateUseCase.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Core/UseCases/Server/SaveCruiserStateUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Server/SaveCruiserStateUseCase.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Core/UseCases/UseCaseResults.cs
+++ b/CruiserJumpPractice/Core/UseCases/UseCaseResults.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 namespace CruiserJumpPractice.Core.UseCases;

--- a/CruiserJumpPractice/CruiserJumpPractice.cs
+++ b/CruiserJumpPractice/CruiserJumpPractice.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using BepInEx;

--- a/CruiserJumpPractice/CruiserJumpPractice.csproj
+++ b/CruiserJumpPractice/CruiserJumpPractice.csproj
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: Unlicense -->
+<!-- SPDX-License-Identifier: MIT -->
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/CruiserJumpPractice/Interop/BepInExPluginLogger.cs
+++ b/CruiserJumpPractice/Interop/BepInExPluginLogger.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using BepInEx.Logging;

--- a/CruiserJumpPractice/Interop/Game/Adapters/CruiserAdapter.cs
+++ b/CruiserJumpPractice/Interop/Game/Adapters/CruiserAdapter.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 extern alias LethalCompany;

--- a/CruiserJumpPractice/Interop/Game/Adapters/GameObjectAdapter.cs
+++ b/CruiserJumpPractice/Interop/Game/Adapters/GameObjectAdapter.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 extern alias LethalCompany;

--- a/CruiserJumpPractice/Interop/Game/Adapters/HudAdapter.cs
+++ b/CruiserJumpPractice/Interop/Game/Adapters/HudAdapter.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Interop/Game/Adapters/NetworkAdapter.cs
+++ b/CruiserJumpPractice/Interop/Game/Adapters/NetworkAdapter.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Interop/Game/Adapters/PlayerAdapter.cs
+++ b/CruiserJumpPractice/Interop/Game/Adapters/PlayerAdapter.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Interop/Game/Adapters/RpcSurrogateAdapter.cs
+++ b/CruiserJumpPractice/Interop/Game/Adapters/RpcSurrogateAdapter.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Interop/Game/Adapters/ShipMagnetAdapter.cs
+++ b/CruiserJumpPractice/Interop/Game/Adapters/ShipMagnetAdapter.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Interop/Game/Behaviours/RpcSurrogateBehaviour.cs
+++ b/CruiserJumpPractice/Interop/Game/Behaviours/RpcSurrogateBehaviour.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 extern alias LethalCompany;

--- a/CruiserJumpPractice/Interop/Game/GameInterop.cs
+++ b/CruiserJumpPractice/Interop/Game/GameInterop.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/Interop/Game/GameInteropException.cs
+++ b/CruiserJumpPractice/Interop/Game/GameInteropException.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 namespace CruiserJumpPractice.Interop.Game;

--- a/CruiserJumpPractice/Interop/Game/Patches/HUDManagerPatch.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/HUDManagerPatch.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 extern alias LethalCompany;

--- a/CruiserJumpPractice/Interop/Game/Patches/HarmonyPatchInstaller.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/HarmonyPatchInstaller.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using HarmonyLib;

--- a/CruiserJumpPractice/Interop/InputUtils/InputUtilsActions.cs
+++ b/CruiserJumpPractice/Interop/InputUtils/InputUtilsActions.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 extern alias LethalCompany;

--- a/CruiserJumpPractice/Interop/InputUtils/InputUtilsPracticeInput.cs
+++ b/CruiserJumpPractice/Interop/InputUtils/InputUtilsPracticeInput.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Ports;

--- a/CruiserJumpPractice/PluginController.cs
+++ b/CruiserJumpPractice/PluginController.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 #nullable enable
 
 using CruiserJumpPractice.Core.Handlers;

--- a/CruiserJumpPractice/nuget.config
+++ b/CruiserJumpPractice/nuget.config
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- SPDX-License-Identifier: MIT -->
 <configuration>
   <packageSources>
     <clear />

--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,21 @@
-This is free and unencumbered software released into the public domain.
+MIT License
 
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
+Copyright (c) 2026 aoirint
 
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-For more information, please refer to <https://unlicense.org>
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: Unlicense -->
+<!-- SPDX-License-Identifier: MIT -->
 
 # CruiserJumpPractice
 

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: Unlicense -->
+<!-- SPDX-License-Identifier: MIT -->
 
 This changelog is the user-facing release notes for Thunderstore.
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: MIT -->
+
 # CruiserJumpPractice
 
 A Lethal Company mod that saves and loads cruiser position, rotation, and


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

Switches the repository's forward-looking license operation from The Unlicense to the MIT License.

- Replaces the root `LICENSE` text with the MIT License.
- Updates existing `SPDX-License-Identifier: Unlicense` notices to `SPDX-License-Identifier: MIT`.
- Adds MIT SPDX notices to project-local text files where the file format has stable comment syntax.
- Leaves SPDX notices omitted for `LICENSE`, JSON/lock files, the Visual Studio solution, and binary assets where adding comments would be inappropriate or unsupported.

### Transition Context

Supplemental context only: the final pre-transition base commit for this pull request is `52cdf250843385e0127f468c457852459eb1a2d7`. Project material up to that commit remains available under The Unlicense.

## Related Issues

- Closes #98

## Notes for reviewers

The transition-history note is intentionally limited to this pull request body to avoid adding durable repository prose beyond the MIT license and SPDX notice updates.

### AI disclosure

Significant AI assistance was used to prepare the issue decision comment, update license notices, run checks, and draft this pull request body. The resulting repository diff and GitHub text were reviewed during the workflow.

## Testing

### Automated checks

- `dotnet restore --locked-mode`
- `dotnet format --no-restore --verify-no-changes`
- `dotnet build --no-restore --configuration Release`
- `docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5`
- `git diff --check`
- `rg -n "SPDX-License-Identifier: Unlicense|The Unlicense|public domain|repository default is Unlicense" -S -uuu --glob '!.git/**' .`

### AI-assisted inspections

Request: Check tracked files for missing SPDX notices after the MIT update.

AI-assisted result: Remaining tracked files without SPDX notices are `LICENSE`, `CruiserJumpPractice.sln`, `CruiserJumpPractice/Properties/launchSettings.json`, `CruiserJumpPractice/packages.lock.json`, and `assets/manifest.json`; these were intentionally left without added SPDX comments because of file role or format constraints.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.


