### PR TITLE
fix(validation): guard Harmony callback exceptions

### DIFF
--- a/CruiserJumpPractice/Core/Validation/ValidationLogRecord.cs
+++ b/CruiserJumpPractice/Core/Validation/ValidationLogRecord.cs
@@ -403,6 +403,18 @@ internal sealed class ValidationLogRecord
         );
     }
 
+    public static ValidationLogRecord CallbackException(string callback, string exceptionType)
+    {
+        return new(
+            "callback_exception",
+            new()
+            {
+                ["callback"] = callback,
+                ["exception_type"] = exceptionType
+            }
+        );
+    }
+
     private static ValidationLogRecord LoadResult(
         string result,
         bool cruiserFound,

--- a/CruiserJumpPractice/CruiserJumpPractice.cs
+++ b/CruiserJumpPractice/CruiserJumpPractice.cs
@@ -41,6 +41,7 @@ public class CruiserJumpPractice : BaseUnityPlugin
         // Inject the logger through the plugin logging port so Core and game interop can emit
         // diagnostics without depending on BepInEx logging types.
         controller = PluginController.Create(logger: logger, validationLogger: validationLogger);
+
         // Startup order matters: configure the guard after the controller is
         // wired and before patching so the first callback can be diagnosed.
         HarmonyCallbackGuard.Configure(

--- a/CruiserJumpPractice/CruiserJumpPractice.cs
+++ b/CruiserJumpPractice/CruiserJumpPractice.cs
@@ -41,6 +41,12 @@ public class CruiserJumpPractice : BaseUnityPlugin
         // Inject the logger through the plugin logging port so Core and game interop can emit
         // diagnostics without depending on BepInEx logging types.
         controller = PluginController.Create(logger: logger, validationLogger: validationLogger);
+        HarmonyCallbackGuard.Configure(
+            new HarmonyCallbackDiagnosticReporter(
+                logger: logger,
+                validationLogger: validationLogger
+            )
+        );
 
         // Startup order matters: construct the controller before patching so the first game
         // callback can enter a fully wired plugin boundary.

--- a/CruiserJumpPractice/CruiserJumpPractice.cs
+++ b/CruiserJumpPractice/CruiserJumpPractice.cs
@@ -18,15 +18,17 @@ public class CruiserJumpPractice : BaseUnityPlugin
 {
     private static PluginController? controller;
 
-    // Harmony and Netcode construct their callback objects outside our
-    // construction path. This static entry exposes one plugin-level controller
-    // instead of scattering use cases across patch and NetworkBehaviour classes.
+    // Game callback types are constructed outside the plugin startup path.
+    // This static entry exposes one plugin-level controller instead of
+    // scattering use cases across callback classes.
     internal static PluginController Controller => controller!;
 
     private void Awake()
     {
         var logger = new BepInExPluginLogger(base.Logger);
+
         var config = BepInExPluginConfig.Bind(Config);
+
         IValidationLogger validationLogger = config.ValidationLogging
             ? new BepInExValidationLogger(logger, System.DateTime.UtcNow)
             : DisabledValidationLogger.Instance;
@@ -38,9 +40,12 @@ public class CruiserJumpPractice : BaseUnityPlugin
             )
         );
 
-        // Inject the logger through the plugin logging port so Core and game interop can emit
-        // diagnostics without depending on BepInEx logging types.
-        controller = PluginController.Create(logger: logger, validationLogger: validationLogger);
+        // Create the workflow facade after BepInEx adapters are bound so Core
+        // stays behind ports.
+        controller = PluginController.Create(
+            logger: logger,
+            validationLogger: validationLogger
+        );
 
         // Startup order matters: configure the guard after the controller is
         // wired and before patching so the first callback can be diagnosed.
@@ -55,6 +60,8 @@ public class CruiserJumpPractice : BaseUnityPlugin
         // callback can enter a fully wired plugin boundary.
         HarmonyPatchInstaller.Install();
 
-        logger.LogInfo($"Plugin {MyPluginInfo.PLUGIN_NAME} v{MyPluginInfo.PLUGIN_VERSION} is loaded!");
+        logger.LogInfo(
+            $"Plugin {MyPluginInfo.PLUGIN_NAME} v{MyPluginInfo.PLUGIN_VERSION} is loaded!"
+        );
     }
 }

--- a/CruiserJumpPractice/CruiserJumpPractice.cs
+++ b/CruiserJumpPractice/CruiserJumpPractice.cs
@@ -41,6 +41,8 @@ public class CruiserJumpPractice : BaseUnityPlugin
         // Inject the logger through the plugin logging port so Core and game interop can emit
         // diagnostics without depending on BepInEx logging types.
         controller = PluginController.Create(logger: logger, validationLogger: validationLogger);
