### PR TITLE
refactor: clarify internal named argument usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,16 @@ dotnet restore --locked-mode
 - Prefer the existing project structure and naming conventions.
 - Keep user-facing behavior explicit in code, documentation, or changelog
   entries when the behavior changes.
+- Use named arguments when they make project-owned call sites easier to review,
+  especially for multiple primitive values, repeated argument types, boolean
+  flags, or compact validation records where adjacent values can be mistaken for
+  each other.
+- Avoid broad mechanical named-argument churn. Keep obvious single-argument
+  calls positional unless a name removes real ambiguity.
+- Be conservative with named arguments for external APIs, Harmony patches,
+  Unity or BepInEx framework calls, generated APIs, and base-game calls. These
+  call sites often depend on upstream parameter names or ecosystem conventions
+  outside this project's control.
 - Update [CHANGELOG.md](./CHANGELOG.md) for developer-facing changes that should
   appear in release history.
 - Update files under [assets/](./assets/) when the Thunderstore package

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,16 +84,6 @@ dotnet restore --locked-mode
 - Prefer the existing project structure and naming conventions.
 - Keep user-facing behavior explicit in code, documentation, or changelog
   entries when the behavior changes.
-- Use named arguments when they make project-owned call sites easier to review,
-  especially for multiple primitive values, repeated argument types, boolean
-  flags, or compact validation records where adjacent values can be mistaken for
-  each other.
-- Avoid broad mechanical named-argument churn. Keep obvious single-argument
-  calls positional unless a name removes real ambiguity.
-- Be conservative with named arguments for external APIs, Harmony patches,
-  Unity or BepInEx framework calls, generated APIs, and base-game calls. These
-  call sites often depend on upstream parameter names or ecosystem conventions
-  outside this project's control.
 - Update [CHANGELOG.md](./CHANGELOG.md) for developer-facing changes that should
   appear in release history.
 - Update files under [assets/](./assets/) when the Thunderstore package

--- a/CruiserJumpPractice/Core/Handlers/FrameHandler.cs
+++ b/CruiserJumpPractice/Core/Handlers/FrameHandler.cs
@@ -52,7 +52,12 @@ internal sealed class FrameHandler
         var busyState = gameInterop.GetLocalPlayerBusyState();
         if (busyState.IsBusy)
         {
-            RecordSuppressedInput(saveTriggered, loadTriggered, toggleMagnetTriggered, busyState);
+            RecordSuppressedInput(
+                saveTriggered: saveTriggered,
+                loadTriggered: loadTriggered,
+                toggleMagnetTriggered: toggleMagnetTriggered,
+                busyState: busyState
+            );
             return;
         }
 
@@ -84,23 +89,28 @@ internal sealed class FrameHandler
     {
         if (saveTriggered)
         {
-            RecordSuppressedInput(ValidationLogInputAction.Save, busyState);
+            RecordSuppressedInput(action: ValidationLogInputAction.Save, busyState: busyState);
         }
 
         if (loadTriggered)
         {
-            RecordSuppressedInput(ValidationLogInputAction.Load, busyState);
+            RecordSuppressedInput(action: ValidationLogInputAction.Load, busyState: busyState);
         }
 
         if (toggleMagnetTriggered)
         {
-            RecordSuppressedInput(ValidationLogInputAction.ToggleMagnet, busyState);
+            RecordSuppressedInput(
+                action: ValidationLogInputAction.ToggleMagnet,
+                busyState: busyState
+            );
         }
     }
 
     private void RecordTriggeredInput(ValidationLogInputAction action)
     {
-        validationLogger.Record(ValidationLogRecord.InputTriggered(action, GetRole()));
+        validationLogger.Record(
+            ValidationLogRecord.InputTriggered(action: action, role: GetRole())
+        );
     }
 
     private void RecordSuppressedInput(
@@ -109,7 +119,11 @@ internal sealed class FrameHandler
     )
     {
         validationLogger.Record(
-            ValidationLogRecord.InputSuppressed(action, GetRole(), busyState)
+            ValidationLogRecord.InputSuppressed(
+                action: action,
+                role: GetRole(),
+                busyState: busyState
+            )
         );
     }
 

