### PR TITLE
ci: add GitHub Actions quality checks

### DIFF
--- a/.agents/skills/github-actions-quality-check/SKILL.md
+++ b/.agents/skills/github-actions-quality-check/SKILL.md
@@ -48,8 +48,9 @@ description: >-
    repository's documented command; when optional integrations would add
    dependencies, disable them explicitly and note the reduced scope. Revisit
    pyflakes disablement when Python scripts exist in the repository.
-7. Run ShellCheck for standalone shell scripts and keep actionlint's ShellCheck
-   integration enabled when the repository installs ShellCheck.
+7. Run ShellCheck for standalone shell scripts discovered in the changed
+   automation scope, and keep actionlint's ShellCheck integration enabled when
+   the repository installs ShellCheck.
 8. Run pinact in check mode for action and reusable-workflow pins. Use
    `GITHUB_TOKEN` when available so API calls use authenticated rate limits.
 9. For new or updated external actions, downloaded tools, or containers, apply
@@ -63,13 +64,21 @@ description: >-
 
 ## Command Examples
 
-Use these examples only when they match the repository's documented tooling:
+Use these examples only when they match the repository's documented tooling.
+Discover shell files from the current repository instead of copying a
+repository-specific path from this skill.
 
 ```bash
 actionlint -pyflakes=
-shellcheck .github/actions/publish-thunderstore/publish-thunderstore.sh
+mapfile -t shell_files < <(rg --files -g '*.sh' -g '*.bash' .github)
+if ((${#shell_files[@]})); then
+  shellcheck "${shell_files[@]}"
+fi
 pinact run --check --min-age 7
 ```
+
+If no shell files are present, rely on actionlint's inline script checks and
+record that the standalone ShellCheck pass had no targets.
 
 When updating action pins, keep the cooldown in the command:
 

--- a/.agents/skills/github-actions-quality-check/SKILL.md
+++ b/.agents/skills/github-actions-quality-check/SKILL.md
@@ -1,0 +1,68 @@
+---
+# SPDX-License-Identifier: MIT
+name: github-actions-quality-check
+description: >-
+  Quality-check GitHub Actions workflows, composite actions, action pinning,
+  runner labels, permissions, triggers, concurrency, secrets, and CI linting
+  changes. Use when creating, editing, reviewing, or documenting GitHub Actions
+  automation.
+---
+
+# GitHub Actions Quality Check
+
+## When to Use
+
+- Use this skill when work touches `.github/workflows/`, `.github/actions/`,
+  action pinning, runner labels, workflow permissions, triggers, concurrency,
+  repository variables, repository secrets, or CI linting policy.
+- Use it with `security-check` for third-party actions, downloaded tools,
+  secrets, tokens, permissions, publishing, containers, or other supply-chain
+  sensitive changes.
+- Use `document-quality-check` when updating contributor-facing workflow
+  guidance or pull request notes.
+
+## Goals
+
+- Keep workflows readable, deterministic, least-privilege, and reviewable.
+- Catch workflow syntax, expression, runner-label, and composite-action metadata
+  mistakes before CI runs.
+- Keep third-party actions and reusable workflows pinned to full commit SHAs
+  with accurate version comments.
+- Prefer checks that do not add unnecessary runtime dependencies.
+- Record verification clearly, including any local/CI difference.
+
+## Workflow
+
+1. Inspect the changed workflow or action files and the repository guidance that
+   documents them.
+2. Check triggers, branch filters, merge queue behavior, and `workflow_dispatch`
+   coverage against the intended repository responsibility.
+3. Check `permissions` at workflow and job scope. Prefer `contents: read` unless
+   a job needs broader access, and document any write permission.
+4. Check concurrency groups and cancellation rules for PRs, pushes, releases,
+   merge queues, and publishing jobs.
+5. Check runner labels and local composite actions. Add or update
+   `.github/actionlint.yaml` only for deliberate labels or variables that
+   actionlint cannot infer.
+6. Run actionlint for workflow and action metadata validation. Match the
+   repository's documented command; when optional integrations would add
+   dependencies, disable them explicitly and note the reduced scope.
+7. Run pinact in check mode for action and reusable-workflow pins. Use
+   `GITHUB_TOKEN` when available so API calls use authenticated rate limits.
+8. For new or updated external actions, downloaded tools, or containers, apply
+   `security-check`: verify release age, provenance, pinning, permissions, and
+   runtime behavior before adopting the artifact.
+9. Re-read comments near non-obvious versions, runner choices, cache paths,
+   suppressions, and install commands. Keep comments specific and actionable.
+10. Summarize verification by category: actionlint, pinact, other automated
+    checks, AI-assisted inspection, and any skipped checks with concrete
+    blockers.
+
+## Review Checklist
+
+- Workflow syntax and expressions were checked with actionlint.
+- Third-party actions and reusable workflows were checked with pinact.
+- New executable artifacts satisfy the repository cooldown and pinning policy.
+- Permissions and secrets are least-privilege and documented when unusual.
+- Runner labels, variables, and suppressions are configured intentionally.
+- Local documentation and CI behavior describe the same quality checks.

--- a/.agents/skills/github-actions-quality-check/SKILL.md
+++ b/.agents/skills/github-actions-quality-check/SKILL.md
@@ -47,23 +47,26 @@ description: >-
 6. Run actionlint for workflow and action metadata validation. Match the
    repository's documented command; when optional integrations would add
    dependencies, disable them explicitly and note the reduced scope.
-7. Run pinact in check mode for action and reusable-workflow pins. Use
+7. Run ShellCheck for standalone shell scripts and keep actionlint's ShellCheck
+   integration enabled when the repository installs ShellCheck.
+8. Run pinact in check mode for action and reusable-workflow pins. Use
    `GITHUB_TOKEN` when available so API calls use authenticated rate limits.
-8. For new or updated external actions, downloaded tools, or containers, apply
+9. For new or updated external actions, downloaded tools, or containers, apply
    `security-check`: verify release age, provenance, pinning, permissions, and
    runtime behavior before adopting the artifact.
-9. Re-read comments near non-obvious versions, runner choices, cache paths,
+10. Re-read comments near non-obvious versions, runner choices, cache paths,
    suppressions, and install commands. Keep comments specific and actionable.