+        // Startup order matters: configure the guard after the controller is
+        // wired and before patching so the first callback can be diagnosed.
         HarmonyCallbackGuard.Configure(
             new HarmonyCallbackDiagnosticReporter(
                 logger: logger,

--- a/CruiserJumpPractice/Interop/Game/Patches/HUDManagerPatch.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/HUDManagerPatch.cs
@@ -13,8 +13,8 @@ namespace CruiserJumpPractice.Interop.Game.Patches;
 [HarmonyPatch(typeof(HUDManager))]
 internal static class HUDManagerPatch
 {
-    // Awake is the base HUD setup lifecycle point. CJP waits until that setup
-    // finishes before running plugin startup work that depends on game UI state.
+    // For the base game, Awake initializes HUD state and UI references. The
+    // Postfix waits until that setup finishes before plugin startup work runs.
     [HarmonyPatch(nameof(HUDManager.Awake))]
     [HarmonyPostfix]
     public static void AwakePostfix()
@@ -25,8 +25,8 @@ internal static class HUDManagerPatch
         );
     }
 
-    // Update is the base HUD frame tick. CJP observes after each tick so frame
-    // work runs alongside the game loop without replacing the base HUD update.
+    // For the base game, Update is the HUD's per-frame UI loop. The Postfix
+    // runs plugin frame work after the base HUD frame update has completed.
     [HarmonyPatch(nameof(HUDManager.Update))]
     [HarmonyPostfix]
     public static void UpdatePostfix()

--- a/CruiserJumpPractice/Interop/Game/Patches/HUDManagerPatch.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/HUDManagerPatch.cs
@@ -11,7 +11,7 @@ namespace CruiserJumpPractice.Interop.Game.Patches;
 // HUDManager is patched only to find lifecycle moments the game already owns. Once those moments
 // are found, work is delegated to PluginController rather than embedding practice logic here.
 [HarmonyPatch(typeof(HUDManager))]
-internal class HUDManagerPatch
+internal static class HUDManagerPatch
 {
     [HarmonyPatch(nameof(HUDManager.Awake))]
     [HarmonyPostfix]

--- a/CruiserJumpPractice/Interop/Game/Patches/HUDManagerPatch.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/HUDManagerPatch.cs
@@ -17,14 +17,20 @@ internal class HUDManagerPatch
     [HarmonyPostfix]
     public static void AwakePostfix()
     {
-        CruiserJumpPractice.Controller.HandleStartup();
+        HarmonyCallbackGuard.TryNotifyHarmonyCallback(
+            callback: HarmonyCallbackTokens.HudManagerAwakePostfix,
+            notify: static () => CruiserJumpPractice.Controller.HandleStartup()
+        );
     }
 
     [HarmonyPatch(nameof(HUDManager.Update))]
     [HarmonyPostfix]
     public static void UpdatePostfix()
     {
-        CruiserJumpPractice.Controller.HandleFrame();
+        HarmonyCallbackGuard.TryNotifyHarmonyCallback(
+            callback: HarmonyCallbackTokens.HudManagerUpdatePostfix,
+            notify: static () => CruiserJumpPractice.Controller.HandleFrame()
+        );
     }
 
 }

--- a/CruiserJumpPractice/Interop/Game/Patches/HUDManagerPatch.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/HUDManagerPatch.cs
@@ -13,6 +13,8 @@ namespace CruiserJumpPractice.Interop.Game.Patches;
 [HarmonyPatch(typeof(HUDManager))]
 internal static class HUDManagerPatch
 {
+    // Awake is the base HUD setup lifecycle point. CJP waits until that setup
+    // finishes before running plugin startup work that depends on game UI state.
     [HarmonyPatch(nameof(HUDManager.Awake))]
     [HarmonyPostfix]
     public static void AwakePostfix()
@@ -23,6 +25,8 @@ internal static class HUDManagerPatch
         );
     }
 
+    // Update is the base HUD frame tick. CJP observes after each tick so frame
+    // work runs alongside the game loop without replacing the base HUD update.
     [HarmonyPatch(nameof(HUDManager.Update))]
     [HarmonyPostfix]
     public static void UpdatePostfix()