--- a/CruiserJumpPractice/Core/UseCases/Client/MagnetToggleObservation.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/MagnetToggleObservation.cs
@@ -37,9 +37,9 @@ internal sealed class MagnetToggleObservation
         // The vanilla lever/RPC boundary is asynchronous from here; this use
         // case intentionally does not claim to observe the synced result.
         return new MagnetToggleObservation(
-            beforeState,
-            expectedAfterState,
-            MagnetState.Unknown
+            beforeState: beforeState,
+            expectedAfterState: expectedAfterState,
+            observedAfterState: MagnetState.Unknown
         );
     }
 }

--- a/CruiserJumpPractice/Core/UseCases/Client/RequestLoadCruiserStateUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/RequestLoadCruiserStateUseCase.cs
@@ -28,19 +28,25 @@ internal sealed class RequestLoadCruiserStateUseCase
         if (!gameInterop.IsHost())
         {
             gameInterop.DisplayTip(HudTipMessage.LoadHostOnly);
-            RecordResult(ValidationLogRole.Client, RequestLoadCruiserStateResult.HostOnly);
+            RecordResult(
+                role: ValidationLogRole.Client,
+                result: RequestLoadCruiserStateResult.HostOnly
+            );
             return RequestLoadCruiserStateResult.HostOnly;
         }
 
         // Record the local acceptance before crossing into the ServerRpc path; on a host the
         // server callback can run before this method returns.
-        RecordResult(ValidationLogRole.Host, RequestLoadCruiserStateResult.Success);
+        RecordResult(
+            role: ValidationLogRole.Host,
+            result: RequestLoadCruiserStateResult.Success
+        );
         gameInterop.RequestLoadCruiserState();
         return RequestLoadCruiserStateResult.Success;
     }
 
     private void RecordResult(ValidationLogRole role, RequestLoadCruiserStateResult result)
     {
-        validationLogger.Record(ValidationLogRecord.RequestLoadResult(role, result));
+        validationLogger.Record(ValidationLogRecord.RequestLoadResult(role: role, result: result));
     }
 }

--- a/CruiserJumpPractice/Core/UseCases/Client/RequestSaveCruiserStateUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/RequestSaveCruiserStateUseCase.cs
@@ -28,19 +28,25 @@ internal sealed class RequestSaveCruiserStateUseCase
         if (!gameInterop.IsHost())
         {
             gameInterop.DisplayTip(HudTipMessage.SaveHostOnly);
-            RecordResult(ValidationLogRole.Client, RequestSaveCruiserStateResult.HostOnly);
+            RecordResult(
+                role: ValidationLogRole.Client,
+                result: RequestSaveCruiserStateResult.HostOnly
+            );
             return RequestSaveCruiserStateResult.HostOnly;
         }
 
         // Record the local acceptance before crossing into the ServerRpc path; on a host the
         // server callback can run before this method returns.
-        RecordResult(ValidationLogRole.Host, RequestSaveCruiserStateResult.Success);
+        RecordResult(
+            role: ValidationLogRole.Host,
+            result: RequestSaveCruiserStateResult.Success
+        );
         gameInterop.RequestSaveCruiserState();
         return RequestSaveCruiserStateResult.Success;
     }
 
     private void RecordResult(ValidationLogRole role, RequestSaveCruiserStateResult result)
     {
-        validationLogger.Record(ValidationLogRecord.RequestSaveResult(role, result));
+        validationLogger.Record(ValidationLogRecord.RequestSaveResult(role: role, result: result));
     }
 }

--- a/CruiserJumpPractice/Core/UseCases/Client/ToggleMagnetUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Client/ToggleMagnetUseCase.cs
@@ -26,7 +26,7 @@ internal sealed class ToggleMagnetUseCase
         if (!gameInterop.IsHost())
         {
             gameInterop.DisplayTip(HudTipMessage.MagnetHostOnly);
-            RecordResult(ValidationLogRole.Client, ToggleMagnetResult.HostOnly);
+            RecordResult(role: ValidationLogRole.Client, result: ToggleMagnetResult.HostOnly);
             return ToggleMagnetResult.HostOnly;
         }
 
@@ -39,7 +39,12 @@ internal sealed class ToggleMagnetUseCase
         var result = observation.ExpectedAfterState == MagnetState.On
             ? ToggleMagnetResult.MagnetOn
             : ToggleMagnetResult.MagnetOff;
