### PR TITLE
chore(release): prepare v0.2.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - [Issue #18][issue-18-ai-generated-category] records the project decision
       to use this category because:
         - The project has used and expects to keep using AI tools to assist
-          development and maintenance while reducing workload.
+          with development and maintenance, and to reduce workload.
         - The applicable disclosure threshold is not clear.
     - Human maintainer review remains the project policy.
 - Aligned Thunderstore manifest dependency strings with the documented v81.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,19 +34,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Notes
 
 - Release validation:
-    - `v0.2.0-alpha.6` passed the #112 validation cycle after the blocked
-      `v0.2.0-alpha.5` startup pass.
+    - `v0.2.0-alpha.6` passed the [#112][issue-112] validation cycle after
+      the blocked `v0.2.0-alpha.5` startup pass.
     - Accepted residual risk: HP/turbo restore records were present, but cases
       where values remained default-like and unchanged do not fully prove
       HP/turbo restore by observable before/after change.
     - Accepted residual risk: the guest-driver load snapback observation is
-      tracked separately in #113 and is not treated as a `v0.2.0` blocker.
+      tracked separately in [#113][issue-113] and is not treated as a
+      `v0.2.0` blocker.
 - Compatibility:
     - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
       `6423525044216269478`).
         - The validation environment used Imperium v1.3.0 for setup support.
         - Imperium v1.3.0 appears to have some cruiser-related issues; see the
-          linked Imperium issue comment in `assets/CHANGELOG.md` for the
+          [Imperium issue comment][imperium-cruiser-workaround] for the
           maintainer-noted workaround reference.
 
 ## v0.2.0-alpha.6 - 2026-05-06 UTC
@@ -355,4 +356,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
         - Backfilled as reference compatibility information while preparing
           the v0.2.0-alpha.1 release.
 
+[imperium-cruiser-workaround]: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735
 [issue-18-ai-generated-category]: https://github.com/aoirint/CruiserJumpPractice/issues/18
+[issue-112]: https://github.com/aoirint/CruiserJumpPractice/issues/112
+[issue-113]: https://github.com/aoirint/CruiserJumpPractice/issues/113

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - [Issue #18][issue-18-ai-generated-category] records the project decision
       to use this category because:
         - The project has used and expects to keep using AI tools to assist
-          development and reduce development burden.
+          development and maintenance while reducing workload.
         - The applicable disclosure threshold is not clear.
     - Human maintainer review remains the project policy.
 - Aligned Thunderstore manifest dependency strings with the documented v81.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,66 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+## v0.2.0 - 2026-05-06 UTC
+
+### Added
+
+- Added automated stable-release publishing to Thunderstore from GitHub Actions:
+    - Stable releases now publish the packaged release artifact to the
+      Lethal Company Thunderstore community after the GitHub release is
+      created.
+    - Prerelease and edge artifacts remain GitHub-only validation artifacts.
+- Added opt-in structured validation logging for release validation and
+  troubleshooting:
+    - `Debug.ValidationLogging` is disabled by default.
+    - When enabled, sparse `[CJP_VALIDATION]` JSONL-style records describe
+      startup, HUD/RPC surrogate lifecycle, input triggers and suppression,
+      host-only denials, save/load/restore results, magnet toggles, HUD tips,
+      and base-game applied-state observations.
+
+### Changed
+
+- Rebuilt the mod for the Lethal Company v81.5 dependency baseline.
+- Refactored internal architecture around Core use cases, ports, and adapters:
+    - The refactor keeps game-specific interop at the repository boundary while
+      preserving save/load, magnet toggle, HUD, and input behavior.
+    - Patch classes now act as timing notifiers for base-game state observation
+      instead of forwarding game state directly.
+- Dropped backward compatibility with CruiserJumpPractice v0.1.4 and earlier:
+    - A mod-internal `NetworkBehaviour` name changed during the refactor.
+    - Multiplayer clients should use the current release line together when
+      installing CruiserJumpPractice on more than the host.
+
+### Fixed
+
+- Fixed ship-magnet HUD/state observation gaps by adding validation evidence
+  around local and receiver-side magnet apply paths.
+- Fixed prerelease validation being blocked by BepInEx 5 plugin-version parsing
+  before startup:
+    - The validated `v0.2.0-alpha.6` retry proved that prerelease builds can
+      keep loader-facing/package metadata conservative while the GitHub release
+      tag, artifact name, and digest carry prerelease identity.
+    - The stable `v0.2.0` release restores real stable package and loader-facing
+      metadata because `0.2.0` is compatible with BepInEx 5 version parsing.
+
+### Notes
+
+- Release validation:
+    - `v0.2.0-alpha.6` passed the #112 validation cycle after the blocked
+      `v0.2.0-alpha.5` startup pass.
+    - Accepted residual risk: HP/turbo restore records were present, but cases
+      where values remained default-like and unchanged do not fully prove
+      HP/turbo restore by observable before/after change.
+    - Accepted residual risk: the guest-driver load snapback observation is
+      tracked separately in #113 and is not treated as a `v0.2.0` blocker.
+- Compatibility:
+    - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
+      `6423525044216269478`).
+        - The validation environment used Imperium v1.3.0 for setup support.
+        - Imperium v1.3.0 appears to have some cruiser-related issues; see the
+          linked Imperium issue comment in `assets/CHANGELOG.md` for the
+          maintainer-noted workaround reference.
+
 ## v0.2.0-alpha.6 - 2026-05-06 UTC
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,9 +130,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - This project uses the category to disclose AI assistance in project work;
       it is package metadata rather than a gameplay feature.
     - [Issue #18][issue-18-ai-generated-category] records the project decision
-      to use this category because the project has used and expects to keep
-      using AI tools to reduce development burden, and because the applicable
-      disclosure threshold is not clear.
+      to use this category because:
+        - The project has used and expects to keep using AI tools to reduce
+          development burden.
+        - The applicable disclosure threshold is not clear.
     - Human maintainer review remains the project policy.
 - Aligned Thunderstore manifest dependency strings with the documented v81.5
   test environment for BepInExPack and LethalCompany_InputUtils:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,8 +130,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - This project uses the category to disclose AI assistance in project work;
       it is package metadata rather than a gameplay feature.
     - [Issue #18][issue-18-ai-generated-category] records the project decision
-      to use this category because the applicable disclosure threshold is not
-      clear.
+      to use this category because the project has used and expects to keep
+      using AI tools to reduce development burden, and because the applicable
+      disclosure threshold is not clear.
     - Human maintainer review remains the project policy.
 - Aligned Thunderstore manifest dependency strings with the documented v81.5
   test environment for BepInExPack and LethalCompany_InputUtils:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,45 +14,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## v0.2.0 - 2026-05-06 UTC
 
-### Added
-
-- Added automated stable-release publishing to Thunderstore from GitHub Actions:
-    - Stable releases now publish the packaged release artifact to the
-      Lethal Company Thunderstore community after the GitHub release is
-      created.
-    - Prerelease and edge artifacts remain GitHub-only validation artifacts.
-- Added opt-in structured validation logging for release validation and
-  troubleshooting:
-    - `Debug.ValidationLogging` is disabled by default.
-    - When enabled, sparse `[CJP_VALIDATION]` JSONL-style records describe
-      startup, HUD/RPC surrogate lifecycle, input triggers and suppression,
-      host-only denials, save/load/restore results, magnet toggles, HUD tips,
-      and base-game applied-state observations.
-
 ### Changed
 
-- Rebuilt the mod for the Lethal Company v81.5 dependency baseline.
-- Refactored internal architecture around Core use cases, ports, and adapters:
-    - The refactor keeps game-specific interop at the repository boundary while
-      preserving save/load, magnet toggle, HUD, and input behavior.
-    - Patch classes now act as timing notifiers for base-game state observation
-      instead of forwarding game state directly.
-- Dropped backward compatibility with CruiserJumpPractice v0.1.4 and earlier:
-    - A mod-internal `NetworkBehaviour` name changed during the refactor.
-    - Multiplayer clients should use the current release line together when
-      installing CruiserJumpPractice on more than the host.
-
-### Fixed
-
-- Fixed ship-magnet HUD/state observation gaps by adding validation evidence
-  around local and receiver-side magnet apply paths.
-- Fixed prerelease validation being blocked by BepInEx 5 plugin-version parsing
-  before startup:
-    - The validated `v0.2.0-alpha.6` retry proved that prerelease builds can
-      keep loader-facing/package metadata conservative while the GitHub release
-      tag, artifact name, and digest carry prerelease identity.
-    - The stable `v0.2.0` release restores real stable package and loader-facing
-      metadata because `0.2.0` is compatible with BepInEx 5 version parsing.
+- Promoted the validated `v0.2.0-alpha.6` release candidate to stable
+  `v0.2.0`.
+- Set the project version to stable `0.2.0`:
+    - `BepInEx.PluginInfoProps` now derives the BepInEx plugin metadata version
+      from the project version again.
+    - Source `assets/manifest.json` remains at the repository placeholder
+      `0.0.0`; the release workflow writes the generated stable
+      Thunderstore manifest version into the packaged artifact.
+- Published stable user-facing release notes in `assets/CHANGELOG.md`:
+    - The stable notes roll up the user-facing outcome from the prerelease
+      cycle.
+    - Detailed developer-facing prerelease implementation history remains in
+      the `v0.2.0-alpha.*` sections below instead of being copied wholesale
+      into this stable entry.
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,7 +130,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
         - <https://thunderstore.io/c/lethal-company/?included_categories=2086&ordering=last-updated&q=&section=mods>
     - This project uses the category to disclose AI assistance in project work;
       it is package metadata rather than a gameplay feature.
-    - [Issue #18][issue-18-ai-generated-category] records the project decision
+    - [Issue #18][issue-18] records the project decision
       to use this category because:
         - The project has used and expects to keep using AI tools to assist
           with development and maintenance, and to reduce workload.
@@ -357,6 +357,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
           the v0.2.0-alpha.1 release.
 
 [imperium-cruiser-workaround]: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735
-[issue-18-ai-generated-category]: https://github.com/aoirint/CruiserJumpPractice/issues/18
+[issue-18]: https://github.com/aoirint/CruiserJumpPractice/issues/18
 [issue-112]: https://github.com/aoirint/CruiserJumpPractice/issues/112
 [issue-113]: https://github.com/aoirint/CruiserJumpPractice/issues/113

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,8 +131,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
       it is package metadata rather than a gameplay feature.
     - [Issue #18][issue-18-ai-generated-category] records the project decision
       to use this category because:
-        - The project has used and expects to keep using AI tools to reduce
-          development burden.
+        - The project has used and expects to keep using AI tools to assist
+          development and reduce development burden.
         - The applicable disclosure threshold is not clear.
     - Human maintainer review remains the project policy.
 - Aligned Thunderstore manifest dependency strings with the documented v81.5

--- a/CruiserJumpPractice/CruiserJumpPractice.csproj
+++ b/CruiserJumpPractice/CruiserJumpPractice.csproj
@@ -9,10 +9,6 @@
     <RootNamespace>CruiserJumpPractice</RootNamespace>
     <!-- !!APP_VERSION_MARKER!! -->
     <Version>0.2.0</Version>
-    <!-- BepInEx 5 validates plugin metadata as System.Version. Stable release
-         versions can use the project version directly; prerelease branches keep
-         this metadata conservative. -->
-    <BepInExPluginVersion>0.2.0</BepInExPluginVersion>
     <!-- Target framework. https://learn.microsoft.com/en-us/dotnet/standard/frameworks -->
     <TargetFramework>netstandard2.1</TargetFramework>
     <!-- C# language version.

--- a/CruiserJumpPractice/CruiserJumpPractice.csproj
+++ b/CruiserJumpPractice/CruiserJumpPractice.csproj
@@ -8,12 +8,11 @@
     <Product>CruiserJumpPractice</Product>
     <RootNamespace>CruiserJumpPractice</RootNamespace>
     <!-- !!APP_VERSION_MARKER!! -->
-    <Version>0.2.0-alpha.6</Version>
-    <!-- BepInEx 5 validates plugin metadata as System.Version, which rejects
-         SemVer prerelease strings such as 0.2.0-alpha.6. Keep the loader-facing
-         metadata conservative while release automation carries the prerelease
-         identity. -->
-    <BepInExPluginVersion>0.0.0</BepInExPluginVersion>
+    <Version>0.2.0</Version>
+    <!-- BepInEx 5 validates plugin metadata as System.Version. Stable release
+         versions can use the project version directly; prerelease branches keep
+         this metadata conservative. -->
+    <BepInExPluginVersion>0.2.0</BepInExPluginVersion>
     <!-- Target framework. https://learn.microsoft.com/en-us/dotnet/standard/frameworks -->
     <TargetFramework>netstandard2.1</TargetFramework>
     <!-- C# language version.

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ can include unrelated local environment details.
 Some parts of this project were developed with AI tools based on large language
 models (LLMs), including agent-based tools.
 The project maintainer reviews the code.
-This disclosure is made in compliance with [Thunderstore policies][thunderstore-home].
+This disclosure is made in compliance with Thunderstore and community policies.
 
 [docker-install]: https://docs.docker.com/get-started/get-docker/
 [dotnet-sdk-download]: https://dotnet.microsoft.com/en-us/download/dotnet/10.0
@@ -297,6 +297,5 @@ This disclosure is made in compliance with [Thunderstore policies][thunderstore-
 [lethal-company-steam]: https://store.steampowered.com/app/1966720/Lethal_Company/
 [powershell-install]: https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows
 [r2modman-package]: https://thunderstore.io/c/lethal-company/p/ebkr/r2modman/
-[thunderstore-home]: https://thunderstore.io/
 [thunderstore-lethal-company-community]: https://thunderstore.io/c/lethal-company/
 [visual-studio-download]: https://visualstudio.microsoft.com/en-us/vs/

--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 # CruiserJumpPractice
 
-A [Lethal Company][lethal-company] mod that saves and loads cruiser position,
+A [Lethal Company][lethal-company-steam] mod that saves and loads cruiser position,
 rotation, and condition, and lets you toggle the magnet remotely.
 
 - [User guide](./assets/README.md)
 
 ## Development
 
-Install [.NET SDK 10.0][dotnet-10] or later.
+Install [.NET SDK 10.0][dotnet-sdk-download] or later.
 
 Install [PowerShell 7][powershell-install].
 
-Install [Visual Studio 2022][visual-studio].
+Install [Visual Studio 2022][visual-studio-download].
 
 Install [Docker][docker-install] for local Markdown linting.
 
@@ -123,7 +123,7 @@ Maintenance references:
 
 ## GitHub Actions
 
-The repository uses [GitHub Actions][github-actions] for CI.
+The repository uses [GitHub Actions][github-actions-docs] for CI.
 
 ### Action pinning
 
@@ -231,7 +231,7 @@ Document the reason and compatibility impact in that change.
 ### Thunderstore publishing
 
 The current workflow deploys to the Thunderstore `aoirint` team and publishes to
-the [`lethal-company`][thunderstore-lethal-company] community with these
+the [`lethal-company`][thunderstore-lethal-company-community] community with these
 categories:
 
 - `Mods`
@@ -264,7 +264,7 @@ can include unrelated local environment details.
 
 ### r2modman
 
-1. Open [r2modman][r2modman].
+1. Open [r2modman][r2modman-package].
 2. Open `Config editor`.
 3. Open `BepInEx\config\BepInEx.cfg` in the config list.
 4. Set `Logging.Console.LogLevels` to `All`.
@@ -289,14 +289,14 @@ can include unrelated local environment details.
 Some parts of this project were developed with AI tools based on large language
 models (LLMs), including agent-based tools.
 The project maintainer reviews the code.
-This disclosure is made in compliance with [Thunderstore policies][thunderstore].
+This disclosure is made in compliance with [Thunderstore policies][thunderstore-home].
 
 [docker-install]: https://docs.docker.com/get-started/get-docker/
-[dotnet-10]: https://dotnet.microsoft.com/en-us/download/dotnet/10.0
-[github-actions]: https://docs.github.com/en/actions
-[lethal-company]: https://store.steampowered.com/app/1966720/Lethal_Company/
+[dotnet-sdk-download]: https://dotnet.microsoft.com/en-us/download/dotnet/10.0
+[github-actions-docs]: https://docs.github.com/en/actions
+[lethal-company-steam]: https://store.steampowered.com/app/1966720/Lethal_Company/
 [powershell-install]: https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows
-[r2modman]: https://thunderstore.io/c/lethal-company/p/ebkr/r2modman/
-[thunderstore]: https://thunderstore.io/
-[thunderstore-lethal-company]: https://thunderstore.io/c/lethal-company/
-[visual-studio]: https://visualstudio.microsoft.com/en-us/vs/
+[r2modman-package]: https://thunderstore.io/c/lethal-company/p/ebkr/r2modman/
+[thunderstore-home]: https://thunderstore.io/
+[thunderstore-lethal-company-community]: https://thunderstore.io/c/lethal-company/
+[visual-studio-download]: https://visualstudio.microsoft.com/en-us/vs/

--- a/README.md
+++ b/README.md
@@ -2,28 +2,20 @@
 
 # CruiserJumpPractice
 
-A Lethal Company mod that saves and loads cruiser position, rotation, and condition,
-and lets you toggle the magnet remotely.
+A [Lethal Company][lethal-company] mod that saves and loads cruiser position,
+rotation, and condition, and lets you toggle the magnet remotely.
 
 - [User guide](./assets/README.md)
 
 ## Development
 
-Install .NET SDK 10.0 or later.
+Install [.NET SDK 10.0][dotnet-10] or later.
 
-- <https://dotnet.microsoft.com/en-us/download/dotnet/10.0>
+Install [PowerShell 7][powershell-install].
 
-Install PowerShell 7.
+Install [Visual Studio 2022][visual-studio].
 
-- <https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows>
-
-Install Visual Studio 2022.
-
-- <https://visualstudio.microsoft.com/en-us/vs/>
-
-Install Docker for local Markdown linting.
-
-- <https://docs.docker.com/get-started/get-docker/>
+Install [Docker][docker-install] for local Markdown linting.
 
 Restore NuGet packages.
 
@@ -131,7 +123,7 @@ Maintenance references:
 
 ## GitHub Actions
 
-The repository uses GitHub Actions for CI.
+The repository uses [GitHub Actions][github-actions] for CI.
 
 ### Action pinning
 
@@ -239,7 +231,8 @@ Document the reason and compatibility impact in that change.
 ### Thunderstore publishing
 
 The current workflow deploys to the Thunderstore `aoirint` team and publishes to
-the `lethal-company` community with these categories:
+the [`lethal-company`][thunderstore-lethal-company] community with these
+categories:
 
 - `Mods`
 - `Tweaks & Quality Of Life`
@@ -271,7 +264,7 @@ can include unrelated local environment details.
 
 ### r2modman
 
-1. Open r2modman.
+1. Open [r2modman][r2modman].
 2. Open `Config editor`.
 3. Open `BepInEx\config\BepInEx.cfg` in the config list.
 4. Set `Logging.Console.LogLevels` to `All`.
@@ -296,4 +289,14 @@ can include unrelated local environment details.
 Some parts of this project were developed with AI tools based on large language
 models (LLMs), including agent-based tools.
 The project maintainer reviews the code.
-This disclosure is made in compliance with Thunderstore policies.
+This disclosure is made in compliance with [Thunderstore policies][thunderstore].
+
+[docker-install]: https://docs.docker.com/get-started/get-docker/
+[dotnet-10]: https://dotnet.microsoft.com/en-us/download/dotnet/10.0
+[github-actions]: https://docs.github.com/en/actions
+[lethal-company]: https://store.steampowered.com/app/1966720/Lethal_Company/
+[powershell-install]: https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows
+[r2modman]: https://thunderstore.io/c/lethal-company/p/ebkr/r2modman/
+[thunderstore]: https://thunderstore.io/
+[thunderstore-lethal-company]: https://thunderstore.io/c/lethal-company/
+[visual-studio]: https://visualstudio.microsoft.com/en-us/vs/

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -26,8 +26,9 @@ No gameplay changes are introduced.
       was created using AI tools.
     - This project uses the category to disclose AI assistance in project work;
       it is package metadata rather than a gameplay feature.
-    - The project decided to use this category because the applicable
-      disclosure threshold is not clear.
+    - The project decided to use this category because it has used and expects
+      to keep using AI tools to reduce development burden, and because the
+      applicable disclosure threshold is not clear.
     - Human maintainer review remains the project policy.
 - Dropped backward compatibility with older CruiserJumpPractice versions:
     - Affects CruiserJumpPractice v0.1.4 and earlier.

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -28,7 +28,7 @@ No gameplay changes are introduced.
       it is package metadata rather than a gameplay feature.
     - The project decided to use this category because:
         - It has used and expects to keep using AI tools to assist development
-          and reduce development burden.
+          and maintenance while reducing workload.
         - The applicable disclosure threshold is not clear.
     - Human maintainer review remains the project policy.
 - Dropped backward compatibility with older CruiserJumpPractice versions:

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -1,6 +1,6 @@
 <!-- SPDX-License-Identifier: MIT -->
 
-This changelog is the user-facing release notes for Thunderstore.
+This changelog is the user-facing release notes for [Thunderstore][thunderstore].
 
 For internal implementation details and developer-facing release history, see
 the [GitHub changelog][github-changelog].
@@ -11,19 +11,19 @@ project issue, see [CONTRIBUTING.md][contributing], then report it in
 
 ## v0.2.0 - 2026-05-06 UTC
 
-This release rebuilds CruiserJumpPractice for Lethal Company v81.5 and includes
-internal improvements.
+This release rebuilds CruiserJumpPractice for [Lethal Company][lethal-company]
+v81.5 and includes internal improvements.
 
 No gameplay changes are introduced.
 
 ### Changed
 
-- Rebuilt for Lethal Company v81.5.
+- Rebuilt for [Lethal Company][lethal-company] v81.5.
 - Improved internal implementation structure and release flow.
 - Added the Thunderstore `AI Generated` category to the package metadata:
-    - The Lethal Company Thunderstore community currently provides this
-      category for authors to disclose when a `significant portion` of a mod
-      was created using AI tools.
+    - The [Lethal Company Thunderstore community][thunderstore-lethal-company]
+      currently provides this category for authors to disclose when a
+      `significant portion` of a mod was created using AI tools.
     - This project uses the category to disclose AI assistance in project work;
       it is package metadata rather than a gameplay feature.
     - The project decided to use this category because:
@@ -38,10 +38,10 @@ No gameplay changes are introduced.
 ### Notes
 
 - Compatibility:
-    - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
-      `6423525044216269478`).
-        - Normally used together with Imperium; the v81.5 test environment
-          used Imperium v1.3.0.
+    - Compatible with [Lethal Company][lethal-company] v81.5 (2026-04-17 UTC,
+      Manifest ID: `6423525044216269478`).
+        - Normally used together with [Imperium][imperium]; the v81.5 test
+          environment used Imperium v1.3.0.
         - Imperium v1.3.0 appears to have some cruiser-related issues:
             - See the [Imperium issue comment][imperium-cruiser-workaround]
               for a workaround.
@@ -120,3 +120,7 @@ No gameplay changes are introduced.
 [contributing]: https://github.com/aoirint/CruiserJumpPractice/blob/main/CONTRIBUTING.md
 [github-changelog]: https://github.com/aoirint/CruiserJumpPractice/blob/main/CHANGELOG.md
 [github-issues]: https://github.com/aoirint/CruiserJumpPractice/issues
+[imperium]: https://thunderstore.io/c/lethal-company/p/giosuel/Imperium/
+[lethal-company]: https://store.steampowered.com/app/1966720/Lethal_Company/
+[thunderstore]: https://thunderstore.io/
+[thunderstore-lethal-company]: https://thunderstore.io/c/lethal-company/

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -27,8 +27,8 @@ No gameplay changes are introduced.
     - This project uses the category to disclose AI assistance in project work;
       it is package metadata rather than a gameplay feature.
     - The project decided to use this category because:
-        - It has used and expects to keep using AI tools to reduce development
-          burden.
+        - It has used and expects to keep using AI tools to assist development
+          and reduce development burden.
         - The applicable disclosure threshold is not clear.
     - Human maintainer review remains the project policy.
 - Dropped backward compatibility with older CruiserJumpPractice versions:

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -9,7 +9,7 @@ If you find a release-note error, encounter a bug, or want to report another
 project issue, see [CONTRIBUTING.md][contributing], then report it in
 [GitHub Issues][github-issues].
 
-## Unreleased
+## v0.2.0 - 2026-05-06 UTC
 
 This release rebuilds CruiserJumpPractice for Lethal Company v81.5 and includes
 internal improvements.

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -26,9 +26,10 @@ No gameplay changes are introduced.
       was created using AI tools.
     - This project uses the category to disclose AI assistance in project work;
       it is package metadata rather than a gameplay feature.
-    - The project decided to use this category because it has used and expects
-      to keep using AI tools to reduce development burden, and because the
-      applicable disclosure threshold is not clear.
+    - The project decided to use this category because:
+        - It has used and expects to keep using AI tools to reduce development
+          burden.
+        - The applicable disclosure threshold is not clear.
     - Human maintainer review remains the project policy.
 - Dropped backward compatibility with older CruiserJumpPractice versions:
     - Affects CruiserJumpPractice v0.1.4 and earlier.

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -1,6 +1,6 @@
 <!-- SPDX-License-Identifier: MIT -->
 
-This changelog is the user-facing release notes for [Thunderstore][thunderstore].
+This changelog is the user-facing release notes for Thunderstore.
 
 For internal implementation details and developer-facing release history, see
 the [GitHub changelog][github-changelog].
@@ -11,19 +11,19 @@ project issue, see [CONTRIBUTING.md][contributing], then report it in
 
 ## v0.2.0 - 2026-05-06 UTC
 
-This release rebuilds CruiserJumpPractice for [Lethal Company][lethal-company]
-v81.5 and includes internal improvements.
+This release rebuilds CruiserJumpPractice for Lethal Company v81.5 and includes
+internal improvements.
 
 No gameplay changes are introduced.
 
 ### Changed
 
-- Rebuilt for [Lethal Company][lethal-company] v81.5.
+- Rebuilt for Lethal Company v81.5.
 - Improved internal implementation structure and release flow.
 - Added the Thunderstore `AI Generated` category to the package metadata:
-    - The [Lethal Company Thunderstore community][thunderstore-lethal-company]
-      currently provides this category for authors to disclose when a
-      `significant portion` of a mod was created using AI tools.
+    - The Lethal Company Thunderstore community currently provides this
+      category for authors to disclose when a `significant portion` of a mod
+      was created using AI tools.
     - This project uses the category to disclose AI assistance in project work;
       it is package metadata rather than a gameplay feature.
     - The project decided to use this category because:
@@ -38,9 +38,9 @@ No gameplay changes are introduced.
 ### Notes
 
 - Compatibility:
-    - Compatible with [Lethal Company][lethal-company] v81.5 (2026-04-17 UTC,
-      Manifest ID: `6423525044216269478`).
-        - Normally used together with [Imperium][imperium]; the v81.5 test
+    - Compatible with Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
+      `6423525044216269478`).
+        - Normally used together with [Imperium][imperium-package]; the v81.5 test
           environment used Imperium v1.3.0.
         - Imperium v1.3.0 appears to have some cruiser-related issues:
             - See the [Imperium issue comment][imperium-cruiser-workaround]
@@ -120,7 +120,4 @@ No gameplay changes are introduced.
 [contributing]: https://github.com/aoirint/CruiserJumpPractice/blob/main/CONTRIBUTING.md
 [github-changelog]: https://github.com/aoirint/CruiserJumpPractice/blob/main/CHANGELOG.md
 [github-issues]: https://github.com/aoirint/CruiserJumpPractice/issues
-[imperium]: https://thunderstore.io/c/lethal-company/p/giosuel/Imperium/
-[lethal-company]: https://store.steampowered.com/app/1966720/Lethal_Company/
-[thunderstore]: https://thunderstore.io/
-[thunderstore-lethal-company]: https://thunderstore.io/c/lethal-company/
+[imperium-package]: https://thunderstore.io/c/lethal-company/p/giosuel/Imperium/

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -19,7 +19,7 @@ No gameplay changes are introduced.
 ### Changed
 
 - Rebuilt for Lethal Company v81.5.
-- Improved internal implementation structure and release packaging.
+- Improved internal implementation structure and release flow.
 - Added the Thunderstore `AI Generated` category to the package metadata:
     - The Lethal Company Thunderstore community currently provides this
       category for authors to disclose when a `significant portion` of a mod

--- a/assets/CHANGELOG.md
+++ b/assets/CHANGELOG.md
@@ -27,8 +27,8 @@ No gameplay changes are introduced.
     - This project uses the category to disclose AI assistance in project work;
       it is package metadata rather than a gameplay feature.
     - The project decided to use this category because:
-        - It has used and expects to keep using AI tools to assist development
-          and maintenance while reducing workload.
+        - It has used and expects to keep using AI tools to assist with
+          development and maintenance, and to reduce workload.
         - The applicable disclosure threshold is not clear.
     - Human maintainer review remains the project policy.
 - Dropped backward compatibility with older CruiserJumpPractice versions:

--- a/assets/README.md
+++ b/assets/README.md
@@ -35,12 +35,6 @@ synced cruiser state even without this mod installed.
 [giosuel/Imperium](https://thunderstore.io/c/lethal-company/p/giosuel/Imperium/)
 is practically required.
 
-Important: this mod **does not** provide any way to:
-
-- ❌ Instantly spawn a cruiser.
-- ❌ Teleport a player.
-- ❌ **Restore a destroyed cruiser**.
-
 ## Keybinds
 
 You can change the keybinds from the
@@ -52,8 +46,18 @@ You can change the keybinds from the
 
 ## Current Limitations
 
-- Exploded cruisers cannot be restored. Use Imperium to respawn the cruiser and
-  then load the saved state.
+- Destroyed cruiser restore is not implemented:
+    - Exploded cruisers cannot be restored. Use Imperium to respawn the cruiser
+      and then load the saved state.
+- Cruiser spawning is not implemented:
+    - This mod does not provide a way to instantly spawn a cruiser.
+- Player teleport is not implemented:
+    - This mod does not provide a way to teleport a player.
+- Known multiplayer issue:
+    - When a guest client is driving and the host loads a saved cruiser state,
+      the cruiser may briefly load on the host and then snap back. This is
+      tracked in
+      [GitHub issue #113](https://github.com/aoirint/CruiserJumpPractice/issues/113).
 
 ## Who needs to install
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -50,7 +50,7 @@ You can change the keybinds from the
 - Save Cruiser State: `]` (US: `]`, JP109: `[`)
 - Toggle Magnet: `\` (US: `\`, JP109: `]`)
 
-## Current Limitations
+## Known Issues and Limitations
 
 - Known multiplayer issue:
     - When a guest client is driving and the host loads a saved cruiser state,

--- a/assets/README.md
+++ b/assets/README.md
@@ -2,23 +2,23 @@
 
 # CruiserJumpPractice
 
-A [Lethal Company][lethal-company] mod that saves and loads cruiser position,
-rotation, and condition, and lets you toggle the magnet remotely.
+A Lethal Company mod that saves and loads cruiser position, rotation, and
+condition, and lets you toggle the magnet remotely.
 
 This mod helps you practice cruiser jumps repeatedly without having to manually
 reset the cruiser every attempt.
 
 ## Compatibility
 
-- [Lethal Company][lethal-company] v81.5 (2026-04-17 UTC, Manifest ID:
+- Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
   `6423525044216269478`)
     - Test environment
-        - [BepInExPack][bepinexpack] v5.4.2305 (2026-03-17 UTC)
-        - [Imperium][imperium] v1.3.0 (2026-04-08 UTC)
-        - [LethalCompany_InputUtils][input-utils] v0.7.13 (2026-03-31 UTC)
-        - [LethalNetworkAPI][lethal-network-api] v3.3.3 (2026-04-02 UTC)
-        - [OdinSerializer][odin-serializer] v2024.2.2700 (2025-05-18 UTC)
-        - [BepInEx_MonoMod_Debug_Patcher][bepinex-monomod-debug-patcher]
+        - [BepInExPack][bepinexpack-package] v5.4.2305 (2026-03-17 UTC)
+        - [Imperium][imperium-package] v1.3.0 (2026-04-08 UTC)
+        - [LethalCompany_InputUtils][input-utils-package] v0.7.13 (2026-03-31 UTC)
+        - [LethalNetworkAPI][lethal-network-api-package] v3.3.3 (2026-04-02 UTC)
+        - [OdinSerializer][odin-serializer-package] v2024.2.2700 (2025-05-18 UTC)
+        - [BepInEx_MonoMod_Debug_Patcher][bepinex-monomod-debug-patcher-package]
           v1.1.1 (2025-04-03 UTC)
     - NOTE: Imperium v1.3.0 appears to have some cruiser-related issues. See
       the [Imperium issue comment][imperium-cruiser-workaround] for a
@@ -33,7 +33,7 @@ reset the cruiser every attempt.
 Only the host can use all features of this mod. Clients will still receive the
 synced cruiser state even without this mod installed.
 
-[giosuel/Imperium][imperium] is practically required.
+[giosuel/Imperium][imperium-package] is practically required.
 
 Important: this mod **does not** provide any way to:
 
@@ -44,7 +44,7 @@ Important: this mod **does not** provide any way to:
 ## Keybinds
 
 You can change the keybinds from the
-[Rune580/LethalCompany_InputUtils][input-utils] settings menu.
+[Rune580/LethalCompany_InputUtils][input-utils-package] settings menu.
 
 - Load Cruiser State: `[` (US: `[`, JP109: `@`)
 - Save Cruiser State: `]` (US: `]`, JP109: `[`)
@@ -55,12 +55,11 @@ You can change the keybinds from the
 - Known multiplayer issue:
     - When a guest client is driving and the host loads a saved cruiser state,
       the cruiser may briefly load on the host and then snap back. This is
-      tracked in
-      [GitHub issue #113](https://github.com/aoirint/CruiserJumpPractice/issues/113).
+      tracked in [GitHub issue #113][issue-113].
 - Gear position is not saved or restored yet:
     - Park, Drive, and Reverse are not included in the saved cruiser state in
       this release. Gear save/load support is tracked in
-      [GitHub issue #114](https://github.com/aoirint/CruiserJumpPractice/issues/114).
+      [GitHub issue #114][issue-114].
 
 ## Who needs to install
 
@@ -73,14 +72,14 @@ Clients cannot use all features even if they install this mod.
 Some parts of this project were developed with AI tools based on large language
 models (LLMs), including agent-based tools.
 The project maintainer reviews the code.
-This disclosure is made in compliance with [Thunderstore policies][thunderstore].
+This disclosure is made in compliance with Thunderstore policies.
 
 [imperium-cruiser-workaround]: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735
-[bepinex-monomod-debug-patcher]: https://thunderstore.io/c/lethal-company/p/BepInEx/BepInEx_MonoMod_Debug_Patcher/
-[bepinexpack]: https://thunderstore.io/c/lethal-company/p/BepInEx/BepInExPack/
-[imperium]: https://thunderstore.io/c/lethal-company/p/giosuel/Imperium/
-[input-utils]: https://thunderstore.io/c/lethal-company/p/Rune580/LethalCompany_InputUtils/
-[lethal-company]: https://store.steampowered.com/app/1966720/Lethal_Company/
-[lethal-network-api]: https://thunderstore.io/c/lethal-company/p/xilophor/LethalNetworkAPI/
-[odin-serializer]: https://thunderstore.io/c/lethal-company/p/Lordfirespeed/OdinSerializer/
-[thunderstore]: https://thunderstore.io/
+[bepinex-monomod-debug-patcher-package]: https://thunderstore.io/c/lethal-company/p/BepInEx/BepInEx_MonoMod_Debug_Patcher/
+[bepinexpack-package]: https://thunderstore.io/c/lethal-company/p/BepInEx/BepInExPack/
+[imperium-package]: https://thunderstore.io/c/lethal-company/p/giosuel/Imperium/
+[input-utils-package]: https://thunderstore.io/c/lethal-company/p/Rune580/LethalCompany_InputUtils/
+[issue-113]: https://github.com/aoirint/CruiserJumpPractice/issues/113
+[issue-114]: https://github.com/aoirint/CruiserJumpPractice/issues/114
+[lethal-network-api-package]: https://thunderstore.io/c/lethal-company/p/xilophor/LethalNetworkAPI/
+[odin-serializer-package]: https://thunderstore.io/c/lethal-company/p/Lordfirespeed/OdinSerializer/

--- a/assets/README.md
+++ b/assets/README.md
@@ -72,7 +72,7 @@ Clients cannot use all features even if they install this mod.
 Some parts of this project were developed with AI tools based on large language
 models (LLMs), including agent-based tools.
 The project maintainer reviews the code.
-This disclosure is made in compliance with Thunderstore policies.
+This disclosure is made in compliance with Thunderstore and community policies.
 
 [imperium-cruiser-workaround]: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735
 [bepinex-monomod-debug-patcher-package]: https://thunderstore.io/c/lethal-company/p/BepInEx/BepInEx_MonoMod_Debug_Patcher/

--- a/assets/README.md
+++ b/assets/README.md
@@ -2,23 +2,24 @@
 
 # CruiserJumpPractice
 
-A Lethal Company mod that saves and loads cruiser position, rotation, and
-condition, and lets you toggle the magnet remotely.
+A [Lethal Company][lethal-company] mod that saves and loads cruiser position,
+rotation, and condition, and lets you toggle the magnet remotely.
 
 This mod helps you practice cruiser jumps repeatedly without having to manually
 reset the cruiser every attempt.
 
 ## Compatibility
 
-- Lethal Company v81.5 (2026-04-17 UTC, Manifest ID:
+- [Lethal Company][lethal-company] v81.5 (2026-04-17 UTC, Manifest ID:
   `6423525044216269478`)
     - Test environment
-        - BepInExPack v5.4.2305 (2026-03-17 UTC)
-        - Imperium v1.3.0 (2026-04-08 UTC)
-        - LethalCompany_InputUtils v0.7.13 (2026-03-31 UTC)
-        - LethalNetworkAPI v3.3.3 (2026-04-02 UTC)
-        - OdinSerializer v2024.2.2700 (2025-05-18 UTC)
-        - BepInEx_MonoMod_Debug_Patcher v1.1.1 (2025-04-03 UTC)
+        - [BepInExPack][bepinexpack] v5.4.2305 (2026-03-17 UTC)
+        - [Imperium][imperium] v1.3.0 (2026-04-08 UTC)
+        - [LethalCompany_InputUtils][input-utils] v0.7.13 (2026-03-31 UTC)
+        - [LethalNetworkAPI][lethal-network-api] v3.3.3 (2026-04-02 UTC)
+        - [OdinSerializer][odin-serializer] v2024.2.2700 (2025-05-18 UTC)
+        - [BepInEx_MonoMod_Debug_Patcher][bepinex-monomod-debug-patcher]
+          v1.1.1 (2025-04-03 UTC)
     - NOTE: Imperium v1.3.0 appears to have some cruiser-related issues. See
       the [Imperium issue comment][imperium-cruiser-workaround] for a
       workaround.
@@ -32,8 +33,7 @@ reset the cruiser every attempt.
 Only the host can use all features of this mod. Clients will still receive the
 synced cruiser state even without this mod installed.
 
-[giosuel/Imperium](https://thunderstore.io/c/lethal-company/p/giosuel/Imperium/)
-is practically required.
+[giosuel/Imperium][imperium] is practically required.
 
 Important: this mod **does not** provide any way to:
 
@@ -73,7 +73,14 @@ Clients cannot use all features even if they install this mod.
 Some parts of this project were developed with AI tools based on large language
 models (LLMs), including agent-based tools.
 The project maintainer reviews the code.
-This disclosure is made in compliance with Thunderstore policies.
+This disclosure is made in compliance with [Thunderstore policies][thunderstore].
 
 [imperium-cruiser-workaround]: https://github.com/giosuel/imperium/issues/153#issuecomment-4317402735
+[bepinex-monomod-debug-patcher]: https://thunderstore.io/c/lethal-company/p/BepInEx/BepInEx_MonoMod_Debug_Patcher/
+[bepinexpack]: https://thunderstore.io/c/lethal-company/p/BepInEx/BepInExPack/
+[imperium]: https://thunderstore.io/c/lethal-company/p/giosuel/Imperium/
 [input-utils]: https://thunderstore.io/c/lethal-company/p/Rune580/LethalCompany_InputUtils/
+[lethal-company]: https://store.steampowered.com/app/1966720/Lethal_Company/
+[lethal-network-api]: https://thunderstore.io/c/lethal-company/p/xilophor/LethalNetworkAPI/
+[odin-serializer]: https://thunderstore.io/c/lethal-company/p/Lordfirespeed/OdinSerializer/
+[thunderstore]: https://thunderstore.io/

--- a/assets/README.md
+++ b/assets/README.md
@@ -35,6 +35,12 @@ synced cruiser state even without this mod installed.
 [giosuel/Imperium](https://thunderstore.io/c/lethal-company/p/giosuel/Imperium/)
 is practically required.
 
+Important: this mod **does not** provide any way to:
+
+- ❌ Instantly spawn a cruiser.
+- ❌ Teleport a player.
+- ❌ **Restore a destroyed cruiser**.
+
 ## Keybinds
 
 You can change the keybinds from the

--- a/assets/README.md
+++ b/assets/README.md
@@ -52,18 +52,15 @@ You can change the keybinds from the
 
 ## Current Limitations
 
-- Destroyed cruiser restore is not implemented:
-    - Exploded cruisers cannot be restored. Use Imperium to respawn the cruiser
-      and then load the saved state.
-- Cruiser spawning is not implemented:
-    - This mod does not provide a way to instantly spawn a cruiser.
-- Player teleport is not implemented:
-    - This mod does not provide a way to teleport a player.
 - Known multiplayer issue:
     - When a guest client is driving and the host loads a saved cruiser state,
       the cruiser may briefly load on the host and then snap back. This is
       tracked in
       [GitHub issue #113](https://github.com/aoirint/CruiserJumpPractice/issues/113).
+- Gear position is not saved or restored yet:
+    - Park, Drive, and Reverse are not included in the saved cruiser state in
+      this release. Gear save/load support is tracked in
+      [GitHub issue #114](https://github.com/aoirint/CruiserJumpPractice/issues/114).
 
 ## Who needs to install
 

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "CruiserJumpPractice",
-    "version_number": "0.0.0",
+    "version_number": "0.2.0",
     "website_url": "https://github.com/aoirint/CruiserJumpPractice",
     "description": "[v81.5] Saves and loads cruiser position, rotation, and condition, and lets you toggle the magnet remotely.",
     "dependencies": [

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "CruiserJumpPractice",
-    "version_number": "0.2.0",
+    "version_number": "0.0.0",
     "website_url": "https://github.com/aoirint/CruiserJumpPractice",
     "description": "[v81.5] Saves and loads cruiser position, rotation, and condition, and lets you toggle the magnet remotely.",
     "dependencies": [


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Prepare the validated `v0.2.0` stable release after the `v0.2.0-alpha.6` validation pass in #112.
- Change the project version from `0.2.0-alpha.6` to stable `0.2.0`.
- Remove the duplicate `BepInExPluginVersion` override; `Version` remains the single source of truth for generated BepInEx plugin metadata.
- Keep source `assets/manifest.json` at the repository placeholder `version_number: "0.0.0"`; the release workflow generates the stable package manifest version as `0.2.0` during packaging.
- Add a concise canonical developer-facing `v0.2.0` changelog promotion entry, including accepted residual risks from #112.
- Promote the Thunderstore-facing release notes from `Unreleased` to `v0.2.0 - 2026-05-06 UTC`, including the `release flow` wording and the expanded AI category rationale.
- Keep the user-facing README `Important` limitation notice and use `Known Issues and Limitations` for tracked items: the guest-driver snapback issue (#113) and gear save/load feature gap (#114).
- Keep user-facing links focused on useful issue/package references, while keeping developer-facing setup and workflow links in the root README.
- Clarify AI disclosure wording as compliance with Thunderstore and community policies without adding another policy link.

## Related Issues

- Refs #92
- Refs #112
- Refs #113
- Refs #114

## Notes for reviewers

Please focus on release metadata and release-note readiness:

- `CruiserJumpPractice.csproj` now uses `<Version>0.2.0</Version>`.
- `BepInExPluginVersion` is no longer explicitly set; the `BepInEx.PluginInfoProps` default maps it to `$(Version)`, producing `MyPluginInfo.PLUGIN_VERSION = "0.2.0"` for this release.
- Source `assets/manifest.json` intentionally remains `version_number: "0.0.0"`; `.github/actions/generate-version` rewrites the packaged manifest to `0.2.0` for stable latest builds.
- Remote tag check found `v0.2.0-alpha.1` through `v0.2.0-alpha.6`, but no `v0.2.0` tag.
- #112 accepted two non-blocking residual risks: HP/turbo restore observability when values stayed default-like and unchanged, and the guest-driver snapback tracked in #113.
- The root `CHANGELOG.md` stable entry records the promotion and stable release metadata decisions; detailed alpha implementation history remains in the existing `v0.2.0-alpha.*` sections.
- The Thunderstore-facing `assets/CHANGELOG.md` now says `release flow` instead of `release packaging` and lists the AI category rationale as separate child bullets.
- The user-facing `assets/README.md` keeps the short `Important` limitation notice for unavailable capabilities, and `Known Issues and Limitations` now lists only the tracked #113 known issue and #114 not-yet-implemented gear save/load support.
- User-facing README/changelog links avoid self-evident Lethal Company, Thunderstore, and Thunderstore community links; developer-facing README links remain for setup/workflow references. Markdown reference labels now use role-based names such as `*-package`, `*-download`, `*-docs`, and `*-community`; issue references use stable number-based labels such as `issue-18`, `issue-112`, and `issue-113`.
- AI disclosure text now says `Thunderstore and community policies` in both README files and intentionally does not link that phrase.

### AI disclosure

Codex helped close the validation workflow issues, prepare the release metadata and changelog/release-note edits, correct the source manifest handling and BepInEx metadata simplification after maintainer feedback, update user-facing limitation and release-note wording, tune cross-reference links, run repository checks, and draft this pull request text. The generated changes were reviewed against the repository release workflow before opening and updating the PR.

## Testing

### Automated checks

- `dotnet build --configuration Release` - passed with 0 warnings and 0 errors before opening the PR.
- `dotnet format --no-restore --verify-no-changes` - passed before opening the PR.
- `git diff --check` - passed; Git only reported repository line-ending warnings.
- `git diff --check origin/main...HEAD` - passed after the release metadata corrections.
- `dotnet build --configuration Release` - passed again after the README limitation update.
- `dotnet format --no-restore --verify-no-changes` - passed again after the latest docs updates.
- `git diff --check` - passed again after the latest docs updates; Git only reported existing Markdown line-ending warnings.
- `markdownlint-cli2` via the pinned Docker image - passed with 0 errors after the link updates.

### Release-readiness checks

- `git ls-remote --tags origin "refs/tags/v0.2.0*"` - confirmed no existing `refs/tags/v0.2.0` remote tag.
- Verified the release workflow publishes stable `latest` releases to Thunderstore when the project version has no prerelease suffix and rewrites packaged `manifest.json` `version_number` from the generated manifest version.
- Verified the generated Release `MyPluginInfo.cs` contains `PLUGIN_VERSION = "0.2.0"` without an explicit `BepInExPluginVersion` property.

### AI-assisted inspections

Request: Review the stable-release metadata, release-note changes, user-facing limitation notes, and documentation links against the #112 validation outcome.

AI-assisted result:

- Confirmed stable package metadata is generated as `0.2.0` by the release workflow rather than committed directly to source `assets/manifest.json`.
- Confirmed the project version is enough for BepInEx plugin metadata through `BepInEx.PluginInfoProps` defaults.
- Confirmed the developer changelog records #112 accepted residual risks separately from release blockers without copying the full alpha implementation history into the stable entry.
- Confirmed the Thunderstore-facing changelog has a stable `v0.2.0` heading at the top, uses `release flow`, and lists the AI category rationale as child bullets.
- Confirmed the user-facing README links #113 and #114 with GitHub URLs, makes clear that gear save/load support is not implemented in this release, keeps the `Important` limitation notice, and uses the `Known Issues and Limitations` heading.
- Confirmed Markdown reference links in README/changelog files have no missing or unused definitions after removing self-evident user-facing links and normalizing reference labels.
- Confirmed the AI disclosure policy wording has no Markdown reference link and no unused policy-link definition remains.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.