-10. Summarize verification by category: actionlint, pinact, other automated
-    checks, AI-assisted inspection, and any skipped checks with concrete
-    blockers.
+11. Summarize verification by category: actionlint, ShellCheck, pinact, other
+    automated checks, AI-assisted inspection, and any skipped checks with
+    concrete blockers.
 
 ## Command Examples
 
 Use these examples only when they match the repository's documented tooling:
 
 ```bash
-actionlint -shellcheck= -pyflakes=
+actionlint -pyflakes=
+shellcheck .github/actions/publish-thunderstore/publish-thunderstore.sh
 pinact run --check --min-age 7
 ```
 
@@ -76,6 +79,8 @@ pinact run --update --min-age 7
 ## Review Checklist
 
 - Workflow syntax and expressions were checked with actionlint.
+- Inline workflow shell scripts and standalone shell scripts were checked with
+  ShellCheck.
 - Third-party actions and reusable workflows were checked with pinact.
 - New executable artifacts satisfy the repository cooldown and pinning policy.
 - Permissions and secrets are least-privilege and documented when unusual.

--- a/.agents/skills/github-actions-quality-check/SKILL.md
+++ b/.agents/skills/github-actions-quality-check/SKILL.md
@@ -46,7 +46,8 @@ description: >-
    actionlint cannot infer.
 6. Run actionlint for workflow and action metadata validation. Match the
    repository's documented command; when optional integrations would add
-   dependencies, disable them explicitly and note the reduced scope.
+   dependencies, disable them explicitly and note the reduced scope. Revisit
+   pyflakes disablement when Python scripts exist in the repository.
 7. Run ShellCheck for standalone shell scripts and keep actionlint's ShellCheck
    integration enabled when the repository installs ShellCheck.
 8. Run pinact in check mode for action and reusable-workflow pins. Use

--- a/.agents/skills/github-actions-quality-check/SKILL.md
+++ b/.agents/skills/github-actions-quality-check/SKILL.md
@@ -58,6 +58,21 @@ description: >-
     checks, AI-assisted inspection, and any skipped checks with concrete
     blockers.
 
+## Command Examples
+
+Use these examples only when they match the repository's documented tooling:
+
+```bash
+actionlint -shellcheck= -pyflakes=
+pinact run --check --min-age 7
+```
+
+When updating action pins, keep the cooldown in the command:
+
+```bash
+pinact run --update --min-age 7
+```
+
 ## Review Checklist
 
 - Workflow syntax and expressions were checked with actionlint.

--- a/.agents/skills/github-actions-quality-check/agents/openai.yaml
+++ b/.agents/skills/github-actions-quality-check/agents/openai.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+interface:
+  display_name: "GitHub Actions Quality Check"
+  short_description: "Quality-check GitHub Actions workflows, pins, permissions, and CI linting."
+  default_prompt: >-
+    Quality-check this GitHub Actions change for workflow syntax, action
+    pinning, permissions, runner labels, triggers, concurrency, secrets, and
+    verification coverage.

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: MIT
-self-hosted-runner:
-  # GitHub-hosted ubuntu-slim is not in actionlint v1.7.12's built-in runner
-  # label list yet. Keep this explicit until actionlint recognizes the label.
-  labels:
-    - ubuntu-slim

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+self-hosted-runner:
+  # GitHub-hosted ubuntu-slim is not in actionlint v1.7.12's built-in runner
+  # label list yet. Keep this explicit until actionlint recognizes the label.
+  labels:
+    - ubuntu-slim

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,10 +27,10 @@ permissions:
 # Keep each tool version directly beside its archive SHA256. They are reviewed
 # and updated as one supply-chain-sensitive pair.
 env:
-  ACTIONLINT_VERSION: 1.7.12
-  ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
   SHELLCHECK_VERSION: 0.11.0
   SHELLCHECK_SHA256: b7af85e41cc99489dcc21d66c6d5f3685138f06d34651e6d34b42ec6d54fe6f6
+  ACTIONLINT_VERSION: 1.7.12
+  ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
   PINACT_VERSION: 3.9.2
   PINACT_SHA256: 6adcc8a2217e4114e0841f8bca0cddf9958a9c52e3e89760c35b791cdba1a916
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,12 @@ defaults:
 permissions:
   contents: read
 
+env:
+  ACTIONLINT_VERSION: 1.7.12
+  ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+  PINACT_VERSION: 3.9.2
+  PINACT_SHA256: 6adcc8a2217e4114e0841f8bca0cddf9958a9c52e3e89760c35b791cdba1a916
+
 jobs:
   lint:
     # Keep this hard-coded to ubuntu-slim while lint steps only need GitHub
@@ -36,28 +42,24 @@ jobs:
       # and Markdown lint read repository-local configuration and source files.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Cache GitHub Actions lint tools
-        # Cache the verified release binaries by tool version. Cache misses
-        # still download fixed archives and validate their SHA256 values.
+      - name: Cache actionlint
+        # Cache the verified release binary by tool version. Cache misses still
+        # download the fixed archive and validate its SHA256 value.
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: |
-            ${{ runner.tool_cache }}/actionlint/1.7.12/linux-amd64
-            ${{ runner.tool_cache }}/pinact/3.9.2/linux-amd64
-          key: gha-lint-tools-${{ runner.os }}-actionlint-1.7.12-pinact-3.9.2
+          path: ${{ runner.tool_cache }}/actionlint/${{ env.ACTIONLINT_VERSION }}/linux-amd64
+          key: actionlint-${{ runner.os }}-${{ runner.arch }}-${{ env.ACTIONLINT_VERSION }}
 
       - name: Install actionlint
         run: |
-          version=1.7.12
-          sha256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
-          archive="actionlint_${version}_linux_amd64.tar.gz"
-          url="https://github.com/rhysd/actionlint/releases/download/v${version}/${archive}"
-          tool_dir="${RUNNER_TOOL_CACHE}/actionlint/${version}/linux-amd64"
+          archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}"
+          tool_dir="${RUNNER_TOOL_CACHE}/actionlint/${ACTIONLINT_VERSION}/linux-amd64"
 
           if [[ ! -x "${tool_dir}/actionlint" ]]; then
             mkdir -p "${tool_dir}"
             curl -fsSLo "${RUNNER_TEMP}/${archive}" "${url}"
-            echo "${sha256}  ${RUNNER_TEMP}/${archive}" | sha256sum -c -
+            echo "${ACTIONLINT_SHA256}  ${RUNNER_TEMP}/${archive}" | sha256sum -c -
             tar -xzf "${RUNNER_TEMP}/${archive}" -C "${tool_dir}" actionlint
           fi
 