-        validationLogger.Record(ValidationLogRecord.ToggleMagnetResultEvent(ValidationLogRole.Host, result));
+        validationLogger.Record(
+            ValidationLogRecord.ToggleMagnetResultEvent(
+                role: ValidationLogRole.Host,
+                result: result
+            )
+        );
         var message = result == ToggleMagnetResult.MagnetOn
             ? HudTipMessage.MagnetOn
             : HudTipMessage.MagnetOff;
@@ -49,6 +54,8 @@ internal sealed class ToggleMagnetUseCase
 
     private void RecordResult(ValidationLogRole role, ToggleMagnetResult result)
     {
-        validationLogger.Record(ValidationLogRecord.ToggleMagnetResultEvent(role, result));
+        validationLogger.Record(
+            ValidationLogRecord.ToggleMagnetResultEvent(role: role, result: result)
+        );
     }
 }

--- a/CruiserJumpPractice/Core/UseCases/Server/LoadCruiserStateUseCase.cs
+++ b/CruiserJumpPractice/Core/UseCases/Server/LoadCruiserStateUseCase.cs
@@ -39,7 +39,7 @@ internal sealed class LoadCruiserStateUseCase
                 logger.LogInfo("No cruiser found.");
                 validationLogger.Record(
                     ValidationLogRecord.LoadNoCruiserFound(
-                        cruiserStateStore.SavedCruiserState != null
+                        savedState: cruiserStateStore.SavedCruiserState != null
                     )
                 );
                 return LoadCruiserStateResult.NoCruiserFound;

--- a/CruiserJumpPractice/Core/Validation/ValidationLogRecord.cs
+++ b/CruiserJumpPractice/Core/Validation/ValidationLogRecord.cs
@@ -129,7 +129,11 @@ internal sealed class ValidationLogRecord
         RequestSaveCruiserStateResult result
     )
     {
-        return Result("request_save_result", role, ToValidationResultToken(result));
+        return Result(
+            eventName: "request_save_result",
+            role: role,
+            result: ToValidationResultToken(result)
+        );
     }
 
     public static ValidationLogRecord RequestLoadResult(
@@ -137,7 +141,11 @@ internal sealed class ValidationLogRecord
         RequestLoadCruiserStateResult result
     )
     {
-        return Result("request_load_result", role, ToValidationResultToken(result));
+        return Result(
+            eventName: "request_load_result",
+            role: role,
+            result: ToValidationResultToken(result)
+        );
     }
 
     public static ValidationLogRecord ToggleMagnetResultEvent(
@@ -145,7 +153,11 @@ internal sealed class ValidationLogRecord
         ToggleMagnetResult result
     )
     {
-        return Result("toggle_magnet_result", role, ToValidationResultToken(result));
+        return Result(
+            eventName: "toggle_magnet_result",
+            role: role,
+            result: ToValidationResultToken(result)
+        );
     }
 
     public static ValidationLogRecord MagnetToggle(MagnetToggleObservation observation)
@@ -164,7 +176,7 @@ internal sealed class ValidationLogRecord
 
     public static ValidationLogRecord SaveServerRpcReceived(ValidationLogRole role)
     {
-        return Role("save_server_rpc_received", role);
+        return Role(eventName: "save_server_rpc_received", role: role);
     }
 
     public static ValidationLogRecord SaveClientRpcReceived(
@@ -172,12 +184,16 @@ internal sealed class ValidationLogRecord
         SaveCruiserStateResult result
     )
     {
-        return Result("save_client_rpc_received", role, ToValidationResultToken(result));
+        return Result(
+            eventName: "save_client_rpc_received",
+            role: role,
+            result: ToValidationResultToken(result)
+        );
     }
 
     public static ValidationLogRecord LoadServerRpcReceived(ValidationLogRole role)
     {
-        return Role("load_server_rpc_received", role);
+        return Role(eventName: "load_server_rpc_received", role: role);
     }
 
     public static ValidationLogRecord LoadClientRpcReceived(
@@ -185,7 +201,11 @@ internal sealed class ValidationLogRecord
         LoadCruiserStateResult result
     )
     {
-        return Result("load_client_rpc_received", role, ToValidationResultToken(result));
+        return Result(
+            eventName: "load_client_rpc_received",
+            role: role,
+            result: ToValidationResultToken(result)
+        );
     }
 
     public static ValidationLogRecord SaveNoCruiserFound()