--- a/CruiserJumpPractice/Interop/Game/Patches/HarmonyCallbackDiagnosticReporter.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/HarmonyCallbackDiagnosticReporter.cs
@@ -23,6 +23,8 @@ internal sealed class HarmonyCallbackDiagnosticReporter
 
     public void RecordCallbackException(string callback, Exception exception)
     {
+        // Keep structured validation diagnostics compact and environment-safe:
+        // no exception messages, stack traces, Unity object data, or local paths.
         var exceptionType = exception.GetType().FullName ?? exception.GetType().Name;
         logger.LogError(
             $"Harmony callback exception: callback={callback}, exception_type={exceptionType}"

--- a/CruiserJumpPractice/Interop/Game/Patches/HarmonyCallbackDiagnosticReporter.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/HarmonyCallbackDiagnosticReporter.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+#nullable enable
+
+using System;
+using CruiserJumpPractice.Core.Ports;
+using CruiserJumpPractice.Core.Validation;
+
+namespace CruiserJumpPractice.Interop.Game.Patches;
+
+internal sealed class HarmonyCallbackDiagnosticReporter
+{
+    private readonly IPluginLogger logger;
+    private readonly IValidationLogger validationLogger;
+
+    public HarmonyCallbackDiagnosticReporter(
+        IPluginLogger logger,
+        IValidationLogger validationLogger
+    )
+    {
+        this.logger = logger;
+        this.validationLogger = validationLogger;
+    }
+
+    public void RecordCallbackException(string callback, Exception exception)
+    {
+        var exceptionType = exception.GetType().FullName ?? exception.GetType().Name;
+        logger.LogError(
+            $"Harmony callback exception: callback={callback}, exception_type={exceptionType}"
+        );
+        validationLogger.Record(
+            ValidationLogRecord.CallbackException(
+                callback: callback,
+                exceptionType: exceptionType
+            )
+        );
+    }
+}

--- a/CruiserJumpPractice/Interop/Game/Patches/HarmonyCallbackGuard.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/HarmonyCallbackGuard.cs
@@ -9,11 +9,15 @@ internal static class HarmonyCallbackGuard
 {
     private static HarmonyCallbackDiagnosticReporter? diagnosticReporter;
 
+    // Configure from plugin startup before Harmony patches are installed so the
+    // guard can keep patch classes free of logger and validation dependencies.
     public static void Configure(HarmonyCallbackDiagnosticReporter reporter)
     {
         diagnosticReporter = reporter;
     }
 
+    // Returns whether the controller notification completed without throwing.
+    // A false result says nothing about whether diagnostic recording succeeded.
     public static bool TryNotifyHarmonyCallback(string callback, Action notify)
     {
         try
@@ -28,6 +32,8 @@ internal static class HarmonyCallbackGuard
         }
     }
 
+    // Use this overload when a patch needs the notification result to decide a
+    // patch-boundary side effect, such as mutating a Harmony ref argument.
     public static bool TryNotifyHarmonyCallback<T>(
         string callback,
         Func<T> notify,

--- a/CruiserJumpPractice/Interop/Game/Patches/HarmonyCallbackGuard.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/HarmonyCallbackGuard.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+#nullable enable
+
+using System;
+
+namespace CruiserJumpPractice.Interop.Game.Patches;
+
+internal static class HarmonyCallbackGuard
+{
+    private static HarmonyCallbackDiagnosticReporter? diagnosticReporter;
+
+    public static void Configure(HarmonyCallbackDiagnosticReporter reporter)
+    {
+        diagnosticReporter = reporter;
+    }
+
+    public static bool TryNotifyHarmonyCallback(string callback, Action notify)
+    {
+        try
+        {
+            notify();
+            return true;
+        }
+        catch (Exception exception)
+        {
+            TryRecordCallbackException(callback: callback, exception: exception);
+            return false;
+        }
+    }
+
+    public static bool TryNotifyHarmonyCallback<T>(
+        string callback,
+        Func<T> notify,
+        out T? result
+    )
+    {
+        try
+        {
+            result = notify();
+            return true;
+        }
+        catch (Exception exception)
+        {
+            result = default;
+            TryRecordCallbackException(callback: callback, exception: exception);
+            return false;
+        }
+    }
+
+    private static void TryRecordCallbackException(string callback, Exception exception)
+    {
+        try
+        {
+            diagnosticReporter?.RecordCallbackException(callback: callback, exception: exception);
+        }
+        catch
+        {
+            // Diagnostics must not turn a fail-open Harmony callback into a base-game failure.
+        }
+    }
+}

--- a/CruiserJumpPractice/Interop/Game/Patches/HarmonyCallbackTokens.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/HarmonyCallbackTokens.cs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+#nullable enable
+
+namespace CruiserJumpPractice.Interop.Game.Patches;
+
+internal static class HarmonyCallbackTokens
+{
+    public const string HudManagerAwakePostfix = "hud_manager.awake.postfix";
+    public const string HudManagerUpdatePostfix = "hud_manager.update.postfix";
+    public const string StartOfRoundSetMagnetOnPrefix = "start_of_round.set_magnet_on.prefix";
+    public const string StartOfRoundSetMagnetOnPostfix = "start_of_round.set_magnet_on.postfix";
+    public const string StartOfRoundSetMagnetOnClientRpcPrefix =
+        "start_of_round.set_magnet_on_client_rpc.prefix";
+    public const string StartOfRoundSetMagnetOnClientRpcPostfix =
+        "start_of_round.set_magnet_on_client_rpc.postfix";
+    public const string VehicleControllerAddEngineOilClientRpcPrefix =
+        "vehicle_controller.add_engine_oil_client_rpc.prefix";
+    public const string VehicleControllerAddEngineOilClientRpcFinalizer =
+        "vehicle_controller.add_engine_oil_client_rpc.finalizer";
+    public const string VehicleControllerAddEngineOilOnLocalClientPrefix =
+        "vehicle_controller.add_engine_oil_on_local_client.prefix";
+    public const string VehicleControllerAddEngineOilOnLocalClientPostfix =
+        "vehicle_controller.add_engine_oil_on_local_client.postfix";
+    public const string VehicleControllerAddTurboBoostClientRpcPrefix =
+        "vehicle_controller.add_turbo_boost_client_rpc.prefix";
+    public const string VehicleControllerAddTurboBoostClientRpcFinalizer =
+        "vehicle_controller.add_turbo_boost_client_rpc.finalizer";
+    public const string VehicleControllerAddTurboBoostOnLocalClientPrefix =
+        "vehicle_controller.add_turbo_boost_on_local_client.prefix";
+    public const string VehicleControllerAddTurboBoostOnLocalClientPostfix =
+        "vehicle_controller.add_turbo_boost_on_local_client.postfix";
+}

--- a/CruiserJumpPractice/Interop/Game/Patches/HarmonyCallbackTokens.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/HarmonyCallbackTokens.cs
@@ -5,28 +5,28 @@ namespace CruiserJumpPractice.Interop.Game.Patches;
 
 internal static class HarmonyCallbackTokens
 {
-    public const string HudManagerAwakePostfix = "hud_manager.awake.postfix";
-    public const string HudManagerUpdatePostfix = "hud_manager.update.postfix";
-    public const string StartOfRoundSetMagnetOnPrefix = "start_of_round.set_magnet_on.prefix";
-    public const string StartOfRoundSetMagnetOnPostfix = "start_of_round.set_magnet_on.postfix";
+    public const string HudManagerAwakePostfix = "hud_manager_awake_postfix";
+    public const string HudManagerUpdatePostfix = "hud_manager_update_postfix";
+    public const string StartOfRoundSetMagnetOnPrefix = "start_of_round_set_magnet_on_prefix";
+    public const string StartOfRoundSetMagnetOnPostfix = "start_of_round_set_magnet_on_postfix";
     public const string StartOfRoundSetMagnetOnClientRpcPrefix =
-        "start_of_round.set_magnet_on_client_rpc.prefix";
+        "start_of_round_set_magnet_on_client_rpc_prefix";
     public const string StartOfRoundSetMagnetOnClientRpcPostfix =
-        "start_of_round.set_magnet_on_client_rpc.postfix";
+        "start_of_round_set_magnet_on_client_rpc_postfix";
     public const string VehicleControllerAddEngineOilClientRpcPrefix =
-        "vehicle_controller.add_engine_oil_client_rpc.prefix";
+        "vehicle_controller_add_engine_oil_client_rpc_prefix";
     public const string VehicleControllerAddEngineOilClientRpcFinalizer =
-        "vehicle_controller.add_engine_oil_client_rpc.finalizer";
+        "vehicle_controller_add_engine_oil_client_rpc_finalizer";
     public const string VehicleControllerAddEngineOilOnLocalClientPrefix =
-        "vehicle_controller.add_engine_oil_on_local_client.prefix";
+        "vehicle_controller_add_engine_oil_on_local_client_prefix";
     public const string VehicleControllerAddEngineOilOnLocalClientPostfix =
-        "vehicle_controller.add_engine_oil_on_local_client.postfix";
+        "vehicle_controller_add_engine_oil_on_local_client_postfix";
     public const string VehicleControllerAddTurboBoostClientRpcPrefix =
-        "vehicle_controller.add_turbo_boost_client_rpc.prefix";
+        "vehicle_controller_add_turbo_boost_client_rpc_prefix";
     public const string VehicleControllerAddTurboBoostClientRpcFinalizer =
-        "vehicle_controller.add_turbo_boost_client_rpc.finalizer";
+        "vehicle_controller_add_turbo_boost_client_rpc_finalizer";
     public const string VehicleControllerAddTurboBoostOnLocalClientPrefix =
-        "vehicle_controller.add_turbo_boost_on_local_client.prefix";
+        "vehicle_controller_add_turbo_boost_on_local_client_prefix";
     public const string VehicleControllerAddTurboBoostOnLocalClientPostfix =
-        "vehicle_controller.add_turbo_boost_on_local_client.postfix";
+        "vehicle_controller_add_turbo_boost_on_local_client_postfix";
 }

--- a/CruiserJumpPractice/Interop/Game/Patches/HarmonyCallbackTokens.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/HarmonyCallbackTokens.cs
@@ -5,6 +5,8 @@ namespace CruiserJumpPractice.Interop.Game.Patches;
 
 internal static class HarmonyCallbackTokens
 {
+    // Tokens are stable validation identifiers, not display text. Use
+    // class_method_patchkind naming so SDC and CJP diagnostics stay comparable.
     public const string HudManagerAwakePostfix = "hud_manager_awake_postfix";
     public const string HudManagerUpdatePostfix = "hud_manager_update_postfix";
     public const string StartOfRoundSetMagnetOnPrefix = "start_of_round_set_magnet_on_prefix";

--- a/CruiserJumpPractice/Interop/Game/Patches/HarmonyCallbackTokens.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/HarmonyCallbackTokens.cs
@@ -7,14 +7,22 @@ internal static class HarmonyCallbackTokens
 {
     // Tokens are stable validation identifiers, not display text. Use
     // class_method_patchkind naming so SDC and CJP diagnostics stay comparable.
+    // Keep tokens grouped by patched game class so new callbacks land near
+    // related patches.
+
+    // HUDManager callbacks.
     public const string HudManagerAwakePostfix = "hud_manager_awake_postfix";
     public const string HudManagerUpdatePostfix = "hud_manager_update_postfix";
+
+    // StartOfRound callbacks.
     public const string StartOfRoundSetMagnetOnPrefix = "start_of_round_set_magnet_on_prefix";
     public const string StartOfRoundSetMagnetOnPostfix = "start_of_round_set_magnet_on_postfix";
     public const string StartOfRoundSetMagnetOnClientRpcPrefix =
         "start_of_round_set_magnet_on_client_rpc_prefix";
     public const string StartOfRoundSetMagnetOnClientRpcPostfix =
         "start_of_round_set_magnet_on_client_rpc_postfix";
+
+    // VehicleController callbacks.
     public const string VehicleControllerAddEngineOilClientRpcPrefix =
         "vehicle_controller_add_engine_oil_client_rpc_prefix";
     public const string VehicleControllerAddEngineOilClientRpcFinalizer =

--- a/CruiserJumpPractice/Interop/Game/Patches/StartOfRoundPatch.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/StartOfRoundPatch.cs
@@ -11,9 +11,9 @@ namespace CruiserJumpPractice.Interop.Game.Patches;
 [HarmonyPatch(typeof(StartOfRound))]
 internal static class StartOfRoundPatch
 {
-    // SetMagnetOn is the local/originating ship-magnet apply path behind the
-    // lever flow. It is useful local-state evidence, but not receiver-side RPC
-    // receipt evidence.
+    // For the base game, SetMagnetOn applies the local/originating ship-magnet
+    // state used by the lever flow. It is not the receiver-side RPC receipt
+    // boundary.
     [HarmonyPatch(nameof(StartOfRound.SetMagnetOn), typeof(bool))]
     [HarmonyPrefix]
     public static void SetMagnetOnPrefix()
@@ -36,9 +36,8 @@ internal static class StartOfRoundPatch
         );
     }
 
-    // SetMagnetOnClientRpc is the receiver-side synchronization boundary for
-    // ship magnet state. Its Postfix is the primary receiver-side final-state
-    // observation point identified by the base-game investigation.
+    // For the base game, SetMagnetOnClientRpc applies ship-magnet state on RPC
+    // receivers. Its Postfix is the receiver-side final-state observation point.
     [HarmonyPatch(nameof(StartOfRound.SetMagnetOnClientRpc), typeof(bool))]
     [HarmonyPrefix]
     public static void SetMagnetOnClientRpcPrefix()

--- a/CruiserJumpPractice/Interop/Game/Patches/StartOfRoundPatch.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/StartOfRoundPatch.cs
@@ -3,7 +3,6 @@
 
 extern alias LethalCompany;
 
-using System;
 using HarmonyLib;
 using LethalCompany;
 
@@ -18,7 +17,8 @@ internal static class StartOfRoundPatch
     [HarmonyPrefix]
     public static void SetMagnetOnPrefix()
     {
-        TryNotifyAppliedStateValidation(
+        HarmonyCallbackGuard.TryNotifyHarmonyCallback(
+            callback: HarmonyCallbackTokens.StartOfRoundSetMagnetOnPrefix,
             notify: static () =>
                 CruiserJumpPractice.Controller.HandleBaseGameShipMagnetLocalPreApply()
         );
@@ -28,7 +28,8 @@ internal static class StartOfRoundPatch
     [HarmonyPostfix]
     public static void SetMagnetOnPostfix()
     {
-        TryNotifyAppliedStateValidation(
+        HarmonyCallbackGuard.TryNotifyHarmonyCallback(
+            callback: HarmonyCallbackTokens.StartOfRoundSetMagnetOnPostfix,
             notify: static () =>
                 CruiserJumpPractice.Controller.HandleBaseGameShipMagnetLocalApplied()
         );
@@ -38,7 +39,8 @@ internal static class StartOfRoundPatch
     [HarmonyPrefix]
     public static void SetMagnetOnClientRpcPrefix()
     {
-        TryNotifyAppliedStateValidation(
+        HarmonyCallbackGuard.TryNotifyHarmonyCallback(
+            callback: HarmonyCallbackTokens.StartOfRoundSetMagnetOnClientRpcPrefix,
             notify: static () =>
                 CruiserJumpPractice.Controller.HandleBaseGameShipMagnetClientRpcPreApply()
         );
@@ -48,21 +50,10 @@ internal static class StartOfRoundPatch
     [HarmonyPostfix]
     public static void SetMagnetOnClientRpcPostfix()
     {
-        TryNotifyAppliedStateValidation(
+        HarmonyCallbackGuard.TryNotifyHarmonyCallback(
+            callback: HarmonyCallbackTokens.StartOfRoundSetMagnetOnClientRpcPostfix,
             notify: static () =>
                 CruiserJumpPractice.Controller.HandleBaseGameShipMagnetClientRpcApplied()
         );
-    }
-
-    private static void TryNotifyAppliedStateValidation(Action notify)
-    {
-        try
-        {
-            notify();
-        }
-        catch
-        {
-            // Validation logging must never interrupt the base-game apply path.
-        }
     }
 }

--- a/CruiserJumpPractice/Interop/Game/Patches/StartOfRoundPatch.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/StartOfRoundPatch.cs
@@ -11,8 +11,9 @@ namespace CruiserJumpPractice.Interop.Game.Patches;
 [HarmonyPatch(typeof(StartOfRound))]
 internal static class StartOfRoundPatch
 {
-    // SetMagnetOn is the local apply callback behind the lever path, while
-    // SetMagnetOnClientRpc is the receiver-side synchronization boundary.
+    // SetMagnetOn is the local/originating ship-magnet apply path behind the
+    // lever flow. It is useful local-state evidence, but not receiver-side RPC
+    // receipt evidence.
     [HarmonyPatch(nameof(StartOfRound.SetMagnetOn), typeof(bool))]
     [HarmonyPrefix]
     public static void SetMagnetOnPrefix()
@@ -35,6 +36,9 @@ internal static class StartOfRoundPatch
         );
     }
 
+    // SetMagnetOnClientRpc is the receiver-side synchronization boundary for
+    // ship magnet state. Its Postfix is the primary receiver-side final-state
+    // observation point identified by the base-game investigation.
     [HarmonyPatch(nameof(StartOfRound.SetMagnetOnClientRpc), typeof(bool))]
     [HarmonyPrefix]
     public static void SetMagnetOnClientRpcPrefix()

--- a/CruiserJumpPractice/Interop/Game/Patches/VehicleControllerPatch.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/VehicleControllerPatch.cs
@@ -11,9 +11,9 @@ namespace CruiserJumpPractice.Interop.Game.Patches;
 [HarmonyPatch(typeof(VehicleController))]
 internal static class VehicleControllerPatch
 {
-    // AddEngineOilClientRpc marks the receiver-side vanilla synchronization
-    // boundary. The local apply method below is the final-state hook used after
-    // both initiating and receiver-side paths update the cruiser HP.
+    // For the base game, AddEngineOilClientRpc is the receiver-side RPC boundary
+    // for synchronized cruiser HP restoration. The local apply method below is
+    // where the HP value is applied.
     [HarmonyPatch(nameof(VehicleController.AddEngineOilClientRpc), typeof(int), typeof(int))]
     [HarmonyPrefix]
     public static void AddEngineOilClientRpcPrefix()
@@ -35,8 +35,8 @@ internal static class VehicleControllerPatch
         );
     }
 
-    // AddEngineOilOnLocalClient is the local apply point identified as the
-    // first HP final-state observation hook.
+    // For the base game, AddEngineOilOnLocalClient applies the cruiser HP value
+    // on the local client after either local or RPC-driven oil restoration.
     [HarmonyPatch(nameof(VehicleController.AddEngineOilOnLocalClient), typeof(int))]
     [HarmonyPrefix]
     public static void AddEngineOilOnLocalClientPrefix()
@@ -58,9 +58,9 @@ internal static class VehicleControllerPatch
         );
     }
 
-    // AddTurboBoostClientRpc uses the same receiver-side synchronization shape
-    // as engine oil. The applied turbo count is private, so final-state reads
-    // stay behind the adapter boundary.
+    // For the base game, AddTurboBoostClientRpc is the receiver-side RPC
+    // boundary for synchronized turbo count restoration. The applied count is
+    // stored inside VehicleController state.
     [HarmonyPatch(nameof(VehicleController.AddTurboBoostClientRpc), typeof(int), typeof(int))]
     [HarmonyPrefix]
     public static void AddTurboBoostClientRpcPrefix()
@@ -81,8 +81,8 @@ internal static class VehicleControllerPatch
         );
     }
 
-    // AddTurboBoostOnLocalClient is the local apply point identified as the
-    // first turbo-count final-state observation hook.
+    // For the base game, AddTurboBoostOnLocalClient applies the turbo count on
+    // the local client after either local or RPC-driven turbo restoration.
     [HarmonyPatch(nameof(VehicleController.AddTurboBoostOnLocalClient), typeof(int))]
     [HarmonyPrefix]
     public static void AddTurboBoostOnLocalClientPrefix()

--- a/CruiserJumpPractice/Interop/Game/Patches/VehicleControllerPatch.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/VehicleControllerPatch.cs
@@ -3,7 +3,6 @@
 
 extern alias LethalCompany;
 
-using System;
 using HarmonyLib;
 using LethalCompany;
 
@@ -18,7 +17,8 @@ internal static class VehicleControllerPatch
     [HarmonyPrefix]
     public static void AddEngineOilClientRpcPrefix()
     {
-        TryNotifyAppliedStateValidation(
+        HarmonyCallbackGuard.TryNotifyHarmonyCallback(
+            callback: HarmonyCallbackTokens.VehicleControllerAddEngineOilClientRpcPrefix,
             notify: static () =>
                 CruiserJumpPractice.Controller.HandleBaseGameEngineOilClientRpcEntered()
         );
@@ -28,7 +28,8 @@ internal static class VehicleControllerPatch
     [HarmonyFinalizer]
     public static void AddEngineOilClientRpcFinalizer()
     {
-        TryNotifyAppliedStateValidation(
+        HarmonyCallbackGuard.TryNotifyHarmonyCallback(
+            callback: HarmonyCallbackTokens.VehicleControllerAddEngineOilClientRpcFinalizer,
             notify: static () => CruiserJumpPractice.Controller.HandleBaseGameEngineOilClientRpcExited()
         );
     }
@@ -37,7 +38,8 @@ internal static class VehicleControllerPatch
     [HarmonyPrefix]
     public static void AddEngineOilOnLocalClientPrefix()
     {
-        TryNotifyAppliedStateValidation(
+        HarmonyCallbackGuard.TryNotifyHarmonyCallback(
+            callback: HarmonyCallbackTokens.VehicleControllerAddEngineOilOnLocalClientPrefix,
             notify: static () => CruiserJumpPractice.Controller.HandleBaseGameEngineOilLocalPreApply()
         );
     }
@@ -46,7 +48,8 @@ internal static class VehicleControllerPatch
     [HarmonyPostfix]
     public static void AddEngineOilOnLocalClientPostfix()
     {
-        TryNotifyAppliedStateValidation(
+        HarmonyCallbackGuard.TryNotifyHarmonyCallback(
+            callback: HarmonyCallbackTokens.VehicleControllerAddEngineOilOnLocalClientPostfix,
             notify: static () =>
                 CruiserJumpPractice.Controller.HandleBaseGameEngineOilLocalApplied()
         );
@@ -58,7 +61,8 @@ internal static class VehicleControllerPatch
     [HarmonyPrefix]
     public static void AddTurboBoostClientRpcPrefix()
     {
-        TryNotifyAppliedStateValidation(
+        HarmonyCallbackGuard.TryNotifyHarmonyCallback(
+            callback: HarmonyCallbackTokens.VehicleControllerAddTurboBoostClientRpcPrefix,
             notify: static () => CruiserJumpPractice.Controller.HandleBaseGameTurboClientRpcEntered()
         );
     }
@@ -67,7 +71,8 @@ internal static class VehicleControllerPatch
     [HarmonyFinalizer]
     public static void AddTurboBoostClientRpcFinalizer()
     {
-        TryNotifyAppliedStateValidation(
+        HarmonyCallbackGuard.TryNotifyHarmonyCallback(
+            callback: HarmonyCallbackTokens.VehicleControllerAddTurboBoostClientRpcFinalizer,
             notify: static () => CruiserJumpPractice.Controller.HandleBaseGameTurboClientRpcExited()
         );
     }
@@ -76,7 +81,8 @@ internal static class VehicleControllerPatch
     [HarmonyPrefix]
     public static void AddTurboBoostOnLocalClientPrefix()
     {
-        TryNotifyAppliedStateValidation(
+        HarmonyCallbackGuard.TryNotifyHarmonyCallback(
+            callback: HarmonyCallbackTokens.VehicleControllerAddTurboBoostOnLocalClientPrefix,
             notify: static () => CruiserJumpPractice.Controller.HandleBaseGameTurboLocalPreApply()
         );
     }
@@ -85,21 +91,10 @@ internal static class VehicleControllerPatch
     [HarmonyPostfix]
     public static void AddTurboBoostOnLocalClientPostfix()
     {
-        TryNotifyAppliedStateValidation(
+        HarmonyCallbackGuard.TryNotifyHarmonyCallback(
+            callback: HarmonyCallbackTokens.VehicleControllerAddTurboBoostOnLocalClientPostfix,
             notify: static () =>
                 CruiserJumpPractice.Controller.HandleBaseGameTurboLocalApplied()
         );
-    }
-
-    private static void TryNotifyAppliedStateValidation(Action notify)
-    {
-        try
-        {
-            notify();
-        }
-        catch
-        {
-            // Validation logging must never interrupt the base-game apply path.
-        }
     }
 }

--- a/CruiserJumpPractice/Interop/Game/Patches/VehicleControllerPatch.cs
+++ b/CruiserJumpPractice/Interop/Game/Patches/VehicleControllerPatch.cs
@@ -11,8 +11,9 @@ namespace CruiserJumpPractice.Interop.Game.Patches;
 [HarmonyPatch(typeof(VehicleController))]
 internal static class VehicleControllerPatch
 {
-    // The local apply method is also used by the host restore path, so the ClientRpc wrapper
-    // marks only receiver-side vanilla synchronization before the shared local helper runs.
+    // AddEngineOilClientRpc marks the receiver-side vanilla synchronization
+    // boundary. The local apply method below is the final-state hook used after
+    // both initiating and receiver-side paths update the cruiser HP.
     [HarmonyPatch(nameof(VehicleController.AddEngineOilClientRpc), typeof(int), typeof(int))]
     [HarmonyPrefix]
     public static void AddEngineOilClientRpcPrefix()
@@ -34,6 +35,8 @@ internal static class VehicleControllerPatch
         );
     }
 
+    // AddEngineOilOnLocalClient is the local apply point identified as the
+    // first HP final-state observation hook.
     [HarmonyPatch(nameof(VehicleController.AddEngineOilOnLocalClient), typeof(int))]
     [HarmonyPrefix]
     public static void AddEngineOilOnLocalClientPrefix()
@@ -55,8 +58,9 @@ internal static class VehicleControllerPatch
         );
     }
 
-    // Turbo uses the same ClientRpc/local-apply split as engine oil, but the applied value is
-    // private in VehicleController and has to be read through the adapter boundary.
+    // AddTurboBoostClientRpc uses the same receiver-side synchronization shape
+    // as engine oil. The applied turbo count is private, so final-state reads
+    // stay behind the adapter boundary.
     [HarmonyPatch(nameof(VehicleController.AddTurboBoostClientRpc), typeof(int), typeof(int))]
     [HarmonyPrefix]
     public static void AddTurboBoostClientRpcPrefix()
@@ -77,6 +81,8 @@ internal static class VehicleControllerPatch
         );
     }
 
+    // AddTurboBoostOnLocalClient is the local apply point identified as the
+    // first turbo-count final-state observation hook.
     [HarmonyPatch(nameof(VehicleController.AddTurboBoostOnLocalClient), typeof(int))]
     [HarmonyPrefix]
     public static void AddTurboBoostOnLocalClientPrefix()

--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ Enabled validation records use one JSON object per log line after the stable
 help. Share full BepInEx logs only when needed, because other mods or BepInEx
 can include unrelated local environment details.
 
+Harmony callback failures that are intentionally swallowed may emit
+`callback_exception` validation records. These records include only the stable
+callback token and exception type.
+
 ### r2modman
 
 1. Open [r2modman][r2modman-package].


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Add a shared `HarmonyCallbackGuard` for Harmony patch callbacks, with `Action` and result-returning overloads.
- Record swallowed Harmony callback failures through `HarmonyCallbackDiagnosticReporter` with stable `HarmonyCallbackTokens` and compact `callback_exception` validation records.
- Keep `PluginController` as the workflow facade while configuring callback diagnostic policy from plugin startup before Harmony patches are installed.
- Align the guard, reporter, token, patch-call, and intent-comment shape with aoirint/SkipDropshipCompany#38.

## Related Issues

- Closes #119
- Refs aoirint/SkipDropshipCompany#37
- Refs aoirint/SkipDropshipCompany#36

## Notes for reviewers

- This PR is part of the shared SDC/CJP Harmony callback guard design.
- This PR is paired with aoirint/SkipDropshipCompany#38 so both repositories use the same callback boundary model.
- `PluginController` remains a workflow facade; callback diagnostic policy lives in `HarmonyCallbackDiagnosticReporter`, and fail-open callback boundaries live in `HarmonyCallbackGuard`.
- Structured `callback_exception` records include only `callback` and `exception_type`; raw exception messages, stack traces, Unity objects, local paths, player identifiers, and lobby identifiers are not recorded.
- Callback tokens are stable validation identifiers, not display text, and use `class_method_patchkind` naming so SDC and CJP diagnostics stay comparable.
- CJP-specific migration: patch-local `TryNotifyAppliedStateValidation` helpers were replaced so applied-state validation and HUD lifecycle callbacks use the same guard boundary.

### AI disclosure

This PR was implemented with significant Codex assistance. AI-assisted work included issue/PR context review, implementation, local verification, PR text drafting, requested blank-slate pre-PR inspection, and later SDC/CJP design alignment checks. The resulting diff and PR text were reviewed before submission.

### Pre-PR review record

- Finding: Harmony patch callbacks need a shared fail-open boundary.
  - Action: routed current patch callback notifications through `HarmonyCallbackGuard`.
- Finding: callback diagnostic recording must not turn a swallowed callback exception into a base-game failure.
  - Action: kept diagnostic reporter failures swallowed inside the guard after recording is attempted.
- Finding: `PluginController` should not own callback diagnostic policy.
  - Action: moved callback diagnostic policy into `HarmonyCallbackDiagnosticReporter` and configured it through `HarmonyCallbackGuard`.
- Finding: structured validation diagnostics must avoid environment-sensitive exception details.
  - Action: limited `callback_exception` records to `callback` and `exception_type`.
- Finding: SDC and CJP guard designs must remain comparable.
  - Action: aligned guard configuration, reporter naming, callback token conventions, patch-call style, and explanatory comments with aoirint/SkipDropshipCompany#38.
- Finding: CJP had patch-local applied-state validation swallow helpers.
  - Action: removed `TryNotifyAppliedStateValidation` helpers and routed those callbacks through the shared guard.

## Testing

### Automated checks

- Passed: `dotnet build`
- Passed: `dotnet format --no-restore --verify-no-changes`
- Passed: `git diff --check`
- Passed before latest comment-only alignment: `docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5`

### AI-assisted inspections

Request: Perform a blank-slate review of the callback guard implementation before opening the PR.

AI-assisted result: Confirmed all current CJP Harmony patch callback paths that delegate to `PluginController` use `HarmonyCallbackGuard`, no patch-local `TryNotifyAppliedStateValidation` helpers remain, diagnostic recording failures are swallowed inside the guard, and structured callback exception records contain only callback and exception type fields.

Request: Compare the SDC and CJP guard/reporter designs after both PRs were opened.

AI-assisted result: Found and fixed structure, naming, token, call-site, and explanatory-comment differences. Remaining differences are domain-specific callback tokens, patched method sets, and the SDC-only Terminal `ref` mutation boundary.

### Manual checks

- Not run - no in-game runtime smoke test was performed in this environment.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