@@ -68,18 +70,24 @@ jobs:
         # single-binary workflow syntax and expression validation path.
         run: actionlint -color -shellcheck= -pyflakes=
 
+      - name: Cache pinact
+        # Cache the verified release binary by tool version. Cache misses still
+        # download the fixed archive and validate its SHA256 value.
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.tool_cache }}/pinact/${{ env.PINACT_VERSION }}/linux-amd64
+          key: pinact-${{ runner.os }}-${{ runner.arch }}-${{ env.PINACT_VERSION }}
+
       - name: Install pinact
         run: |
-          version=3.9.2
-          sha256="6adcc8a2217e4114e0841f8bca0cddf9958a9c52e3e89760c35b791cdba1a916"
           archive="pinact_linux_amd64.tar.gz"
-          url="https://github.com/suzuki-shunsuke/pinact/releases/download/v${version}/${archive}"
-          tool_dir="${RUNNER_TOOL_CACHE}/pinact/${version}/linux-amd64"
+          url="https://github.com/suzuki-shunsuke/pinact/releases/download/v${PINACT_VERSION}/${archive}"
+          tool_dir="${RUNNER_TOOL_CACHE}/pinact/${PINACT_VERSION}/linux-amd64"
 
           if [[ ! -x "${tool_dir}/pinact" ]]; then
             mkdir -p "${tool_dir}"
             curl -fsSLo "${RUNNER_TEMP}/${archive}" "${url}"
-            echo "${sha256}  ${RUNNER_TEMP}/${archive}" | sha256sum -c -
+            echo "${PINACT_SHA256}  ${RUNNER_TEMP}/${archive}" | sha256sum -c -
             tar -xzf "${RUNNER_TEMP}/${archive}" -C "${tool_dir}" pinact
           fi
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,18 +36,32 @@ jobs:
       # and Markdown lint read repository-local configuration and source files.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Cache GitHub Actions lint tools
+        # Cache the verified release binaries by tool version. Cache misses
+        # still download fixed archives and validate their SHA256 values.
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ${{ runner.tool_cache }}/actionlint/1.7.12/linux-amd64
+            ${{ runner.tool_cache }}/pinact/3.9.2/linux-amd64
+          key: gha-lint-tools-${{ runner.os }}-actionlint-1.7.12-pinact-3.9.2
+
       - name: Install actionlint
         run: |
           version=1.7.12
+          sha256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
           archive="actionlint_${version}_linux_amd64.tar.gz"
           url="https://github.com/rhysd/actionlint/releases/download/v${version}/${archive}"
-          sha256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+          tool_dir="${RUNNER_TOOL_CACHE}/actionlint/${version}/linux-amd64"
 
-          mkdir -p "${RUNNER_TEMP}/actionlint"
-          curl -fsSLo "${RUNNER_TEMP}/${archive}" "${url}"
-          echo "${sha256}  ${RUNNER_TEMP}/${archive}" | sha256sum -c -
-          tar -xzf "${RUNNER_TEMP}/${archive}" -C "${RUNNER_TEMP}/actionlint" actionlint
-          echo "${RUNNER_TEMP}/actionlint" >> "${GITHUB_PATH}"
+          if [[ ! -x "${tool_dir}/actionlint" ]]; then
+            mkdir -p "${tool_dir}"
+            curl -fsSLo "${RUNNER_TEMP}/${archive}" "${url}"
+            echo "${sha256}  ${RUNNER_TEMP}/${archive}" | sha256sum -c -
+            tar -xzf "${RUNNER_TEMP}/${archive}" -C "${tool_dir}" actionlint
+          fi
+
+          echo "${tool_dir}" >> "${GITHUB_PATH}"
 
       - name: Run actionlint
         # Disable optional external integrations so the check remains a
@@ -57,15 +71,19 @@ jobs:
       - name: Install pinact
         run: |
           version=3.9.2
+          sha256="6adcc8a2217e4114e0841f8bca0cddf9958a9c52e3e89760c35b791cdba1a916"
           archive="pinact_linux_amd64.tar.gz"
           url="https://github.com/suzuki-shunsuke/pinact/releases/download/v${version}/${archive}"
-          sha256="6adcc8a2217e4114e0841f8bca0cddf9958a9c52e3e89760c35b791cdba1a916"
+          tool_dir="${RUNNER_TOOL_CACHE}/pinact/${version}/linux-amd64"
 
-          mkdir -p "${RUNNER_TEMP}/pinact"
-          curl -fsSLo "${RUNNER_TEMP}/${archive}" "${url}"
-          echo "${sha256}  ${RUNNER_TEMP}/${archive}" | sha256sum -c -
-          tar -xzf "${RUNNER_TEMP}/${archive}" -C "${RUNNER_TEMP}/pinact" pinact
-          echo "${RUNNER_TEMP}/pinact" >> "${GITHUB_PATH}"
+          if [[ ! -x "${tool_dir}/pinact" ]]; then
+            mkdir -p "${tool_dir}"
+            curl -fsSLo "${RUNNER_TEMP}/${archive}" "${url}"
+            echo "${sha256}  ${RUNNER_TEMP}/${archive}" | sha256sum -c -
+            tar -xzf "${RUNNER_TEMP}/${archive}" -C "${tool_dir}" pinact
+          fi
+
+          echo "${tool_dir}" >> "${GITHUB_PATH}"
 
       - name: Run pinact
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Run pinact
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: pinact run --check
+        run: pinact run --check --min-age 7
 
       - name: Setup .NET
         # Keep dotnet-version aligned with build.yml per the README .NET and

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     # Keep this hard-coded to ubuntu-slim while lint steps only need GitHub
@@ -32,6 +35,42 @@ jobs:
       # Checkout is required before every lint check because both dotnet format
       # and Markdown lint read repository-local configuration and source files.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install actionlint