@@ -203,7 +223,11 @@ internal sealed class ValidationLogRecord
 
     public static ValidationLogRecord SaveUnexpectedState()
     {
-        return Result("save_result", ValidationLogRole.Host, "unexpected_state");
+        return Result(
+            eventName: "save_result",
+            role: ValidationLogRole.Host,
+            result: "unexpected_state"
+        );
     }
 
     public static ValidationLogRecord SaveSuccess(CruiserSnapshot cruiserState)
@@ -267,7 +291,11 @@ internal sealed class ValidationLogRecord
 
     public static ValidationLogRecord LoadUnexpectedState()
     {
-        return Result("load_result", ValidationLogRole.Host, "unexpected_state");
+        return Result(
+            eventName: "load_result",
+            role: ValidationLogRole.Host,
+            result: "unexpected_state"
+        );
     }
 
     public static ValidationLogRecord RestoreApplied(CruiserRestoreObservation observation)

--- a/CruiserJumpPractice/CruiserJumpPractice.cs
+++ b/CruiserJumpPractice/CruiserJumpPractice.cs
@@ -37,12 +37,15 @@ public class CruiserJumpPractice : BaseUnityPlugin
             : DisabledValidationLogger.Instance;
 
         validationLogger.Record(
-            ValidationLogRecord.PluginLoaded(MyPluginInfo.PLUGIN_VERSION, validationLogging.Value)
+            ValidationLogRecord.PluginLoaded(
+                version: MyPluginInfo.PLUGIN_VERSION,
+                validationLogging: validationLogging.Value
+            )
         );
 
         // Inject the logger through the plugin logging port so Core and game interop can emit
         // diagnostics without depending on BepInEx logging types.
-        controller = PluginController.Create(logger, validationLogger);
+        controller = PluginController.Create(logger: logger, validationLogger: validationLogger);
 
         // Startup order matters: construct the controller before patching so the first game
         // callback can enter a fully wired plugin boundary.

--- a/CruiserJumpPractice/Interop/Game/Adapters/CruiserAdapter.cs
+++ b/CruiserJumpPractice/Interop/Game/Adapters/CruiserAdapter.cs
@@ -159,7 +159,7 @@ internal sealed class CruiserAdapter
 
     private static Vector3Value FromUnityVector3(Vector3 value)
     {
-        return new Vector3Value(value.x, value.y, value.z);
+        return new Vector3Value(x: value.x, y: value.y, z: value.z);
     }
 
     private static Vector3 ToUnityVector3(Vector3Value value)

--- a/CruiserJumpPractice/Interop/Game/Adapters/PlayerAdapter.cs
+++ b/CruiserJumpPractice/Interop/Game/Adapters/PlayerAdapter.cs
@@ -30,9 +30,9 @@ internal sealed class PlayerAdapter
             }
 
             return new LocalPlayerBusyState(
-                quickMenuManager.isMenuOpen,
-                localPlayer.inTerminalMenu,
-                localPlayer.isTypingChat
+                isMenuOpen: quickMenuManager.isMenuOpen,
+                isInTerminal: localPlayer.inTerminalMenu,
+                isTypingChat: localPlayer.isTypingChat
             );
         }
         catch (System.Exception error)

--- a/CruiserJumpPractice/Interop/Game/Adapters/RpcSurrogateAdapter.cs
+++ b/CruiserJumpPractice/Interop/Game/Adapters/RpcSurrogateAdapter.cs
@@ -64,8 +64,8 @@ internal sealed class RpcSurrogateAdapter
         if (cachedRpcSurrogateBehaviour != null)
         {
             RecordResolved(
-                ValidationLogRpcSurrogateResolveSource.Cache,
-                ValidationLogRpcSurrogateResolveResult.Success
+                source: ValidationLogRpcSurrogateResolveSource.Cache,
+                result: ValidationLogRpcSurrogateResolveResult.Success
             );
             return cachedRpcSurrogateBehaviour;
         }
