### PR TITLE
fix: prepare alpha.6 with conservative prerelease metadata

### DIFF
--- a/.github/actions/generate-version/action.yml
+++ b/.github/actions/generate-version/action.yml
@@ -92,8 +92,8 @@ runs:
           MANIFEST_VERSION="${{ steps.app-version.outputs.version }}"
         else
           # Thunderstore-style package metadata does not carry prerelease or
-          # edge identity. Keep release identity in the artifact name, Git tag,
-          # and assembly metadata instead.
+          # edge identity. Keep release identity in the project version,
+          # artifact name, and Git tag instead.
           MANIFEST_VERSION="0.0.0"
         fi
 

--- a/.github/actions/generate-version/action.yml
+++ b/.github/actions/generate-version/action.yml
@@ -19,6 +19,9 @@ outputs:
   git_version:
     description: 'Git tag version'
     value: ${{ steps.git-version.outputs.version }}
+  manifest_version:
+    description: 'Thunderstore manifest version_number'
+    value: ${{ steps.manifest-version.outputs.version }}
 
 runs:
   using: "composite"
@@ -79,6 +82,23 @@ runs:
         APP_VERSION="${{ steps.app-version.outputs.version }}"
         echo "version=v${APP_VERSION}" >> "${GITHUB_OUTPUT}"
 
+    - name: Generate manifest version
+      id: manifest-version
+      shell: bash
+      run: |
+        RELEASE_MODE="${{ steps.release-mode.outputs.mode }}"
+
+        if [ "${RELEASE_MODE}" = "latest" ]; then
+          MANIFEST_VERSION="${{ steps.app-version.outputs.version }}"
+        else
+          # Thunderstore-style package metadata does not carry prerelease or
+          # edge identity. Keep release identity in the artifact name, Git tag,
+          # and assembly metadata instead.
+          MANIFEST_VERSION="0.0.0"
+        fi
+
+        echo "version=${MANIFEST_VERSION}" >> "${GITHUB_OUTPUT}"
+
     - name: Replace version in csproj
       shell: bash
       run: |
@@ -90,8 +110,9 @@ runs:
     - name: Replace version in manifest.json
       shell: bash
       run: |
-        # Thunderstore reads version_number from the manifest inside the zip,
-        # so keep it synchronized with the build-time package version.
-        APP_VERSION="${{ steps.app-version.outputs.version }}"
-        jq --arg ver "${APP_VERSION}" '.version_number = $ver' assets/manifest.json > assets/manifest.tmp.json
+        # Thunderstore reads version_number from the manifest inside the zip.
+        # Stable releases use the app version; prerelease and edge artifacts keep
+        # a conservative placeholder because they are GitHub-only artifacts.
+        MANIFEST_VERSION="${{ steps.manifest-version.outputs.version }}"
+        jq --arg ver "${MANIFEST_VERSION}" '.version_number = $ver' assets/manifest.json > assets/manifest.tmp.json
         mv assets/manifest.tmp.json assets/manifest.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
       release_mode: ${{ steps.generate-version.outputs.release_mode }}
       app_version: ${{ steps.generate-version.outputs.app_version }}
       git_version: ${{ steps.generate-version.outputs.git_version }}
+      manifest_version: ${{ steps.generate-version.outputs.manifest_version }}
 
     steps:
       # Checkout is required before generating versions because the local
@@ -122,6 +123,7 @@ jobs:
             echo "| Release Mode | ${{ steps.generate-version.outputs.release_mode }} |"
             echo "| App Version | ${{ steps.generate-version.outputs.app_version }} |"
             echo "| Git Version | ${GIT_VERSION_MARKDOWN} |"
+            echo "| Manifest Version | ${{ steps.generate-version.outputs.manifest_version }} |"
             echo "| Time Duration | ${TIME_DURATION_S}s |"
             echo "| Artifact | ${ARTIFACT_LINK_MARKDOWN} |"
             echo "| Artifact Digest | ${ARTIFACT_DIGEST_MARKDOWN} |"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
       prerelease suffix.
     - The BepInEx plugin metadata version is now pinned to `0.0.0`, which keeps
       the metadata compatible with BepInEx 5's `System.Version` validation.
-    - The assembly/package version remains the release identity, so
-      validation logs and startup logs still report the concrete artifact
-      version such as `0.2.0-alpha.6`.
     - GitHub-only prerelease and edge artifacts now keep the packaged
       `manifest.json` `version_number` at `0.0.0`, matching the conservative