+        run: |
+          version=1.7.12
+          archive="actionlint_${version}_linux_amd64.tar.gz"
+          url="https://github.com/rhysd/actionlint/releases/download/v${version}/${archive}"
+          sha256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+
+          mkdir -p "${RUNNER_TEMP}/actionlint"
+          curl -fsSLo "${RUNNER_TEMP}/${archive}" "${url}"
+          echo "${sha256}  ${RUNNER_TEMP}/${archive}" | sha256sum -c -
+          tar -xzf "${RUNNER_TEMP}/${archive}" -C "${RUNNER_TEMP}/actionlint" actionlint
+          echo "${RUNNER_TEMP}/actionlint" >> "${GITHUB_PATH}"
+
+      - name: Run actionlint
+        # Disable optional external integrations so the check remains a
+        # single-binary workflow syntax and expression validation path.
+        run: actionlint -color -shellcheck= -pyflakes=
+
+      - name: Install pinact
+        run: |
+          version=3.9.2
+          archive="pinact_linux_amd64.tar.gz"
+          url="https://github.com/suzuki-shunsuke/pinact/releases/download/v${version}/${archive}"
+          sha256="6adcc8a2217e4114e0841f8bca0cddf9958a9c52e3e89760c35b791cdba1a916"
+
+          mkdir -p "${RUNNER_TEMP}/pinact"
+          curl -fsSLo "${RUNNER_TEMP}/${archive}" "${url}"
+          echo "${sha256}  ${RUNNER_TEMP}/${archive}" | sha256sum -c -
+          tar -xzf "${RUNNER_TEMP}/${archive}" -C "${RUNNER_TEMP}/pinact" pinact
+          echo "${RUNNER_TEMP}/pinact" >> "${GITHUB_PATH}"
+
+      - name: Run pinact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pinact run --check
 
       - name: Setup .NET
         # Keep dotnet-version aligned with build.yml per the README .NET and

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,9 +36,8 @@ env:
 
 jobs:
   lint:
-    # Keep this hard-coded to ubuntu-slim while lint steps only need GitHub
-    # Actions, .NET, and standard shell tooling. Revisit this runner if a future
-    # lint tool requires packages that are only available on ubuntu-latest.
+    # The lint job installs its external tools explicitly, so it can run on the
+    # smaller hosted runner image without relying on ubuntu-latest's toolset.
     runs-on: ubuntu-slim
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,26 +43,42 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Cache actionlint
-        # Cache the verified release binary by tool version. Cache misses still
-        # download the fixed archive and validate its SHA256 value.
+        # Cache only the release archive. The install step verifies SHA256 on
+        # every run before extracting an executable into RUNNER_TEMP.
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: ${{ runner.tool_cache }}/actionlint/${{ env.ACTIONLINT_VERSION }}/linux-amd64
-          key: actionlint-${{ runner.os }}-${{ runner.arch }}-${{ env.ACTIONLINT_VERSION }}
+          path: ${{ runner.tool_cache }}/actionlint-archives/${{ env.ACTIONLINT_VERSION }}/linux-amd64
+          key: actionlint-${{ runner.os }}-${{ runner.arch }}-${{ env.ACTIONLINT_VERSION }}-${{ env.ACTIONLINT_SHA256 }}
 
       - name: Install actionlint
         run: |
           archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}"
-          tool_dir="${RUNNER_TOOL_CACHE}/actionlint/${ACTIONLINT_VERSION}/linux-amd64"
+          archive_dir="${RUNNER_TOOL_CACHE}/actionlint-archives/${ACTIONLINT_VERSION}/linux-amd64"
+          archive_path="${archive_dir}/${archive}"
+          tool_dir="${RUNNER_TEMP}/actionlint"
 
-          if [[ ! -x "${tool_dir}/actionlint" ]]; then
-            mkdir -p "${tool_dir}"
-            curl -fsSLo "${RUNNER_TEMP}/${archive}" "${url}"
-            echo "${ACTIONLINT_SHA256}  ${RUNNER_TEMP}/${archive}" | sha256sum -c -
-            tar -xzf "${RUNNER_TEMP}/${archive}" -C "${tool_dir}" actionlint
+          download_archive() {
+            curl --fail --silent --show-error --location --retry 3 --retry-delay 2 \
+              --retry-connrefused --output "${archive_path}" "${url}"
+          }
+
+          verify_archive() {
+            echo "${ACTIONLINT_SHA256}  ${archive_path}" | sha256sum -c -
+          }
+
+          mkdir -p "${archive_dir}" "${tool_dir}"
+          if [[ ! -f "${archive_path}" ]]; then
+            download_archive
           fi
 
+          if ! verify_archive; then
+            rm -f "${archive_path}"
+            download_archive
+            verify_archive
+          fi
+
+          tar -xzf "${archive_path}" -C "${tool_dir}" actionlint
           echo "${tool_dir}" >> "${GITHUB_PATH}"
 
       - name: Run actionlint
@@ -71,26 +87,42 @@ jobs:
         run: actionlint -color -shellcheck= -pyflakes=
 
       - name: Cache pinact
-        # Cache the verified release binary by tool version. Cache misses still
-        # download the fixed archive and validate its SHA256 value.
+        # Cache only the release archive. The install step verifies SHA256 on
+        # every run before extracting an executable into RUNNER_TEMP.
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: ${{ runner.tool_cache }}/pinact/${{ env.PINACT_VERSION }}/linux-amd64
-          key: pinact-${{ runner.os }}-${{ runner.arch }}-${{ env.PINACT_VERSION }}
+          path: ${{ runner.tool_cache }}/pinact-archives/${{ env.PINACT_VERSION }}/linux-amd64
+          key: pinact-${{ runner.os }}-${{ runner.arch }}-${{ env.PINACT_VERSION }}-${{ env.PINACT_SHA256 }}
 
       - name: Install pinact
         run: |
           archive="pinact_linux_amd64.tar.gz"
           url="https://github.com/suzuki-shunsuke/pinact/releases/download/v${PINACT_VERSION}/${archive}"
-          tool_dir="${RUNNER_TOOL_CACHE}/pinact/${PINACT_VERSION}/linux-amd64"
+          archive_dir="${RUNNER_TOOL_CACHE}/pinact-archives/${PINACT_VERSION}/linux-amd64"
+          archive_path="${archive_dir}/${archive}"
+          tool_dir="${RUNNER_TEMP}/pinact"
 
-          if [[ ! -x "${tool_dir}/pinact" ]]; then
-            mkdir -p "${tool_dir}"
-            curl -fsSLo "${RUNNER_TEMP}/${archive}" "${url}"
-            echo "${PINACT_SHA256}  ${RUNNER_TEMP}/${archive}" | sha256sum -c -
-            tar -xzf "${RUNNER_TEMP}/${archive}" -C "${tool_dir}" pinact
+          download_archive() {
+            curl --fail --silent --show-error --location --retry 3 --retry-delay 2 \
+              --retry-connrefused --output "${archive_path}" "${url}"
+          }
+
+          verify_archive() {
+            echo "${PINACT_SHA256}  ${archive_path}" | sha256sum -c -
+          }
+
+          mkdir -p "${archive_dir}" "${tool_dir}"
+          if [[ ! -f "${archive_path}" ]]; then
+            download_archive
           fi
 