@@ -83,16 +83,16 @@ internal sealed class RpcSurrogateAdapter
 
             cachedRpcSurrogateBehaviour = rpcSurrogateNetworkBehaviour;
             RecordResolved(
-                ValidationLogRpcSurrogateResolveSource.Lookup,
-                ValidationLogRpcSurrogateResolveResult.Success
+                source: ValidationLogRpcSurrogateResolveSource.Lookup,
+                result: ValidationLogRpcSurrogateResolveResult.Success
             );
             return rpcSurrogateNetworkBehaviour;
         }
         catch (System.Exception error)
         {
             RecordResolved(
-                ValidationLogRpcSurrogateResolveSource.Lookup,
-                ValidationLogRpcSurrogateResolveResult.Error
+                source: ValidationLogRpcSurrogateResolveSource.Lookup,
+                result: ValidationLogRpcSurrogateResolveResult.Error
             );
             logger.LogError($"Exception while getting RpcSurrogateBehaviour: {error}");
             throw new GameInteropException($"Exception while getting RpcSurrogateBehaviour: {error}");
@@ -104,6 +104,8 @@ internal sealed class RpcSurrogateAdapter
         ValidationLogRpcSurrogateResolveResult result
     )
     {
-        validationLogger.Record(ValidationLogRecord.RpcSurrogateResolved(source, result));
+        validationLogger.Record(
+            ValidationLogRecord.RpcSurrogateResolved(source: source, result: result)
+        );
     }
 }

--- a/CruiserJumpPractice/Interop/Game/GameInterop.cs
+++ b/CruiserJumpPractice/Interop/Game/GameInterop.cs
@@ -26,7 +26,7 @@ internal sealed class GameInterop : IGameInterop
     public GameInterop(IPluginLogger logger, IValidationLogger validationLogger)
     {
         this.validationLogger = validationLogger;
-        var gameObjects = new GameObjectAdapter(logger: logger);
+        var gameObjects = new GameObjectAdapter(logger);
 
         networkInterop = new NetworkAdapter(logger: logger, gameObjects: gameObjects);
         playerInterop = new PlayerAdapter(logger: logger, gameObjects: gameObjects);
@@ -86,7 +86,7 @@ internal sealed class GameInterop : IGameInterop
             return null;
         }
 
-        return cruiserInterop.CaptureCruiser(cruiser: cruiser);
+        return cruiserInterop.CaptureCruiser(cruiser);
     }
 
     public CruiserRestoreObservation RestoreCruiser(CruiserSnapshot snapshot)
@@ -108,7 +108,7 @@ internal sealed class GameInterop : IGameInterop
             throw new GameInteropException("No cruiser found.");
         }
 
-        return cruiserInterop.IsCruiserMagnetedToShip(cruiser: cruiser);
+        return cruiserInterop.IsCruiserMagnetedToShip(cruiser);
     }
 
     public bool IsShipMagnetOn()

--- a/CruiserJumpPractice/Interop/Game/GameInterop.cs
+++ b/CruiserJumpPractice/Interop/Game/GameInterop.cs
@@ -26,14 +26,18 @@ internal sealed class GameInterop : IGameInterop
     public GameInterop(IPluginLogger logger, IValidationLogger validationLogger)
     {
         this.validationLogger = validationLogger;
-        var gameObjects = new GameObjectAdapter(logger);
+        var gameObjects = new GameObjectAdapter(logger: logger);
 
-        networkInterop = new NetworkAdapter(logger, gameObjects);
-        playerInterop = new PlayerAdapter(logger, gameObjects);
-        hudInterop = new HudAdapter(logger, gameObjects);
-        rpcSurrogateInterop = new RpcSurrogateAdapter(logger, gameObjects, validationLogger);
-        cruiserInterop = new CruiserAdapter(logger, gameObjects);
-        shipMagnetInterop = new ShipMagnetAdapter(logger, gameObjects);
+        networkInterop = new NetworkAdapter(logger: logger, gameObjects: gameObjects);
+        playerInterop = new PlayerAdapter(logger: logger, gameObjects: gameObjects);
+        hudInterop = new HudAdapter(logger: logger, gameObjects: gameObjects);
+        rpcSurrogateInterop = new RpcSurrogateAdapter(
+            logger: logger,
+            gameObjects: gameObjects,
+            validationLogger: validationLogger
+        );
+        cruiserInterop = new CruiserAdapter(logger: logger, gameObjects: gameObjects);
+        shipMagnetInterop = new ShipMagnetAdapter(logger: logger, gameObjects: gameObjects);
     }
 
     public bool IsHost()
