### PR TITLE
docs: clarify markdownlint-cli2 setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,10 @@ docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markd
 DOTNET_CLI_UI_LANGUAGE=en dotnet build
 ```
 
+The Docker command is the documented pinned Markdown lint path, but Docker is
+not required. Another `markdownlint-cli2` installation method is acceptable when
+it uses the repository configuration.
+
 On Linux, run the Markdown lint command with `sudo docker` and use
 `--user "$(id -u):$(id -g)"`.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Install [PowerShell 7][powershell-install].
 
 Install [Visual Studio 2022][visual-studio-download].
 
-Install [Docker][docker-install] for local Markdown linting.
+Install [Docker][docker-install] if you plan to use the documented local
+Markdown lint command.
 
 Restore NuGet packages.
 
@@ -46,10 +47,14 @@ including diagnostics that cannot be automatically fixed.
 
 ### Markdown lint
 
-Markdown is checked with `markdownlint-cli2`. The project uses the pinned Docker
-image below so contributors do not need a local Node.js project.
+Markdown is checked with
+[`markdownlint-cli2`][markdownlint-cli2-repo].
+The pinned Docker image below is the documented local command so contributors do
+not need a local Node.js project, but Docker is not required.
+Other installation methods are acceptable when they run the same
+`markdownlint-cli2` version with this repository's configuration.
 The image's default working directory is `/workdir`, so mount the repository
-there. Run it without network access and as a non-root user.
+there. Run the Docker command without network access and as a non-root user.
 
 On Windows with PowerShell, use UID/GID `1000:1000`:
 
@@ -63,7 +68,7 @@ On Linux, use `sudo docker` and pass the host user's UID and GID:
 sudo docker run --rm --network none --user "$(id -u):$(id -g)" -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5
 ```
 
-When updating Markdown lint tooling, update both the local Docker image and the
+When updating Markdown lint tooling, update the documented local command and the
 CI action together after the repository cooldown period has elapsed.
 
 ## Package management
@@ -299,6 +304,7 @@ This disclosure is made in compliance with Thunderstore and community policies.
 [dotnet-sdk-download]: https://dotnet.microsoft.com/en-us/download/dotnet/10.0
 [github-actions-docs]: https://docs.github.com/en/actions
 [lethal-company-steam]: https://store.steampowered.com/app/1966720/Lethal_Company/
+[markdownlint-cli2-repo]: https://github.com/DavidAnson/markdownlint-cli2
 [powershell-install]: https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows
 [r2modman-package]: https://thunderstore.io/c/lethal-company/p/ebkr/r2modman/
 [thunderstore-lethal-company-community]: https://thunderstore.io/c/lethal-company/


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Clarifies that Docker is the documented pinned local Markdown lint path, not the only acceptable way to run `markdownlint-cli2`.
- Links `markdownlint-cli2` to its upstream distribution repository at <https://github.com/DavidAnson/markdownlint-cli2>.
- Updates contributor verification guidance so alternate `markdownlint-cli2` installations remain acceptable when they use this repository's configuration.

## Related Issues

None

## Notes for reviewers

This is documentation-only. The Docker command remains the pinned reproducible example.

### AI disclosure

Codex drafted the documentation wording, checked the rendered Markdown structure, and prepared this pull request body. The maintainer should review the final wording and upstream link.

## Testing

### Automated checks

- `docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5` - passed, 0 errors.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