+          if ! verify_archive; then
+            rm -f "${archive_path}"
+            download_archive
+            verify_archive
+          fi
+
+          tar -xzf "${archive_path}" -C "${tool_dir}" pinact
           echo "${tool_dir}" >> "${GITHUB_PATH}"
 
       - name: Run pinact

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -127,8 +127,8 @@ jobs:
 
       - name: Run actionlint
         # ShellCheck is installed above so actionlint can inspect inline
-        # workflow scripts. Keep pyflakes disabled until this repository has
-        # Python workflow scripts that justify another lint runtime.
+        # workflow scripts. No Python files are currently in this repository;
+        # revisit the pyflakes disablement when Python scripts are added.
         run: actionlint -color -pyflakes=
 
       - name: Run ShellCheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,9 +24,13 @@ defaults:
 permissions:
   contents: read
 
+# Keep each tool version directly beside its archive SHA256. They are reviewed
+# and updated as one supply-chain-sensitive pair.
 env:
   ACTIONLINT_VERSION: 1.7.12
   ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+  SHELLCHECK_VERSION: 0.11.0
+  SHELLCHECK_SHA256: b7af85e41cc99489dcc21d66c6d5f3685138f06d34651e6d34b42ec6d54fe6f6
   PINACT_VERSION: 3.9.2
   PINACT_SHA256: 6adcc8a2217e4114e0841f8bca0cddf9958a9c52e3e89760c35b791cdba1a916
 
@@ -41,6 +45,46 @@ jobs:
       # Checkout is required before every lint check because both dotnet format
       # and Markdown lint read repository-local configuration and source files.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Cache ShellCheck
+        # Cache only the release archive. The install step verifies SHA256 on
+        # every run before extracting an executable into RUNNER_TEMP.
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.tool_cache }}/shellcheck-archives/${{ env.SHELLCHECK_VERSION }}/linux-x86_64
+          key: shellcheck-${{ runner.os }}-${{ runner.arch }}-${{ env.SHELLCHECK_VERSION }}-${{ env.SHELLCHECK_SHA256 }}
+
+      - name: Install ShellCheck
+        run: |
+          archive="shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.gz"
+          url="https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/${archive}"
+          archive_dir="${RUNNER_TOOL_CACHE}/shellcheck-archives/${SHELLCHECK_VERSION}/linux-x86_64"
+          archive_path="${archive_dir}/${archive}"
+          tool_dir="${RUNNER_TEMP}/shellcheck"
+
+          download_archive() {
+            curl --fail --silent --show-error --location --retry 3 --retry-delay 2 \
+              --retry-connrefused --output "${archive_path}" "${url}"
+          }
+
+          verify_archive() {
+            echo "${SHELLCHECK_SHA256}  ${archive_path}" | sha256sum -c -
+          }
+
+          mkdir -p "${archive_dir}" "${tool_dir}"
+          if [[ ! -f "${archive_path}" ]]; then
+            download_archive
+          fi
+
+          if ! verify_archive; then
+            rm -f "${archive_path}"
+            download_archive
+            verify_archive
+          fi
+
+          tar -xzf "${archive_path}" -C "${tool_dir}" \
+            --strip-components=1 "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+          echo "${tool_dir}" >> "${GITHUB_PATH}"
 
       - name: Cache actionlint
         # Cache only the release archive. The install step verifies SHA256 on
@@ -82,9 +126,15 @@ jobs:
           echo "${tool_dir}" >> "${GITHUB_PATH}"
 
       - name: Run actionlint
-        # Disable optional external integrations so the check remains a
-        # single-binary workflow syntax and expression validation path.
-        run: actionlint -color -shellcheck= -pyflakes=
+        # ShellCheck is installed above so actionlint can inspect inline
+        # workflow scripts. Keep pyflakes disabled until this repository has
+        # Python workflow scripts that justify another lint runtime.
+        run: actionlint -color -pyflakes=
+
+      - name: Run ShellCheck
+        # actionlint checks inline workflow scripts; this explicit pass covers
+        # standalone shell files used by composite actions.
+        run: shellcheck .github/actions/publish-thunderstore/publish-thunderstore.sh
 
       - name: Cache pinact
         # Cache only the release archive. The install step verifies SHA256 on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,8 +97,8 @@ Run the checks that match your change before opening a pull request:
 ```powershell
 dotnet format
 docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5
-actionlint -pyflakes=
 shellcheck .github/actions/publish-thunderstore/publish-thunderstore.sh
+actionlint -pyflakes=
 pinact run --check --min-age 7
 DOTNET_CLI_UI_LANGUAGE=en dotnet build
 ```
@@ -111,8 +111,10 @@ Use the commands as follows:
   The Docker command is the documented pinned path, but Docker is not required.
   Another `markdownlint-cli2` installation method is acceptable when it uses the
   repository configuration.
-- Run `actionlint`, `shellcheck`, and `pinact` when changing GitHub Actions
+- Run `shellcheck`, `actionlint`, and `pinact` when changing GitHub Actions
   workflows, composite actions, shell scripts, or related repository automation.
+  ShellCheck should run before actionlint so actionlint can use its ShellCheck
+  integration for inline workflow shell scripts.
 
 On Linux, run the Markdown lint command with `sudo docker` and use
 `--user "$(id -u):$(id -g)"`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,16 +103,19 @@ pinact run --check --min-age 7
 DOTNET_CLI_UI_LANGUAGE=en dotnet build
 ```
 
-The Docker command is the documented pinned Markdown lint path, but Docker is
-not required. Another `markdownlint-cli2` installation method is acceptable when
-it uses the repository configuration.
+Use the commands as follows:
+
+- Run `dotnet format` and `DOTNET_CLI_UI_LANGUAGE=en dotnet build` for source
+  changes.
+- Run Markdown lint for documentation changes.
+  The Docker command is the documented pinned path, but Docker is not required.
+  Another `markdownlint-cli2` installation method is acceptable when it uses the
+  repository configuration.
+- Run `actionlint`, `shellcheck`, and `pinact` when changing GitHub Actions
+  workflows, composite actions, shell scripts, or related repository automation.
 
 On Linux, run the Markdown lint command with `sudo docker` and use
 `--user "$(id -u):$(id -g)"`.
-
-The `actionlint`, `shellcheck`, and `pinact` commands are required when changing
-GitHub Actions workflows, composite actions, shell scripts, or related
-repository automation.
 
 For package or release changes, also verify the release documentation in
 [README.md](./README.md) and confirm that the Thunderstore-facing files under

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Run the checks that match your change before opening a pull request:
 dotnet format
 docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5
 actionlint -shellcheck= -pyflakes=
-pinact run --check
+pinact run --check --min-age 7
 DOTNET_CLI_UI_LANGUAGE=en dotnet build
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,8 @@ Run the checks that match your change before opening a pull request:
 ```powershell
 dotnet format
 docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5