-      metadata approach while the artifact name, Git tag, and assembly metadata
-      carry the release identity.
+      metadata approach while the artifact name and Git tag carry the release
+      identity.
 
 ## v0.2.0-alpha.5 - 2026-05-06 UTC
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - The assembly/package version remains the release identity, so
       validation logs and startup logs still report the concrete artifact
       version such as `0.2.0-alpha.6`.
+    - GitHub-only prerelease and edge artifacts now keep the packaged
+      `manifest.json` `version_number` at `0.0.0`, matching the conservative
+      metadata approach while the artifact name, Git tag, and assembly metadata
+      carry the release identity.
 
 ## v0.2.0-alpha.5 - 2026-05-06 UTC
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+## v0.2.0-alpha.6 - 2026-05-06 UTC
+
+### Fixed
+
+- Fixed prerelease artifacts being rejected by BepInEx 5 before plugin startup:
+    - `v0.2.0-alpha.5` validation was blocked because BepInEx skipped the
+      plugin type when the loader-facing version contained the SemVer
+      prerelease suffix.
+    - The BepInEx plugin metadata version is now pinned to `0.0.0`, which keeps
+      the metadata compatible with BepInEx 5's `System.Version` validation.
+    - The assembly/package version remains the release identity, so
+      validation logs and startup logs still report the concrete artifact
+      version such as `0.2.0-alpha.6`.
+
 ## v0.2.0-alpha.5 - 2026-05-06 UTC
 
 ### Changed

--- a/CruiserJumpPractice/CruiserJumpPractice.cs
+++ b/CruiserJumpPractice/CruiserJumpPractice.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #nullable enable
 
+using System.Reflection;
 using BepInEx;
 using CruiserJumpPractice.Core.Ports;
 using CruiserJumpPractice.Core.Validation;
@@ -17,6 +18,11 @@ namespace CruiserJumpPractice;
 public class CruiserJumpPractice : BaseUnityPlugin
 {
     private static PluginController? controller;
+    private static readonly string ReleaseVersion =
+        typeof(CruiserJumpPractice).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion
+        ?? MyPluginInfo.PLUGIN_VERSION;
 
     // Harmony and Netcode construct their callback objects outside our
     // construction path. This static entry exposes one plugin-level controller
@@ -38,7 +44,7 @@ public class CruiserJumpPractice : BaseUnityPlugin
 
         validationLogger.Record(
             ValidationLogRecord.PluginLoaded(
-                version: MyPluginInfo.PLUGIN_VERSION,
+                version: ReleaseVersion,
                 validationLogging: validationLogging.Value
             )
         );
@@ -51,6 +57,8 @@ public class CruiserJumpPractice : BaseUnityPlugin
         // callback can enter a fully wired plugin boundary.
         HarmonyPatchInstaller.Install();
 
-        logger.LogInfo($"Plugin {MyPluginInfo.PLUGIN_NAME} v{MyPluginInfo.PLUGIN_VERSION} is loaded!");
+        logger.LogInfo(
+            $"Plugin {MyPluginInfo.PLUGIN_NAME} v{ReleaseVersion} is loaded with BepInEx metadata version {MyPluginInfo.PLUGIN_VERSION}!"
+        );
     }
 }

--- a/CruiserJumpPractice/CruiserJumpPractice.cs
+++ b/CruiserJumpPractice/CruiserJumpPractice.cs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 #nullable enable
 
-using System.Reflection;
 using BepInEx;
 using CruiserJumpPractice.Core.Ports;
 using CruiserJumpPractice.Core.Validation;
@@ -18,11 +17,6 @@ namespace CruiserJumpPractice;
 public class CruiserJumpPractice : BaseUnityPlugin
 {
     private static PluginController? controller;
-    private static readonly string ReleaseVersion =
-        typeof(CruiserJumpPractice).Assembly
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-            ?.InformationalVersion
-        ?? MyPluginInfo.PLUGIN_VERSION;
 
     // Harmony and Netcode construct their callback objects outside our
     // construction path. This static entry exposes one plugin-level controller
@@ -44,7 +38,7 @@ public class CruiserJumpPractice : BaseUnityPlugin
 
         validationLogger.Record(
             ValidationLogRecord.PluginLoaded(
-                version: ReleaseVersion,
+                version: MyPluginInfo.PLUGIN_VERSION,
                 validationLogging: validationLogging.Value
             )
         );
@@ -57,8 +51,6 @@ public class CruiserJumpPractice : BaseUnityPlugin
         // callback can enter a fully wired plugin boundary.
         HarmonyPatchInstaller.Install();
 
-        logger.LogInfo(
-            $"Plugin {MyPluginInfo.PLUGIN_NAME} v{ReleaseVersion} is loaded with BepInEx metadata version {MyPluginInfo.PLUGIN_VERSION}!"
-        );
+        logger.LogInfo($"Plugin {MyPluginInfo.PLUGIN_NAME} v{MyPluginInfo.PLUGIN_VERSION} is loaded!");
     }
 }

