### PR TITLE
ci: add merge queue triggers and PR concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,16 +5,10 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-  merge_group:
-    types:
-      - checks_requested
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 defaults:
   run:
@@ -144,7 +138,7 @@ jobs:
       - build
     # Edge builds are validation artifacts only; GitHub releases are created
     # only for new project versions that should receive a tag.
-    if: github.event_name == 'push' && needs.build.outputs.release_mode != 'edge'
+    if: needs.build.outputs.release_mode != 'edge'
 
     # Keep this on ubuntu-slim: release publishing only needs standard shell tools
     # included in that image, and does not require ubuntu-latest's larger toolset.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,16 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+  merge_group:
+    types:
+      - checks_requested
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 defaults:
   run:
@@ -134,7 +144,7 @@ jobs:
       - build
     # Edge builds are validation artifacts only; GitHub releases are created
     # only for new project versions that should receive a tag.
-    if: needs.build.outputs.release_mode != 'edge'
+    if: github.event_name == 'push' && needs.build.outputs.release_mode != 'edge'
 
     # Keep this on ubuntu-slim: release publishing only needs standard shell tools
     # included in that image, and does not require ubuntu-latest's larger toolset.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,14 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 defaults:
   run:


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Add `merge_group` triggers to the Lint workflow so required lint checks can run for merge queue entries.
- Add workflow-level concurrency that cancels superseded Lint runs for the same PR.
- Add Build workflow concurrency for `main` pushes with `cancel-in-progress: false`, so release-capable builds are not interrupted by newer `main` pushes.

## Related Issues

None

## Notes for reviewers

- Build intentionally remains `push`-only because it publishes release artifacts from `main`; PR and merge queue validation should not need the Build workflow.
- Lint keeps `merge_group` because it is the PR-facing required check that merge queue entries need.

### AI disclosure

Codex drafted and applied the workflow changes, then reviewed the resulting diff and verification output.

## Testing

### Automated checks

- `git diff --check` - passed.
- `dotnet build --configuration Release` - passed.
- `dotnet format --no-restore --verify-no-changes` - passed.
- `actionlint` - not run; the tool is not installed in this local environment.

### AI-assisted inspections

Request: Review the CI diff for merge queue behavior, release publishing boundaries, and unnecessary supply-chain changes.

AI-assisted result: The diff changes workflow triggers and concurrency only. No new actions, permissions, secrets, containers, or package-runner commands were added.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