-actionlint -shellcheck= -pyflakes=
+actionlint -pyflakes=
+shellcheck .github/actions/publish-thunderstore/publish-thunderstore.sh
 pinact run --check --min-age 7
 DOTNET_CLI_UI_LANGUAGE=en dotnet build
 ```
@@ -109,8 +110,9 @@ it uses the repository configuration.
 On Linux, run the Markdown lint command with `sudo docker` and use
 `--user "$(id -u):$(id -g)"`.
 
-The `actionlint` and `pinact` commands are required when changing GitHub Actions
-workflows, composite actions, or related repository automation.
+The `actionlint`, `shellcheck`, and `pinact` commands are required when changing
+GitHub Actions workflows, composite actions, shell scripts, or related
+repository automation.
 
 For package or release changes, also verify the release documentation in
 [README.md](./README.md) and confirm that the Thunderstore-facing files under

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,8 @@ Run the checks that match your change before opening a pull request:
 ```powershell
 dotnet format
 docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5
+actionlint -shellcheck= -pyflakes=
+pinact run --check
 DOTNET_CLI_UI_LANGUAGE=en dotnet build
 ```
 
@@ -106,6 +108,9 @@ it uses the repository configuration.
 
 On Linux, run the Markdown lint command with `sudo docker` and use
 `--user "$(id -u):$(id -g)"`.
+
+The `actionlint` and `pinact` commands are required when changing GitHub Actions
+workflows, composite actions, or related repository automation.
 
 For package or release changes, also verify the release documentation in
 [README.md](./README.md) and confirm that the Thunderstore-facing files under

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install [Visual Studio 2022][visual-studio-download].
 Install [Docker][docker-install] if you plan to use the documented local
 Markdown lint command.
 
-Install [`actionlint`][actionlint-repo], [ShellCheck][shellcheck-repo], and
+Install [ShellCheck][shellcheck-repo], [`actionlint`][actionlint-repo], and
 [pinact][pinact-repo] if you plan to run GitHub Actions quality checks locally.
 
 Restore NuGet packages.
@@ -81,27 +81,28 @@ GitHub Actions workflows and composite actions are checked with
 
 The local lint pass has two parts:
 
+- ShellCheck checks shell scripts used by repository automation.
 - `actionlint` checks workflow syntax, expressions, runner labels, and composite
   action metadata.
-- ShellCheck checks shell scripts used by repository automation.
 
-CI installs ShellCheck before running actionlint, so actionlint can also inspect
-inline shell scripts in workflows.
+Run ShellCheck before actionlint.
+This keeps actionlint's ShellCheck integration available so actionlint can also
+inspect inline shell scripts in workflows.
 The pyflakes integration remains disabled because this repository does not
 currently contain Python files.
 Revisit that setting if Python scripts are added.
 
 ```powershell
-actionlint -pyflakes=
 shellcheck .github/actions/publish-thunderstore/publish-thunderstore.sh
+actionlint -pyflakes=
 ```
 
 Install these tools from trusted distributions:
 
-- `actionlint`: upstream releases, package-manager integrations, Docker image,
-  or another trusted distribution.
 - ShellCheck: upstream releases, package-manager integrations, Docker image, or
   another trusted distribution.
+- `actionlint`: upstream releases, package-manager integrations, Docker image,
+  or another trusted distribution.
 
 When updating CI, use cooldown-compliant pinned releases.
 The workflow downloads Linux release archives directly and verifies their SHA256

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Install `actionlint` from its upstream releases, package-manager integrations,
 Docker image, or another trusted distribution.
 Use a cooldown-compliant pinned release when updating CI.
 The CI workflow downloads the Linux amd64 release archive directly and verifies
-its SHA256 before running it.
+its SHA256 before running it on cache misses.
 
 ### GitHub Actions pinning
 
@@ -117,7 +117,7 @@ authenticated rate limits.
 Install pinact from its upstream releases, package-manager integrations, or
 another trusted distribution.
 The CI workflow downloads the Linux amd64 release archive directly and verifies
-its SHA256 before running it.
+its SHA256 before running it on cache misses.
 
 ## Package management
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Install `actionlint` from its upstream releases, package-manager integrations,
 Docker image, or another trusted distribution.
 Use a cooldown-compliant pinned release when updating CI.
 The CI workflow downloads the Linux amd64 release archive directly and verifies
-its SHA256 before running it on cache misses.
+its SHA256 before running it. CI caches the archive, not the extracted
+executable, so cached downloads are still verified before use.
 
 ### GitHub Actions pinning
 
@@ -117,7 +118,8 @@ authenticated rate limits.
 Install pinact from its upstream releases, package-manager integrations, or
 another trusted distribution.
 The CI workflow downloads the Linux amd64 release archive directly and verifies
-its SHA256 before running it on cache misses.
+its SHA256 before running it. CI caches the archive, not the extracted
+executable, so cached downloads are still verified before use.
 
 ## Package management
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Install [Visual Studio 2022][visual-studio-download].
 Install [Docker][docker-install] if you plan to use the documented local
 Markdown lint command.
 
-Install [`actionlint`][actionlint-repo] and [pinact][pinact-repo] if you plan to
-run GitHub Actions quality checks locally.
+Install [`actionlint`][actionlint-repo], [ShellCheck][shellcheck-repo], and
+[pinact][pinact-repo] if you plan to run GitHub Actions quality checks locally.
 
 Restore NuGet packages.
 
@@ -78,20 +78,23 @@ CI action together after the repository cooldown period has elapsed.
 
 GitHub Actions workflows and composite actions are checked with
 [`actionlint`][actionlint-repo].
-The CI check runs only actionlint's built-in workflow, expression, and action
-metadata checks so it does not require extra tools such as ShellCheck or
-pyflakes.
+CI installs ShellCheck so actionlint can also check inline workflow shell
+scripts. The pyflakes integration remains disabled because this repository does
+not currently maintain Python workflow scripts.
 
 ```powershell