--- a/CruiserJumpPractice/CruiserJumpPractice.csproj
+++ b/CruiserJumpPractice/CruiserJumpPractice.csproj
@@ -11,10 +11,9 @@
     <Version>0.2.0-alpha.6</Version>
     <!-- BepInEx 5 validates plugin metadata as System.Version, which rejects
          SemVer prerelease strings such as 0.2.0-alpha.6. Keep the loader-facing
-         metadata conservative while the assembly/package version carries the
-         release identity. -->
+         metadata conservative while release automation carries the prerelease
+         identity. -->
     <BepInExPluginVersion>0.0.0</BepInExPluginVersion>
-    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <!-- Target framework. https://learn.microsoft.com/en-us/dotnet/standard/frameworks -->
     <TargetFramework>netstandard2.1</TargetFramework>
     <!-- C# language version.

--- a/CruiserJumpPractice/CruiserJumpPractice.csproj
+++ b/CruiserJumpPractice/CruiserJumpPractice.csproj
@@ -8,7 +8,13 @@
     <Product>CruiserJumpPractice</Product>
     <RootNamespace>CruiserJumpPractice</RootNamespace>
     <!-- !!APP_VERSION_MARKER!! -->
-    <Version>0.2.0-alpha.5</Version>
+    <Version>0.2.0-alpha.6</Version>
+    <!-- BepInEx 5 validates plugin metadata as System.Version, which rejects
+         SemVer prerelease strings such as 0.2.0-alpha.6. Keep the loader-facing
+         metadata conservative while the assembly/package version carries the
+         release identity. -->
+    <BepInExPluginVersion>0.0.0</BepInExPluginVersion>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <!-- Target framework. https://learn.microsoft.com/en-us/dotnet/standard/frameworks -->
     <TargetFramework>netstandard2.1</TargetFramework>
     <!-- C# language version.


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Prepare `v0.2.0-alpha.6` after alpha.5 startup validation was blocked by BepInEx version parsing.
- Pin the BepInEx loader-facing plugin metadata version to `0.0.0`, avoiding BepInEx 5's `System.Version` rejection of SemVer prerelease suffixes.
- Keep GitHub-only prerelease and edge package `manifest.json` `version_number` values at `0.0.0`; stable releases still write the real app version.
- Keep the prerelease identity in the project version, artifact name, Git tag, and CI summary outputs instead of duplicating separate runtime version handling.
- Record the alpha.6 fix in the canonical developer changelog.

## Related Issues

- Refs #110

## Notes for reviewers

Please focus on the metadata split:

- `CruiserJumpPractice.csproj` keeps `<Version>0.2.0-alpha.6</Version>` for release automation.
- `BepInExPluginVersion` is intentionally loader-facing and should remain `0.0.0` for prerelease compatibility.
- `manifest.json` `version_number` is intentionally conservative for prerelease/edge artifacts because those artifacts are GitHub-only.
- Startup and validation logs continue to use the generated BepInEx metadata version; this PR intentionally does not add reflection-based runtime version lookup.

### AI disclosure

Codex helped inspect the alpha.5 validation feedback, implement the metadata split, adjust CI manifest-version generation, simplify the C# runtime version handling, and prepare this PR text. The resulting diff and verification outputs were reviewed during this workflow.

## Testing

### Automated checks

- `dotnet build --configuration Release` - passed with 0 warnings and 0 errors.
- `dotnet format --no-restore --verify-no-changes` - passed.
- `git diff --check` - passed; Git only reported repository line-ending warnings.

### AI-assisted inspections

Request: Review the PR title and body against the current diff.

AI-assisted result:

- Updated the title to cover both BepInEx metadata and packaged manifest metadata.
- Updated the body so it no longer implies runtime logs carry the prerelease identity.
- Confirmed the described behavior matches the current diff: project version and release automation carry `0.2.0-alpha.6`; loader-facing and prerelease package metadata use `0.0.0`.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.