### PR TITLE
refactor(config): add BepInEx plugin config adapter

### DIFF
--- a/CruiserJumpPractice/Core/Ports/IPluginConfig.cs
+++ b/CruiserJumpPractice/Core/Ports/IPluginConfig.cs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+#nullable enable
+
+namespace CruiserJumpPractice.Core.Ports;
+
+internal interface IPluginConfig
+{
+    bool ValidationLogging { get; }
+}

--- a/CruiserJumpPractice/CruiserJumpPractice.cs
+++ b/CruiserJumpPractice/CruiserJumpPractice.cs
@@ -26,20 +26,15 @@ public class CruiserJumpPractice : BaseUnityPlugin
     private void Awake()
     {
         var logger = new BepInExPluginLogger(base.Logger);
-        var validationLogging = Config.Bind(
-            "Debug",
-            "ValidationLogging",
-            false,
-            "Enable structured validation logs for release validation and troubleshooting."
-        );
-        IValidationLogger validationLogger = validationLogging.Value
+        var config = BepInExPluginConfig.Bind(Config);
+        IValidationLogger validationLogger = config.ValidationLogging
             ? new BepInExValidationLogger(logger, System.DateTime.UtcNow)
             : DisabledValidationLogger.Instance;
 
         validationLogger.Record(
             ValidationLogRecord.PluginLoaded(
                 version: MyPluginInfo.PLUGIN_VERSION,
-                validationLogging: validationLogging.Value
+                validationLogging: config.ValidationLogging
             )
         );
 

--- a/CruiserJumpPractice/Interop/BepInExPluginConfig.cs
+++ b/CruiserJumpPractice/Interop/BepInExPluginConfig.cs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+#nullable enable
+
+using BepInEx.Configuration;
+using CruiserJumpPractice.Core.Ports;
+
+namespace CruiserJumpPractice.Interop;
+
+internal sealed class BepInExPluginConfig : IPluginConfig
+{
+    private readonly ConfigEntry<bool> validationLoggingConfig;
+
+    private BepInExPluginConfig(ConfigEntry<bool> validationLoggingConfig)
+    {
+        this.validationLoggingConfig = validationLoggingConfig;
+    }
+
+    public bool ValidationLogging => validationLoggingConfig.Value;
+
+    public static BepInExPluginConfig Bind(ConfigFile config)
+    {
+        var validationLoggingConfig = config.Bind(
+            "Debug",
+            "ValidationLogging",
+            false,
+            "Enable structured validation logs for release validation and troubleshooting."
+        );
+
+        return new BepInExPluginConfig(validationLoggingConfig: validationLoggingConfig);
+    }
+}


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Adds an `IPluginConfig` Core port and `BepInExPluginConfig` adapter for plugin config bindings.
- Moves the existing `Debug.ValidationLogging` binding out of `CruiserJumpPractice.cs` while keeping the section, key, default, and description unchanged.
- Keeps `ValidationLogging` explicit on the config port so startup validation logging continues to use the same setting through the adapter boundary.

## Related Issues

- Closes #117

## Notes for reviewers

- This is intentionally limited to config wiring; README validation logging guidance is unchanged because the user-facing config name and behavior stay the same.

### AI disclosure

- Codex inspected the CJP startup/config wiring and compared the intended shape with the SkipDropshipCompany config adapter follow-up before implementing the focused CJP adapter.

## Testing

### Automated checks

- `dotnet restore --locked-mode`
- `dotnet format --no-restore --verify-no-changes`
- `$env:DOTNET_CLI_UI_LANGUAGE='en'; dotnet build --configuration Release --no-restore`
- `git diff --check origin/main..HEAD`

### Manual checks

- Not run: in-game validation was not available in this environment.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
