### PR TITLE
fix(bepinex): guard non-stable CI metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,16 @@ jobs:
         run: echo "time_ms=$(date +%s%3N)" >> "${GITHUB_OUTPUT}"
 
       - name: Run dotnet build
-        run: dotnet build --no-restore --configuration Release
+        run: |
+          dotnet_build_args=(--no-restore --configuration Release)
+          if [ "${{ steps.generate-version.outputs.release_mode }}" != "latest" ]; then
+            # BepInEx 5 validates plugin metadata as System.Version, which
+            # rejects SemVer prerelease and edge strings. Keep release identity
+            # in Version, and scope the loader-facing fallback to this build.
+            dotnet_build_args+=(/p:BepInExPluginVersion=0.0.0)
+          fi
+
+          dotnet build "${dotnet_build_args[@]}"
 
       - name: Record end time
         id: end-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Added CI-only BepInEx plugin metadata fallback for future prerelease and edge
+  artifacts:
+    - CJP `v0.2.0-alpha.6` used a source `BepInExPluginVersion` override to
+      pass BepInEx 5 startup validation.
+    - The stable `v0.2.0` release correctly removed that source override once
+      `Version` became loader-compatible again.
+    - Future non-stable builds now pass `BepInExPluginVersion=0.0.0` only to
+      the CI build, keeping stable source metadata clean while preventing the
+      prerelease startup blocker from recurring.
+
 ## v0.2.0 - 2026-05-06 UTC
 
 ### Changed


### PR DESCRIPTION
> [!WARNING]
> This pull request was created with assistance from LLMs.

## Summary

- Add a CI-only BepInEx metadata fallback for future prerelease and edge builds.
- Keep stable/latest builds on the source `Version` metadata path.
- Prevent the alpha.5 startup blocker from recurring without re-adding a prerelease-only `BepInExPluginVersion` override to the source project file.
- Record the follow-up in the canonical developer changelog.

## Related Issues

- Closes #125
- Related blocker precedent: #110
- Related alpha workaround: #111
- Related stable cleanup: #115
- Related horizontal fix: aoirint/SkipDropshipCompany#45

## Notes for reviewers

- Current CJP `main` is not broken for stable `v0.2.0`; this PR protects the next prerelease or edge artifact.
- `BepInEx.PluginInfoProps` defaults `BepInExPluginVersion` to `$(Version)`. That is fine for stable `0.2.0`, but it is not loader-compatible when the generated app version has a prerelease or edge suffix.
- This PR scopes the `0.0.0` fallback to the CI `dotnet build` invocation when `release_mode != latest`.
- This intentionally does not mutate `.github/actions/generate-version`, generated `.csproj` content, or source `CruiserJumpPractice.csproj`.

### AI disclosure

Codex helped compare the CJP alpha/stable history with the SkipDropshipCompany follow-up fix, implement the CI-only metadata fallback, draft the linked follow-up issue, and run local verification. The resulting diff and generated `MyPluginInfo.cs` output were reviewed before opening this pull request.

## Testing

### Automated checks

- `dotnet build --configuration Release /p:BepInExPluginVersion=0.0.0` passed with 0 warnings and 0 errors.
- `dotnet format --no-restore --verify-no-changes` passed.
- `docker run --rm --network none --user 1000:1000 -v "${PWD}:/workdir" davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5` passed with 0 errors.
- `git diff --check` passed; Git only reported repository line-ending warnings.

### Generated metadata checks

- Checked the CI build argument logic with `release_mode=edge`; it includes `/p:BepInExPluginVersion=0.0.0`.
- Checked the same logic with `release_mode=latest`; it does not include the fallback property.

### AI-assisted inspections

Request: Confirm the generated BepInEx plugin metadata version is compatible with BepInEx 5 non-stable startup validation.

AI-assisted result: Inspected `CruiserJumpPractice/obj/Release/netstandard2.1/MyPluginInfo.cs` after the build with the loader-facing override and confirmed `PLUGIN_VERSION = "0.0.0"`.

### Manual checks

- Not run - real-game validation should be performed with the next generated prerelease or edge artifact.

## Checklist

As the pull request author, I have checked all required items:

- [x] I have read `CONTRIBUTING.md` and agree to the Contribution License Agreement.