@@ -50,8 +54,8 @@ internal sealed class GameInterop : IGameInterop
     {
         // Message selection stays in Core; Interop records the closed token
         // before unwrapping user-visible text at the final HUD boundary.
-        validationLogger.Record(ValidationLogRecord.HudTip(GetRole(), message));
-        hudInterop.DisplayTip(message.HeaderText, message.BodyText);
+        validationLogger.Record(ValidationLogRecord.HudTip(role: GetRole(), message: message));
+        hudInterop.DisplayTip(headerText: message.HeaderText, bodyText: message.BodyText);
     }
 
     public RpcSurrogateSpawnResult SpawnRpcSurrogate()
@@ -82,7 +86,7 @@ internal sealed class GameInterop : IGameInterop
             return null;
         }
 
-        return cruiserInterop.CaptureCruiser(cruiser);
+        return cruiserInterop.CaptureCruiser(cruiser: cruiser);
     }
 
     public CruiserRestoreObservation RestoreCruiser(CruiserSnapshot snapshot)
@@ -93,7 +97,7 @@ internal sealed class GameInterop : IGameInterop
             throw new GameInteropException("No cruiser found.");
         }
 
-        return cruiserInterop.RestoreCruiser(cruiser, snapshot);
+        return cruiserInterop.RestoreCruiser(cruiser: cruiser, snapshot: snapshot);
     }
 
     public bool IsCruiserMagnetedToShip()
@@ -104,7 +108,7 @@ internal sealed class GameInterop : IGameInterop
             throw new GameInteropException("No cruiser found.");
         }
 
-        return cruiserInterop.IsCruiserMagnetedToShip(cruiser);
+        return cruiserInterop.IsCruiserMagnetedToShip(cruiser: cruiser);
     }
 
     public bool IsShipMagnetOn()

--- a/CruiserJumpPractice/PluginController.cs
+++ b/CruiserJumpPractice/PluginController.cs
@@ -58,7 +58,7 @@ internal sealed class PluginController
         // dependency should usually mean adding another adapter here, not
         // another static property on CruiserJumpPractice.
         var inputActions = new InputUtilsActions();