-actionlint -shellcheck= -pyflakes=
+actionlint -pyflakes=
+shellcheck .github/actions/publish-thunderstore/publish-thunderstore.sh
 ```
 
 Install `actionlint` from its upstream releases, package-manager integrations,
 Docker image, or another trusted distribution.
+Install ShellCheck from its upstream releases, package-manager integrations,
+Docker image, or another trusted distribution.
 Use a cooldown-compliant pinned release when updating CI.
-The CI workflow downloads the Linux amd64 release archive directly and verifies
-its SHA256 before running it. CI caches the archive, not the extracted
-executable, so cached downloads are still verified before use.
+The CI workflow downloads the Linux release archives directly and verifies their
+SHA256 values before running them. CI caches the archives, not the extracted
+executables, so cached downloads are still verified before use.
 
 ### GitHub Actions pinning
 
@@ -359,5 +362,6 @@ This disclosure is made in compliance with Thunderstore and community policies.
 [pinact-repo]: https://github.com/suzuki-shunsuke/pinact
 [powershell-install]: https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows
 [r2modman-package]: https://thunderstore.io/c/lethal-company/p/ebkr/r2modman/
+[shellcheck-repo]: https://github.com/koalaman/shellcheck
 [thunderstore-lethal-company-community]: https://thunderstore.io/c/lethal-company/
 [visual-studio-download]: https://visualstudio.microsoft.com/en-us/vs/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Install [Visual Studio 2022][visual-studio-download].
 Install [Docker][docker-install] if you plan to use the documented local
 Markdown lint command.
 
+Install [`actionlint`][actionlint-repo] and [pinact][pinact-repo] if you plan to
+run GitHub Actions quality checks locally.
+
 Restore NuGet packages.
 
 ```powershell
@@ -70,6 +73,51 @@ sudo docker run --rm --network none --user "$(id -u):$(id -g)" -v ".:/workdir" d
 
 When updating Markdown lint tooling, update the documented local command and the
 CI action together after the repository cooldown period has elapsed.
+
+### GitHub Actions lint
+
+GitHub Actions workflows and composite actions are checked with
+[`actionlint`][actionlint-repo].
+The CI check runs only actionlint's built-in workflow, expression, and action
+metadata checks so it does not require extra tools such as ShellCheck or
+pyflakes.
+
+```powershell
+actionlint -shellcheck= -pyflakes=
+```
+
+Install `actionlint` from its upstream releases, package-manager integrations,
+Docker image, or another trusted distribution.
+Use a cooldown-compliant pinned release when updating CI.
+The CI workflow downloads the Linux amd64 release archive directly and verifies
+its SHA256 before running it.
+
+### GitHub Actions pinning
+
+GitHub Actions and reusable workflows are checked with [pinact][pinact-repo] so
+external actions stay pinned to full commit SHAs with synchronized version
+comments.
+
+```powershell
+pinact run --check
+```
+
+For local fixes or updates, use the documented pinact commands:
+
+```powershell
+# Pin or refresh version comments.
+pinact run --min-age 7
+
+# Update pinned actions after the repository cooldown period.
+pinact run --update --min-age 7
+```
+
+Set `GITHUB_TOKEN` when possible so pinact can query GitHub's API with normal
+authenticated rate limits.
+Install pinact from its upstream releases, package-manager integrations, or
+another trusted distribution.
+The CI workflow downloads the Linux amd64 release archive directly and verifies
+its SHA256 before running it.
 
 ## Package management
 
@@ -132,7 +180,7 @@ The repository uses [GitHub Actions][github-actions-docs] for CI.
 
 ### Action pinning
 