-        var practiceInput = new InputUtilsPracticeInput(inputActions: inputActions);
+        var practiceInput = new InputUtilsPracticeInput(inputActions);
         IGameInterop gameInterop = new GameInterop(
             logger: logger,
             validationLogger: validationLogger

--- a/CruiserJumpPractice/PluginController.cs
+++ b/CruiserJumpPractice/PluginController.cs
@@ -58,50 +58,56 @@ internal sealed class PluginController
         // dependency should usually mean adding another adapter here, not
         // another static property on CruiserJumpPractice.
         var inputActions = new InputUtilsActions();
-        var practiceInput = new InputUtilsPracticeInput(inputActions);
-        IGameInterop gameInterop = new GameInterop(logger, validationLogger);
+        var practiceInput = new InputUtilsPracticeInput(inputActions: inputActions);
+        IGameInterop gameInterop = new GameInterop(
+            logger: logger,
+            validationLogger: validationLogger
+        );
 
         var cruiserStateStore = new CruiserStateStore();
         var baseGameAppliedStateValidationStore = new BaseGameAppliedStateValidationStore();
         validationLogger.Record(ValidationLogRecord.StateStoreCreated());
         var saveCruiserStateUseCase = new SaveCruiserStateUseCase(
-            gameInterop,
-            cruiserStateStore,
-            logger,
-            validationLogger
+            gameInterop: gameInterop,
+            cruiserStateStore: cruiserStateStore,
+            logger: logger,
+            validationLogger: validationLogger
         );
         var loadCruiserStateUseCase = new LoadCruiserStateUseCase(
-            gameInterop,
-            cruiserStateStore,
-            logger,
-            validationLogger
+            gameInterop: gameInterop,
+            cruiserStateStore: cruiserStateStore,
+            logger: logger,
+            validationLogger: validationLogger
         );
 
         var requestSaveCruiserStateUseCase = new RequestSaveCruiserStateUseCase(
-            gameInterop,
-            validationLogger
+            gameInterop: gameInterop,
+            validationLogger: validationLogger
         );
         var requestLoadCruiserStateUseCase = new RequestLoadCruiserStateUseCase(
-            gameInterop,
-            validationLogger
+            gameInterop: gameInterop,
+            validationLogger: validationLogger
         );
-        var toggleMagnetUseCase = new ToggleMagnetUseCase(gameInterop, validationLogger);
+        var toggleMagnetUseCase = new ToggleMagnetUseCase(
+            gameInterop: gameInterop,
+            validationLogger: validationLogger
+        );
         var presentSaveCruiserStateResultUseCase = new PresentSaveCruiserStateResultUseCase(
-            gameInterop,
-            logger
+            gameInterop: gameInterop,
+            logger: logger
         );
         var presentLoadCruiserStateResultUseCase = new PresentLoadCruiserStateResultUseCase(
-            gameInterop,
-            logger
+            gameInterop: gameInterop,
+            logger: logger
         );
 
         var frameHandler = new FrameHandler(
-            gameInterop,
-            practiceInput,
-            validationLogger,
-            requestSaveCruiserStateUseCase,
-            requestLoadCruiserStateUseCase,
-            toggleMagnetUseCase
+            gameInterop: gameInterop,
+            practiceInput: practiceInput,
+            validationLogger: validationLogger,
+            requestSaveCruiserStateUseCase: requestSaveCruiserStateUseCase,
+            requestLoadCruiserStateUseCase: requestLoadCruiserStateUseCase,
+            toggleMagnetUseCase: toggleMagnetUseCase
         );
 
         validationLogger.Record(ValidationLogRecord.ControllerCreated());
@@ -109,7 +115,10 @@ internal sealed class PluginController
             gameInterop: gameInterop,
             validationLogger: validationLogger,
             frameHandler: frameHandler,
-            startupHandler: new StartupHandler(gameInterop, validationLogger),
+            startupHandler: new StartupHandler(
+                gameInterop: gameInterop,
+                validationLogger: validationLogger
+            ),
             baseGameAppliedStateValidationHandler: new BaseGameAppliedStateValidationHandler(
                 gameInterop: gameInterop,
                 validationLogger: validationLogger,
@@ -160,7 +169,7 @@ internal sealed class PluginController
     public void RecordSaveClientRpcReceived(SaveCruiserStateResult result)
     {
         validationLogger.Record(
-            ValidationLogRecord.SaveClientRpcReceived(GetRole(), result)
+            ValidationLogRecord.SaveClientRpcReceived(role: GetRole(), result: result)
         );
     }
 


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Applies named arguments to compatibility-safe project-owned call sites where adjacent booleans, repeated primitive values, dependency wiring, or validation result pairs were harder to scan.
- Leaves external, Harmony, Unity, BepInEx, generated, and base-game API calls positional unless existing code already had a strong local reason to name them.
- Keeps broad contributor guidance out of `CONTRIBUTING.md`; this PR is limited to the code cleanup.

## Related Issues

- Closes #104
- Follows up #103

## Notes for reviewers

- Review focus: whether the selected call sites improve readability without creating noisy style churn.
- The cleanup intentionally avoids adding a repository-wide convention document in this PR.

### AI disclosure

This PR was implemented by Codex from the issue request. AI assistance was used to inspect call-site patterns, apply the named-argument cleanup, and run AI-assisted review passes. The resulting diff was reviewed and adjusted to remove obvious single-argument noise and to drop the proposed `CONTRIBUTING.md` guidance before submission.

## Testing

### Automated checks

- `docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5` - passed
- `dotnet format --verify-no-changes` - passed
- `$env:DOTNET_CLI_UI_LANGUAGE='en'; dotnet build` - passed
- `git diff --check origin/main..HEAD` - passed

### AI-assisted inspections

Request: Inventory project-owned named-argument opportunities while avoiding external/Harmony/Unity/BepInEx/base-game APIs.

AI-assisted result: Identified ambiguous internal call sites involving bool expressions, repeated primitive values, dependency wiring, and validation source/result pairs. The recommendations were applied selectively; simple single-argument calls, broad documentation guidance, and external/framework surfaces were deferred.

### Manual checks

- Not run - no in-game behavior changes are intended.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