-The version of the actions are pinned with [pinact](https://github.com/suzuki-shunsuke/pinact).
+Action versions are pinned with [pinact][pinact-repo].
 Actions and other executable CI tooling should be updated after the repository
 cooldown period has elapsed. Keep SHA pins and version comments synchronized
 when updating pinned actions.
@@ -303,8 +351,10 @@ This disclosure is made in compliance with Thunderstore and community policies.
 [docker-install]: https://docs.docker.com/get-started/get-docker/
 [dotnet-sdk-download]: https://dotnet.microsoft.com/en-us/download/dotnet/10.0
 [github-actions-docs]: https://docs.github.com/en/actions
+[actionlint-repo]: https://github.com/rhysd/actionlint
 [lethal-company-steam]: https://store.steampowered.com/app/1966720/Lethal_Company/
 [markdownlint-cli2-repo]: https://github.com/DavidAnson/markdownlint-cli2
+[pinact-repo]: https://github.com/suzuki-shunsuke/pinact
 [powershell-install]: https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows
 [r2modman-package]: https://thunderstore.io/c/lethal-company/p/ebkr/r2modman/
 [thunderstore-lethal-company-community]: https://thunderstore.io/c/lethal-company/

--- a/README.md
+++ b/README.md
@@ -78,23 +78,36 @@ CI action together after the repository cooldown period has elapsed.
 
 GitHub Actions workflows and composite actions are checked with
 [`actionlint`][actionlint-repo].
-CI installs ShellCheck so actionlint can also check inline workflow shell
-scripts. The pyflakes integration remains disabled because this repository does
-not currently contain Python files; revisit this if Python scripts are added.
+
+The local lint pass has two parts:
+
+- `actionlint` checks workflow syntax, expressions, runner labels, and composite
+  action metadata.
+- ShellCheck checks shell scripts used by repository automation.
+
+CI installs ShellCheck before running actionlint, so actionlint can also inspect
+inline shell scripts in workflows.
+The pyflakes integration remains disabled because this repository does not
+currently contain Python files.
+Revisit that setting if Python scripts are added.
 
 ```powershell
 actionlint -pyflakes=
 shellcheck .github/actions/publish-thunderstore/publish-thunderstore.sh
 ```
 
-Install `actionlint` from its upstream releases, package-manager integrations,
-Docker image, or another trusted distribution.
-Install ShellCheck from its upstream releases, package-manager integrations,
-Docker image, or another trusted distribution.
-Use a cooldown-compliant pinned release when updating CI.
-The CI workflow downloads the Linux release archives directly and verifies their
-SHA256 values before running them. CI caches the archives, not the extracted
-executables, so cached downloads are still verified before use.
+Install these tools from trusted distributions:
+
+- `actionlint`: upstream releases, package-manager integrations, Docker image,
+  or another trusted distribution.
+- ShellCheck: upstream releases, package-manager integrations, Docker image, or
+  another trusted distribution.
+
+When updating CI, use cooldown-compliant pinned releases.
+The workflow downloads Linux release archives directly and verifies their SHA256
+values before running them.
+It caches only the archives, not the extracted executables, so cached downloads
+are still verified before use.
 
 ### GitHub Actions pinning
 
@@ -106,7 +119,7 @@ comments.
 pinact run --check --min-age 7
 ```
 
-For local fixes or updates, use the documented pinact commands:
+For local fixes or maintenance updates, use the same cooldown setting:
 
 ```powershell
 # Pin or refresh version comments.
@@ -120,9 +133,11 @@ Set `GITHUB_TOKEN` when possible so pinact can query GitHub's API with normal
 authenticated rate limits.
 Install pinact from its upstream releases, package-manager integrations, or
 another trusted distribution.
-The CI workflow downloads the Linux amd64 release archive directly and verifies
-its SHA256 before running it. CI caches the archive, not the extracted
-executable, so cached downloads are still verified before use.
+
+CI downloads the Linux amd64 release archive directly and verifies its SHA256
+before running pinact.
+It caches only the archive, not the extracted executable, so cached downloads
+are still verified before use.
 
 ## Package management
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ GitHub Actions workflows and composite actions are checked with
 [`actionlint`][actionlint-repo].
 CI installs ShellCheck so actionlint can also check inline workflow shell
 scripts. The pyflakes integration remains disabled because this repository does
-not currently maintain Python workflow scripts.
+not currently contain Python files; revisit this if Python scripts are added.
 
 ```powershell
 actionlint -pyflakes=

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ external actions stay pinned to full commit SHAs with synchronized version
 comments.
 
 ```powershell
-pinact run --check
+pinact run --check --min-age 7
 ```
 
 For local fixes or updates, use the documented pinact commands:


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Adds `ShellCheck v0.11.0`, `actionlint v1.7.12`, and `pinact v3.9.2` to the lint workflow.
- Installs each tool from a pinned GitHub release archive, verifies SHA256 before extraction on every run, and caches only the release archives.
- Keeps each tool version adjacent to its SHA256 because those values are reviewed and updated together.
- Runs ShellCheck before actionlint so actionlint can use its ShellCheck integration for inline workflow shell scripts.
- Runs `actionlint -pyflakes=` for workflow syntax, expression, runner-label, and composite-action checks.
- Runs a separate ShellCheck pass for the standalone composite-action shell script.
- Runs `pinact run --check --min-age 7` so action pin validation keeps the repository cooldown policy visible in CI.
- Documents the local `shellcheck`, `actionlint`, and `pinact` checks in `README.md` and `CONTRIBUTING.md`.
- Adds a repository-local `github-actions-quality-check` Agent Skill with generic command examples for GitHub Actions workflow, shell, pinning, permissions, and CI lint review.

## Related Issues

- Related rollout: aoirint/SkipDropshipCompany#43 ports this finalized pattern to SkipDropshipCompany with minimal project-specific differences.

## Notes for reviewers

- This PR is the source pattern for the SDC rollout.
- The SDC lint workflow comparison currently differs from this PR only in the .NET cache dependency path.
- Tool ordering is intentional: ShellCheck is installed and run before actionlint so actionlint's ShellCheck integration can inspect inline workflow shell scripts.
- Selected tool releases satisfy the repository 7-day cooldown as of the current verification:
  - ShellCheck v0.11.0, published 2025-08-04.
  - actionlint v1.7.12, published 2026-03-30.
  - pinact v3.9.2, published 2026-04-29.
- `pinact run --check --min-age 7` is used in CI and local documentation.
- `actionlint v1.7.12` accepts `ubuntu-slim`, so no `.github/actionlint.yaml` override is needed.
- `actionlint -pyflakes=` remains intentional because the repository does not currently contain Python files. Revisit it if Python scripts are added.

Official references checked:

- `actionlint` recommends using its GitHub Actions download script or Docker image for CI; this PR uses the same upstream release binary directly so the workflow can verify the archive SHA256 and avoid adding another setup action or runtime dependency.
- `actionlint` documents that `-shellcheck=` and `-pyflakes=` disable those integrations. This PR keeps ShellCheck integration enabled by installing ShellCheck and passing only `-pyflakes=`.
- `pinact` documents `pinact run --check` for validation and `--min-age 7` for cooldown-aware updates. This PR includes `--min-age 7` in the CI check command as requested.
- `pinact` also documents stronger release-asset verification options with GitHub CLI, SLSA verifier, or Cosign. This PR keeps CI dependency-light by using release metadata SHA256 verification.

### AI disclosure

Codex drafted the workflow, documentation, Agent Skill, PR body, and PR-thread notes; checked upstream documentation and release metadata; and ran the local verification commands listed below. The maintainer should review the CI install/cache commands and public PR-thread notes before merging.

## Testing

### Automated checks

- `ShellCheck v0.11.0` Windows release archive downloaded from GitHub Releases, SHA256 verified, then `shellcheck .github/actions/publish-thunderstore/publish-thunderstore.sh` - passed.
- `actionlint v1.7.12` Windows release archive downloaded from GitHub Releases, SHA256 verified, then `actionlint -pyflakes=` with ShellCheck on `PATH` - passed.
- `docker run --rm -v ${PWD}:/repo --workdir /repo rhysd/actionlint:1.7.12 -color -pyflakes=` - passed.
- `pinact v3.9.2` Windows release archive downloaded from GitHub Releases, SHA256 verified, then `pinact run --check --min-age 7` - passed.
- `docker run --rm --network none --user 1000:1000 -v ".:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5` - passed, 0 errors.
- `git diff --check` - passed.
- `dotnet restore --locked-mode` - passed.
- `dotnet format --no-restore --verify-no-changes` - passed.
- GitHub Actions `lint` check - passed.

### AI-assisted inspections

- Request: Quality-check the new Agent Skill.
  - AI-assisted result: Checked frontmatter, trigger scope, `agents/openai.yaml`, structure, security-check handoff, generic command examples, and scenario fit. `quick_validate.py` could not run because Python is not installed in this environment.
- Request: Confirm CJP-to-SDC rollout parity and cross-linking.
  - AI-assisted result: Verified that the SDC workflow differs from this PR only by `cache-dependency-path`, the Agent Skill files are equivalent, the documented GitHub Actions commands match across repositories, and both PRs cross-reference the rollout.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
